### PR TITLE
Modified Index.html to enable 2 hour alarm silence

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -28,11 +28,7 @@
                         <li><a href="#" data-snooze-time="1800000">Silence for 30 minutes</a></li>
                         <li><a href="#" data-snooze-time="3600000">Silence for 60 minutes</a></li>
                         <li><a href="#" data-snooze-time="5400000">Silence for 90 minutes</a></li>
-<<<<<<< HEAD:index.html
 						<li><a href="#" data-snooze-time="7200000">Silence for 120 minutes</a></li>
-=======
-                        <li><a href="#" data-snooze-time="7200000">Silence for 120 minutes</a></li>
->>>>>>> upstream/master:static/index.html
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Added another time interval to index.html to align with Dexcom 2 hour window. Our insulin action is 2 hours and that's what we use for "at night." Plus, with longer silence, it will reduce website traffic.
