### PR TITLE
fullscreen on iPhones ios7.1+

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0", minimal-ui" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui" />
         <title>NightScout</title>
         <link href="/images/round1.png" rel="icon" id="favicon" type="image/png" />
         <link rel="stylesheet" type="text/css" href="/css/main.css?v=0.3.3" />


### PR DESCRIPTION
On my iphone 4 iOS 7.1.2 the address bar and bookmark buttons take away to much screen real estate. The layout is really squashed together. By adding minimal_ui to the meta, the page directly opens in minimal mode, therfore I get the same screen size as an iPhone 5C with the buttons and address bar visible (tested on my girlfriends phone). This does not work on iOS 7.0 or earlier which I could test on the 5C. Only from 7.1+. Also iPads with version 1.7.2 remain uninfected.
