### PR TITLE
Update index.html

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -134,6 +134,7 @@
                             <option value="Question">Note or Question</option>
                             <option value="Exercise">Exercise</option>
                             <option value="Site Change">Pump Site Change</option>
+                            <option value="Sensor Start">Dexcom Sensor Start</option>
                             <option value="D.A.D. Alert">D.A.D. Alert</option>
                         </select>
                     </label>


### PR DESCRIPTION
Add "sensor start" to treatment event type.  I've found value in noting a Dexcom sensor start / restart in the care portal to explain data loss.
