### PR TITLE
added tooltips when hovering over dots

### DIFF
--- a/static/js/client.js
+++ b/static/js/client.js
@@ -271,7 +271,9 @@
             .attr('cx', function (d) { return xScale(d.date); })
             .attr('cy', function (d) { return yScale(d.sgv); })
             .attr('fill', function (d) { return d.color; })
-            .attr('r', 3);
+            .attr('r', 3)
+            .append('svg:title')
+            .text(function(d) { return d.sgv; });
 
         focusCircles.exit()
             .remove();


### PR DESCRIPTION
Small change to add a tooltip when hovering over a datapoint.  (Triggering a tooltip seems to require fairly precise cursor placement over a given dot, however).

Tested in Firefox 31.0, 32.0 and Safari 7.0.6.
