### PR TITLE
detect deployed git HEAD in azure

### DIFF
--- a/env.js
+++ b/env.js
@@ -23,10 +23,14 @@ function config ( ) {
   if (readENV('SCM_GIT_EMAIL') == 'windowsazure' && readENV('ScmType') == 'GitHub') {
     git.cwd('/home/site/repository');
   }
-  git.short(function record_git_head (head) {
-    console.log("GIT HEAD", head);
-    env.head = head;
-  });
+  if (readENV('SCM_COMMIT_ID')) {
+    env.head = readENV('SCM_COMMIT_ID');
+  } else {
+    git.short(function record_git_head (head) {
+      console.log("GIT HEAD", head);
+      env.head = head;
+    });
+  }
   env.version = software.version;
   env.name = software.name;
 


### PR DESCRIPTION
When deployed on MS azure, the available git commit used to deploy the
software is available in the SCM_COMMIT_ID environment variable.
We encourage all hosting providers to provide some similar facility to
avoid spawning spurious processes.

Thanks to @shanselman for reminders and pointers to the fix.
