### PR TITLE
Correct location - Adding a Robots.txt to hide NightScout from Google

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Wrong location.
