### PR TITLE
display 5m SGV delta between SGV and arrow

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -60,6 +60,10 @@ body {
 .bgStatus.current .currentBG {
     text-decoration: none;
 }
+.bgStatus.current .currentDelta {
+    font-size: 50%;
+    text-decoration: none;
+}
 .currentDirection {
     font-weight: normal;
     text-decoration: none;

--- a/static/index.html
+++ b/static/index.html
@@ -36,6 +36,7 @@
                 <div class="bgStatus current">
                     <div id="noButton">
                         <span class="currentBG">---</span>
+                        <span class="currentDelta">--</span>
                         <span class="currentDirection">-</span>
                     </div>
                     <div id="bgButton" hidden="true">

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -423,6 +423,14 @@
                     $('.container .currentBG').text('HIGH');
                 else
                     $('.container .currentBG').text(scaleBg(latestSGV.y));
+                    var bgDelta = scaleBg(latestSGV.y-sgvData[sgvData.length-2].y);
+                    if (bgDelta < 0) {
+                        var bgDeltaString = bgDelta;
+                    }
+                    else {
+                        var bgDeltaString = "+" + bgDelta;
+                    }
+                    $('.container .currentDelta').text(bgDeltaString);
 
                 $('.container .currentBG').css('text-decoration', '');
                 $('.container .currentDirection')
@@ -431,6 +439,10 @@
                 var color = sgvToColor(latestSGV.y);
                 $('.container #noButton .currentBG').css({color: color});
                 $('.container #noButton .currentDirection').css({color: color});
+
+                var deltaColor = deltaToColor(bgDelta);
+                $('.container #noButton .currentDelta').css({color: deltaColor});
+                //$('.container #noButton .currentDirection').css({color: color});
             }
         }
 
@@ -971,6 +983,22 @@
         }
     });
 
+    function deltaToColor(delta) {
+        var color = 'grey';
+
+        if (browserSettings.theme == "colors") {
+            if (Math.abs(delta) > 10) {
+                color = 'red';
+            } else if (Math.abs(delta) > 5) {
+                color = 'yellow';
+            } else {
+                //color = '#4cff00';
+                color = 'grey';
+            }
+        }
+
+        return color;
+    }
     function sgvToColor(sgv) {
         var color = 'grey';
 


### PR DESCRIPTION
This displays the change in SGV since the last data point, like the Pebble app does.  I put it in between the SGV and the arrow, at 50% of the size of the SGV.  If colors are enabled, the delta will be grey if it's <= 5 mg/dL, yellow if it's >5 and <=10, and red if it's >10.

If we want to do this in dev, it should probably be an optional off-by-default feature, so someone will need to add a pref for it.

![screenshot 2014-11-11 20 51 51](https://cloud.githubusercontent.com/assets/6982790/5005514/a34e19a2-69e4-11e4-8605-b8c50df9afd1.png)
