### PR TITLE
Set Pushover notification priority to normal for Care Portal treatments.

### DIFF
--- a/lib/treatments.js
+++ b/lib/treatments.js
@@ -21,7 +21,7 @@ function storage (collection, storage, pushover) {
           title: obj.eventType,
           sound: 'gamelan',
           timestamp: new Date( ),
-          priority: 1,
+          priority: 0,
           retry: 30
         };
 


### PR DESCRIPTION
Set treatment Priority to 0 / Normal for Pushover notifications.  Current master has CP treatments as high priority, Meter BG as Normal priority.  IMO High priority should be reserved for future BG threshold alarms or possibly an optional user-set priority level.  It's also easier to read CP treatments from Pushover with a white background.
