### PR TITLE
Add API_SECRET and optional variables for Heroku deployment

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,15 +3,32 @@
   "repository": "https://github.com/nightscout/cgm-remote-monitor",
   "env": {
     "MONGO_COLLECTION": {
-      "description": "The mongo collection to connect to.",
-      "value": "entries"
+      "description": "The mongo collection for CGM data.  Most users should leave this as default.",
+      "value": "entries",
+      "required": true
     },
     "API_SECRET": {
       "description": "User generated password required for REST API and other features (12 character minimum).",
-      "value": ""
+      "value": "",
+      "required": true
+    },
+    "ENABLE": {
+      "description": "Space delimited list of optional features to enable.  Leave blank for a default site.",
+      "value": "",
+      "required": false
+    },
+    "PUSHOVER_API_TOKEN": {
+      "description": "Pushover API token, required for Pushover notifications.  Leave blank for a default site.",
+      "value": "",
+      "required": false
+    },
+    "PUSHOVER_USER_KEY": {
+      "description": "Pushover user key, required for Pushover notifications.  Leave blank for a default site.",
+      "value": "",
+      "required": false
     }
   },
   "addons": [
-    "mongolab"
+    "mongolab:sandbox"
   ]
 }


### PR DESCRIPTION
Simplifies deploying a Heroku app by adding the following vars to the app.json:

API_SECRET - required, blank
ENABLE - optional, blank 
PUSHOVER_API_TOKEN - optional, blank
PUSHOVER_USER_KEY - optional, blank
