### PR TITLE
Alarm / Threshold updates (and some other UI updates...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-cgm-remote-monitor (a.k.a. NightScout)
+cgm-remote-monitor (a.k.a. Nightscout)
 ======================================
  
 [![Build Status](https://travis-ci.org/nightscout/cgm-remote-monitor.png)](https://travis-ci.org/nightscout/cgm-remote-monitor)

--- a/env.js
+++ b/env.js
@@ -79,7 +79,7 @@ function config ( ) {
   }
 
   env.thresholds = {
-    bg_high: readIntENV('BG_HIGH', 240)
+    bg_high: readIntENV('BG_HIGH', 260)
     , bg_target_top: readIntENV('BG_TARGET_TOP', 180)
     , bg_target_bottom: readIntENV('BG_TARGET_BOTTOM', 80)
     , bg_low: readIntENV('BG_LOW', 55)

--- a/env.js
+++ b/env.js
@@ -85,6 +85,32 @@ function config ( ) {
     , bg_low: readIntENV('BG_LOW', 55)
   };
 
+  //NOTE: using +/- 1 here to make the thresholds look visibly wrong in the UI
+  //      if all thresholds were set to the same value you should see 4 lines stacked right on top of each other
+  if (env.thresholds.bg_target_bottom >= env.thresholds.bg_target_top) {
+    console.warn('BG_TARGET_BOTTOM(' + env.thresholds.bg_target_bottom + ') was >= BG_TARGET_TOP(' + env.thresholds.bg_target_top + ')');
+    env.thresholds.bg_target_bottom = env.thresholds.bg_target_top - 1;
+    console.warn('BG_TARGET_BOTTOM is now ' + env.thresholds.bg_target_bottom);
+  }
+
+  if (env.thresholds.bg_target_top <= env.thresholds.bg_target_bottom) {
+    console.warn('BG_TARGET_TOP(' + env.thresholds.bg_target_top + ') was <= BG_TARGET_BOTTOM(' + env.thresholds.bg_target_bottom + ')');
+    env.thresholds.bg_target_top = env.thresholds.bg_target_bottom + 1;
+    console.warn('BG_TARGET_TOP is now ' + env.thresholds.bg_target_top);
+  }
+
+  if (env.thresholds.bg_low >= env.thresholds.bg_target_bottom) {
+    console.warn('BG_LOW(' + env.thresholds.bg_low + ') was >= BG_TARGET_BOTTOM(' + env.thresholds.bg_target_bottom + ')');
+    env.thresholds.bg_low = env.thresholds.bg_target_bottom - 1;
+    console.warn('BG_LOW is now ' + env.thresholds.bg_low);
+  }
+
+  if (env.thresholds.bg_high <= env.thresholds.bg_target_top) {
+    console.warn('BG_HIGH(' + env.thresholds.bg_high + ') was <= BG_TARGET_TOP(' + env.thresholds.bg_target_top + ')');
+    env.thresholds.bg_high = env.thresholds.bg_target_top + 1;
+    console.warn('BG_HIGH is now ' + env.thresholds.bg_high);
+  }
+
   //if any of the BG_* thresholds are set, default to "simple" otherwise default to "predict" to preserve current behavior
   var thresholdsSet = readIntENV('BG_HIGH') || readIntENV('BG_TARGET_TOP') || readIntENV('BG_TARGET_BOTTOM') || readIntENV('BG_LOW');
   env.alarm_types = readENV('ALARM_TYPES') || (thresholdsSet ? "simple" : "predict");

--- a/env.js
+++ b/env.js
@@ -78,6 +78,15 @@ function config ( ) {
     env.api_secret = shasum.digest('hex');
   }
 
+  env.thresholds = {
+    bg_high: parseInt(readENV('BG_HIGH')) || 220
+    , bg_target_top: parseInt(readENV('BG_TARGET_TOP')) || 180
+    , bg_target_bottom: parseInt(readENV('BG_TARGET_BOTTOM')) || 80
+    , bg_low: parseInt(readENV('BG_LOW')) || 55
+  };
+
+  env.alarm_types = readENV('ALARM_TYPES') || "simple";
+
   // For pushing notifications to Pushover.
   env.pushover_api_token = readENV('PUSHOVER_API_TOKEN');
   env.pushover_user_key = readENV('PUSHOVER_USER_KEY') || readENV('PUSHOVER_GROUP_KEY');

--- a/env.js
+++ b/env.js
@@ -79,13 +79,15 @@ function config ( ) {
   }
 
   env.thresholds = {
-    bg_high: parseInt(readENV('BG_HIGH')) || 240
-    , bg_target_top: parseInt(readENV('BG_TARGET_TOP')) || 180
-    , bg_target_bottom: parseInt(readENV('BG_TARGET_BOTTOM')) || 80
-    , bg_low: parseInt(readENV('BG_LOW')) || 55
+    bg_high: readIntENV('BG_HIGH', 240)
+    , bg_target_top: readIntENV('BG_TARGET_TOP', 180)
+    , bg_target_bottom: readIntENV('BG_TARGET_BOTTOM', 80)
+    , bg_low: readIntENV('BG_LOW', 55)
   };
 
-  env.alarm_types = readENV('ALARM_TYPES') || "simple";
+  //if any of the BG_* thresholds are set, default to "simple" otherwise default to "predict" to preserve current behavior
+  var thresholdsSet = readIntENV('BG_HIGH') || readIntENV('BG_TARGET_TOP') || readIntENV('BG_TARGET_BOTTOM') || readIntENV('BG_LOW');
+  env.alarm_types = readENV('ALARM_TYPES') || (thresholdsSet ? "simple" : "predict");
 
   // For pushing notifications to Pushover.
   env.pushover_api_token = readENV('PUSHOVER_API_TOKEN');
@@ -104,6 +106,10 @@ function config ( ) {
   env.static_files = readENV('NIGHTSCOUT_STATIC_FILES', __dirname + '/static/');
 
   return env;
+}
+
+function readIntENV(varName, defaultValue) {
+    return parseInt(readENV(varName)) || defaultValue;
 }
 
 function readENV(varName, defaultValue) {

--- a/env.js
+++ b/env.js
@@ -79,7 +79,7 @@ function config ( ) {
   }
 
   env.thresholds = {
-    bg_high: parseInt(readENV('BG_HIGH')) || 220
+    bg_high: parseInt(readENV('BG_HIGH')) || 240
     , bg_target_top: parseInt(readENV('BG_TARGET_TOP')) || 180
     , bg_target_bottom: parseInt(readENV('BG_TARGET_BOTTOM')) || 80
     , bg_low: parseInt(readENV('BG_LOW')) || 55

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -34,6 +34,7 @@ function create (env, entries, settings, treatments, devicestatus) {
   app.set('title', [app.get('name'),  'API', app.get('version')].join(' '));
 
   app.thresholds = env.thresholds;
+  app.alarm_types = env.alarm_types;
 
  // Start setting up routes
   if (app.enabled('api')) {

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -33,6 +33,8 @@ function create (env, entries, settings, treatments, devicestatus) {
 
   app.set('title', [app.get('name'),  'API', app.get('version')].join(' '));
 
+  app.thresholds = env.thresholds;
+
  // Start setting up routes
   if (app.enabled('api')) {
     // experiments

--- a/lib/api/status.js
+++ b/lib/api/status.js
@@ -17,6 +17,7 @@ function configure (app, wares) {
           , head: wares.get_head( )
           , version: app.get('version')
           , thresholds: app.thresholds
+          , alarm_types: app.alarm_types
           , name: app.get('name')};
       var badge = 'http://img.shields.io/badge/Nightscout-OK-green';
       return res.format({

--- a/lib/api/status.js
+++ b/lib/api/status.js
@@ -16,6 +16,7 @@ function configure (app, wares) {
           , units: app.get('units')
           , head: wares.get_head( )
           , version: app.get('version')
+          , thresholds: app.thresholds
           , name: app.get('name')};
       var badge = 'http://img.shields.io/badge/Nightscout-OK-green';
       return res.format({

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -124,12 +124,14 @@ function update() {
                   obj.y = element.mbg;
                   obj.x = element.date;
                   obj.d = element.dateString;
+                  obj.device = element.device;
                   mbgData.push(obj);
               } else if (element.sgv) {
                   var obj = {};
                   obj.y = element.sgv;
                   obj.x = element.date;
                   obj.d = element.dateString;
+                  obj.device = element.device;
                   obj.direction = directionToChar(element.direction);
                   cgmData.push(obj);
               }

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -238,20 +238,43 @@ function loadData() {
           emitData( );
         }
 
-        // compute current loss
-        var avgLoss = 0;
-        var size = Math.min(predicted.length - 1, 6);
-        for (var j = 0; j <= size; j++) {
-            avgLoss += 1 / size * Math.pow(log10(predicted[j].y / 120), 2);
+        var emitAlarmType = null;
+
+        
+        if (env.alarm_types.indexOf("simple") > -1) {
+            var lastBG = actual[actualLength].y;
+
+            if (lastBG > env.thresholds.bg_high) {
+                emitAlarmType = 'urgent_alarm';
+            } else if (lastBG > env.thresholds.bg_target_top) {
+                emitAlarmType = 'alarm';
+            } else if (lastBG < env.thresholds.bg_low) {
+                emitAlarmType = 'urgent_alarm';
+            } else if (lastBG < env.thresholds.bg_target_bottom) {
+                emitAlarmType = 'alarm';
+            }
         }
 
-        if (avgLoss > alarms['urgent_alarm'].threshold) {
-            emitAlarm('urgent_alarm');
-        } else if (avgLoss > alarms['alarm'].threshold) {
-            emitAlarm('alarm');
-        } else if (errorCode) {
-            emitAlarm('urgent_alarm');
+        if (!emitAlarmType && env.alarm_types.indexOf("predict") > -1) {
+            // compute current loss
+            var avgLoss = 0;
+            var size = Math.min(predicted.length - 1, 6);
+            for (var j = 0; j <= size; j++) {
+                avgLoss += 1 / size * Math.pow(log10(predicted[j].y / 120), 2);
+            }
+
+            if (avgLoss > alarms['urgent_alarm'].threshold) {
+                emitAlarmType = 'urgent_alarm';
+            } else if (avgLoss > alarms['alarm'].threshold) {
+                emitAlarmType = 'alarm';
+            }
         }
+
+        if (errorCode) {
+            emitAlarmType = 'urgent_alarm';
+        }
+
+        if (emitAlarmType) emitAlarm(emitAlarmType);
     }
 }
   function is_different (actual, predicted, mbg, treatment, errorCode) {

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -240,7 +240,6 @@ function loadData() {
 
         var emitAlarmType = null;
 
-        
         if (env.alarm_types.indexOf("simple") > -1) {
             var lastBG = actual[actualLength].y;
 

--- a/static/css/drawer.css
+++ b/static/css/drawer.css
@@ -10,7 +10,7 @@
     position: absolute;
     margin-top: 45px;
     right: -200px;
-    width: 200px;
+    width: 300px;
     top: 0;
     z-index: 1;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -151,7 +151,7 @@ body {
 }
 
 #bgButton {
-    background: #ff2035;
+    background: yellow;
     border: 2px solid #DDD;
     border-right: 2px solid #ccc;
     border-bottom: 2px solid #ccc;
@@ -174,6 +174,10 @@ body {
     -khtml-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
+}
+
+#bgButton.urgent {
+  background: red;
 }
 
 .bgButton:active {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -242,6 +242,11 @@ div.tooltip {
     font-size: 70%;
   }
 
+  html body #bgButton {
+    font-size: 80%;
+  }
+
+
   html body #chartContainer {
     top: 130px;
   }
@@ -289,13 +294,6 @@ div.tooltip {
   }
   .dropdown-menu {
     font-size: 60% !important;
-  }
-  #currentTime {
-    font-size: 65%;
-    padding: 0;
-  }
-  #lastEntry {
-    font-size: 65%;
   }
 
   #chartContainer {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -224,37 +224,6 @@ div.tooltip {
 	padding: 0 0 10px 0;
 }
 
-@media (max-height: 480px) {
-  html body #toolbar {
-    float: right;
-    height: auto;
-  }
-
-  #toolbar h1 {
-    display: none;
-  }
-
-  html body .container {
-    top: 15px;
-    padding-bottom: 20px;
-  }
-  html body .container .status {
-    font-size: 70%;
-  }
-
-  html body #bgButton {
-    font-size: 80%;
-  }
-
-
-  html body #chartContainer {
-    top: 130px;
-  }
-  html body #chartContainer svg {
-    height: calc(100vh - 130px);
-  }
-}
-
 /* Large desktop */
 @media (min-width: 980px) {
     .content {
@@ -270,7 +239,7 @@ div.tooltip {
 
 @media (max-width: 800px) {
   #chartContainer {
-    font-size: 115%;
+    font-size: 80%;
   }
 
   .bgStatus {
@@ -294,6 +263,10 @@ div.tooltip {
   }
   .dropdown-menu {
     font-size: 60% !important;
+  }
+
+  .container .status {
+    font-size: 70%;
   }
 
   #chartContainer {
@@ -344,6 +317,10 @@ div.tooltip {
         margin-left: 2vw;
         width: 96vw;
     }
+    .container .status {
+        font-size: 100% !important;
+    }
+
     .time {
         margin-bottom: 0.1em;
         margin-top: -1em;
@@ -356,7 +333,7 @@ div.tooltip {
     }
     #currentTime {
         display: inline;
-        font-size: 25%;
+        font-size: 25% !important;
         font-weight: bold;
     }
     .timeOther {
@@ -365,10 +342,54 @@ div.tooltip {
     }
 
     #chartContainer {
-        font-size: 110%;
+        font-size: 110% !important;
         top: 210px;
     }
     #chartContainer svg {
         height: calc(100vh - (210px));
+    }
+}
+
+@media (max-height: 480px) {
+    #toolbar {
+        float: right;
+        height: auto !important;
+    }
+
+    #toolbar h1 {
+        display: none;
+    }
+
+    .container {
+        top: 15px;
+        padding-bottom: 20px;
+    }
+
+    #bgButton {
+        font-size: 70% !important;
+    }
+
+    #currentTime {
+        font-size: 85%;
+    }
+
+    #chartContainer {
+        top: 130px;
+        font-size: 80%;
+    }
+    #chartContainer svg {
+        height: calc(100vh - 130px);
+    }
+}
+
+@media (max-height: 480px) and (min-width: 400px) {
+    .container .status {
+        font-size: 70%;
+    }
+}
+
+@media (max-height: 480px) and (max-width: 400px) {
+    .container .status {
+        font-size: 80% !important;
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -76,8 +76,10 @@
                     </dl>
                     <dl class="toggle">
                         <dt>Enable Alarms <a class="tip" original-title="When enabled the an alarm will sound."><i class="icon-help-circled"></i></a></dt>
-                        <dd><input type="checkbox" name="alarmhigh-browser" id="alarmhigh-browser" /><label for="alarmhigh-browser">High Alarm</label></dd>
-                        <dd><input type="checkbox" name="alarmlow-browser" id="alarmlow-browser" /><label for="alarmlow-browser">Low Alarm</label></dd>
+                        <dd><input type="checkbox" id="alarm-urgenthigh-browser" /><label for="alarm-urgenthigh-browser">Urgent High Alarm</label></dd>
+                        <dd><input type="checkbox" id="alarm-high-browser" /><label for="alarm-high-browser">High Alarm</label></dd>
+                        <dd><input type="checkbox" id="alarm-low-browser" /><label for="alarm-low-browser">Low Alarm</label></dd>
+                        <dd><input type="checkbox" id="alarm-urgentlow-browser" /><label for="alarm-urgentlow-browser">Urgent Low Alarm</label></dd>
                     </dl>
                     <dl class="toggle">
                         <dt>Night Mode <a class="tip" original-title="When enabled the page will be dimmed from 10pm - 6am."><i class="icon-help-circled"></i></a></dt>

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
         <meta name="viewport" content="width=device-width, maximum-scale=1, initial-scale=1, user-scalable=0" />
         <meta name="apple-mobile-web-app-capable" content="yes">
         <link rel="apple-touch-icon" href="/images/logomobile.png">
-        <title>NightScout</title>
+        <title>Nightscout</title>
         <link href="/images/round1.png" rel="icon" id="favicon" type="image/png" />
         <link rel="stylesheet" type="text/css" href="/css/main.css?v=0.5.x-12-13" />
         <link rel="stylesheet" type="text/css" href="/css/dropdown.css" />

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -405,6 +405,17 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         // selects all our data into data and uses date function to get current max date
         var focusCircles = focus.selectAll('circle').data(focusData, dateFn);
 
+        var focusDotRadius = function(d) {
+            if (d.type == 'mbg')
+                return 6;
+            else if ($(window).width() > WIDTH_BIG_DOTS)
+                return 4;
+            else if ($(window).width() < WIDTH_SMALL_DOTS)
+                return 2;
+            else
+                return 3;
+        };
+
         // if already existing then transition each circle to its new position
         focusCircles
             .transition()
@@ -412,6 +423,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             .attr('cx', function (d) { return xScale(d.date); })
             .attr('cy', function (d) { return yScale(d.sgv); })
             .attr('fill', function (d) { return d.color; })
+            .attr('r', focusDotRadius)
             .attr('opacity', function (d) { return futureOpacity(d.date.getTime() - latestSGV.x); });
 
         // if new circle then just display
@@ -425,16 +437,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 var device = d.device && d.device.toLowerCase();
                 return (device == 'shugatrak' ? '#a4c2db' : 'white');
             })
-            .attr('r', function(d) {
-                if (d.type == 'mbg')
-                    return 6;
-                else if ($(window).width() > WIDTH_BIG_DOTS)
-                    return 4;
-                else if ($(window).width() < WIDTH_SMALL_DOTS)
-                    return 2;
-                else
-                    return 3;
-            })
+            .attr('r', focusDotRadius)
             .on('mouseover', function (d) {
                 if (d.type != "sgv" && d.type != 'mbg') return;
 

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -501,6 +501,13 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             .attr('x2', xScale(nowDate))
             .attr('y2', yScale(scaleBg(420)));
 
+        context.select('.now-line')
+            .transition()
+            .attr('x1', xScale2(new Date(brush.extent()[1]- THIRTY_MINS_IN_MS)))
+            .attr('y1', yScale2(scaleBg(36)))
+            .attr('x2', xScale2(new Date(brush.extent()[1]- THIRTY_MINS_IN_MS)))
+            .attr('y2', yScale2(scaleBg(420)));
+
         // update x axis
         focus.select('.x.axis')
             .call(xAxis);
@@ -851,14 +858,6 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
 
         // update domain
         xScale2.domain(dataRange);
-
-        context.select('.now-line')
-            .transition()
-            .duration(UPDATE_TRANS_MS)
-            .attr('x1', xScale2(new Date(now)))
-            .attr('y1', yScale2(scaleBg(36)))
-            .attr('x2', xScale2(new Date(now)))
-            .attr('y2', yScale2(scaleBg(420)));
 
         // only if a user brush is not active, update brush and focus chart with recent data
         // else, just transition brush

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -1,3 +1,6 @@
+//TODO: clean up
+var app = {}, browserSettings = {}, browserStorage = $.localStorage;
+
 (function () {
     "use strict";
 
@@ -32,9 +35,7 @@
         , alarmSound = 'alarm.mp3'
         , urgentAlarmSound = 'alarm2.mp3';
 
-    var targetTop
-        , targetBottom
-        , tickValues
+    var tickValues
         , charts
         , futureOpacity
         , focus
@@ -607,9 +608,29 @@
                 focus.append('line')
                     .attr('class', 'high-line')
                     .attr('x1', xScale(dataRange[0]))
-                    .attr('y1', yScale(scaleBg(targetTop)))
+                    .attr('y1', yScale(scaleBg(app.thresholds.bg_high)))
                     .attr('x2', xScale(dataRange[1]))
-                    .attr('y2', yScale(scaleBg(targetTop)))
+                    .attr('y2', yScale(scaleBg(app.thresholds.bg_high)))
+                    .style('stroke-dasharray', ('1, 6'))
+                    .attr('stroke', '#777');
+
+                // add a y-axis line that shows the high bg threshold
+                focus.append('line')
+                    .attr('class', 'target-top-line')
+                    .attr('x1', xScale(dataRange[0]))
+                    .attr('y1', yScale(scaleBg(app.thresholds.bg_target_top)))
+                    .attr('x2', xScale(dataRange[1]))
+                    .attr('y2', yScale(scaleBg(app.thresholds.bg_target_top)))
+                    .style('stroke-dasharray', ('3, 3'))
+                    .attr('stroke', 'grey');
+
+                // add a y-axis line that shows the low bg threshold
+                focus.append('line')
+                    .attr('class', 'target-bottom-line')
+                    .attr('x1', xScale(dataRange[0]))
+                    .attr('y1', yScale(scaleBg(app.thresholds.bg_target_bottom)))
+                    .attr('x2', xScale(dataRange[1]))
+                    .attr('y2', yScale(scaleBg(app.thresholds.bg_target_bottom)))
                     .style('stroke-dasharray', ('3, 3'))
                     .attr('stroke', 'grey');
 
@@ -617,11 +638,11 @@
                 focus.append('line')
                     .attr('class', 'low-line')
                     .attr('x1', xScale(dataRange[0]))
-                    .attr('y1', yScale(scaleBg(targetBottom)))
+                    .attr('y1', yScale(scaleBg(app.thresholds.bg_low)))
                     .attr('x2', xScale(dataRange[1]))
-                    .attr('y2', yScale(scaleBg(targetBottom)))
-                    .style('stroke-dasharray', ('3, 3'))
-                    .attr('stroke', 'grey');
+                    .attr('y2', yScale(scaleBg(app.thresholds.bg_low)))
+                    .style('stroke-dasharray', ('1, 6'))
+                    .attr('stroke', '#777');
 
                 // add a y-axis line that opens up the brush extent from the context to the focus
                 focus.append('line')
@@ -653,9 +674,9 @@
                 context.append('line')
                     .attr('class', 'high-line')
                     .attr('x1', xScale(dataRange[0]))
-                    .attr('y1', yScale2(scaleBg(targetTop)))
+                    .attr('y1', yScale2(scaleBg(app.thresholds.bg_target_top)))
                     .attr('x2', xScale(dataRange[1]))
-                    .attr('y2', yScale2(scaleBg(targetTop)))
+                    .attr('y2', yScale2(scaleBg(app.thresholds.bg_target_top)))
                     .style('stroke-dasharray', ('3, 3'))
                     .attr('stroke', 'grey');
 
@@ -663,9 +684,9 @@
                 context.append('line')
                     .attr('class', 'low-line')
                     .attr('x1', xScale(dataRange[0]))
-                    .attr('y1', yScale2(scaleBg(targetBottom)))
+                    .attr('y1', yScale2(scaleBg(app.thresholds.bg_target_bottom)))
                     .attr('x2', xScale(dataRange[1]))
-                    .attr('y2', yScale2(scaleBg(targetBottom)))
+                    .attr('y2', yScale2(scaleBg(app.thresholds.bg_target_bottom)))
                     .style('stroke-dasharray', ('3, 3'))
                     .attr('stroke', 'grey');
 
@@ -705,23 +726,38 @@
                 // redraw old brush with new dimensions
                 d3.select('.brush').transition().duration(UPDATE_TRANS_MS).call(brush.extent(currentBrushExtent));
 
-                // transition high line to correct location
+                // transition lines to correct location
                 focus.select('.high-line')
                     .transition()
                     .duration(UPDATE_TRANS_MS)
                     .attr('x1', xScale(currentBrushExtent[0]))
-                    .attr('y1', yScale(scaleBg(targetTop)))
+                    .attr('y1', yScale(scaleBg(app.thresholds.bg_high)))
                     .attr('x2', xScale(currentBrushExtent[1]))
-                    .attr('y2', yScale(scaleBg(targetTop)));
+                    .attr('y2', yScale(scaleBg(app.thresholds.bg_high)));
 
-                // transition low line to correct location
+                focus.select('.target-top-line')
+                    .transition()
+                    .duration(UPDATE_TRANS_MS)
+                    .attr('x1', xScale(currentBrushExtent[0]))
+                    .attr('y1', yScale(scaleBg(app.thresholds.bg_target_top)))
+                    .attr('x2', xScale(currentBrushExtent[1]))
+                    .attr('y2', yScale(scaleBg(app.thresholds.bg_target_top)));
+
+                focus.select('.target-bottom-line')
+                    .transition()
+                    .duration(UPDATE_TRANS_MS)
+                    .attr('x1', xScale(currentBrushExtent[0]))
+                    .attr('y1', yScale(scaleBg(app.thresholds.bg_target_bottom)))
+                    .attr('x2', xScale(currentBrushExtent[1]))
+                    .attr('y2', yScale(scaleBg(app.thresholds.bg_target_bottom)));
+
                 focus.select('.low-line')
                     .transition()
                     .duration(UPDATE_TRANS_MS)
                     .attr('x1', xScale(currentBrushExtent[0]))
-                    .attr('y1', yScale(scaleBg(targetBottom)))
+                    .attr('y1', yScale(scaleBg(app.thresholds.bg_low)))
                     .attr('x2', xScale(currentBrushExtent[1]))
-                    .attr('y2', yScale(scaleBg(targetBottom)));
+                    .attr('y2', yScale(scaleBg(app.thresholds.bg_low)));
 
                 // transition open-top line to correct location
                 focus.select('.open-top')
@@ -755,18 +791,18 @@
                     .transition()
                     .duration(UPDATE_TRANS_MS)
                     .attr('x1', xScale2(dataRange[0]))
-                    .attr('y1', yScale2(scaleBg(targetTop)))
+                    .attr('y1', yScale2(scaleBg(app.thresholds.bg_target_top)))
                     .attr('x2', xScale2(dataRange[1]))
-                    .attr('y2', yScale2(scaleBg(targetTop)));
+                    .attr('y2', yScale2(scaleBg(app.thresholds.bg_target_top)));
 
                 // transition low line to correct location
                 context.select('.low-line')
                     .transition()
                     .duration(UPDATE_TRANS_MS)
                     .attr('x1', xScale2(dataRange[0]))
-                    .attr('y1', yScale2(scaleBg(targetBottom)))
+                    .attr('y1', yScale2(scaleBg(app.thresholds.bg_target_bottom)))
                     .attr('x2', xScale2(dataRange[1]))
-                    .attr('y2', yScale2(scaleBg(targetBottom)));
+                    .attr('y2', yScale2(scaleBg(app.thresholds.bg_target_bottom)));
             }
         }
 
@@ -828,12 +864,16 @@
         var color = 'grey';
 
         if (browserSettings.theme == "colors") {
-            if (sgv > targetTop) {
-                color = 'yellow';
-            } else if (sgv >= targetBottom && sgv <= targetTop) {
-                color = '#4cff00';
-            } else if (sgv < targetBottom) {
+            if (sgv > app.thresholds.bg_high) {
                 color = 'red';
+            } else if (sgv > app.thresholds.bg_target_top) {
+                color = 'yellow';
+            } else if (sgv >= app.thresholds.bg_target_bottom && sgv <= app.thresholds.bg_target_top) {
+                color = '#4cff00';
+            } else if (sgv < app.thresholds.bg_low) {
+                color = 'red';
+            } else if (sgv < app.thresholds.bg_target_bottom) {
+                color = 'yellow';
             }
         }
 
@@ -848,10 +888,11 @@
             playAlarm(audio);
             $(this).addClass('playing');
         });
-        var element = document.getElementById('bgButton');
-        element.hidden = '';
-        var element1 = document.getElementById('noButton');
-        element1.hidden = 'true';
+        var bgButton = $('#bgButton');
+        bgButton.show();
+        bgButton.toggleClass("urgent", file == urgentAlarmSound);
+        var noButton = $('#noButton');
+        noButton.hide();
         $('.container .currentBG').text();
 
         if ($(window).width() <= WIDTH_TIME_HIDDEN) {
@@ -870,10 +911,10 @@
 
     function stopAlarm(isClient, silenceTime) {
         alarmInProgress = false;
-        var element = document.getElementById('bgButton');
-        element.hidden = 'true';
-        element = document.getElementById('noButton');
-        element.hidden = '';
+        var bgButton = $('#bgButton');
+        bgButton.hide();
+        var noButton = $('#noButton');
+        noButton.show();
         d3.select('audio.playing').each(function (d, i) {
             var audio = this;
             audio.pause();
@@ -1063,13 +1104,27 @@
             .attr("class", "tooltip")
             .style("opacity", 0);
 
-        targetTop = app.thresholds.bg_target_top;
-        targetBottom = app.thresholds.bg_target_bottom;
-
         // Tick Values
-        tickValues = [40, 60, targetBottom, 120, targetTop, 300, 400];
         if (browserSettings.units == "mmol") {
-            tickValues = [2.0, 3.0, Math.round(scaleBg(targetBottom)), 6.0, Math.round(scaleBg(targetTop)), 15.0, 22.0];
+            tickValues = [
+                  2.0
+                , Math.round(scaleBg(app.thresholds.bg_low))
+                , Math.round(scaleBg(app.thresholds.bg_target_bottom))
+                , 6.0
+                , Math.round(scaleBg(app.thresholds.bg_target_top))
+                , Math.round(scaleBg(app.thresholds.bg_high))
+                , 22.0
+            ];
+        } else {
+            tickValues = [
+                  40
+                , app.thresholds.bg_low
+                , app.thresholds.bg_target_bottom
+                , 120
+                , app.thresholds.bg_target_top
+                , app.thresholds.bg_high
+                , 400
+            ];
         }
 
         futureOpacity = d3.scale.linear( )
@@ -1190,20 +1245,41 @@
         socket.on('connect', function () {
             console.log('Client connected to server.')
         });
+
+        //with predicted alarms, latestSGV may still be in target so to see if the alarm
+        //  is for a HIGH we can only check if it's >= the bottom of the target
+        function isAlarmForHigh() {
+            return latestSGV.y >= app.thresholds.bg_target_bottom;
+        }
+
+        //with predicted alarms, latestSGV may still be in target so to see if the alarm
+        //  is for a LOW we can only check if it's <= the top of the target
+        function isAlarmForLow() {
+            return latestSGV.y <= app.thresholds.bg_target_top;
+        }
+
         socket.on('alarm', function () {
-            if (browserSettings.alarmHigh) {
+            console.info("alarm received from server");
+            var enabled = (isAlarmForHigh() && browserSettings.alarmHigh) || (isAlarmForLow() && browserSettings.alarmLow);
+            if (enabled) {
                 console.log("Alarm raised!");
                 currentAlarmType = 'alarm';
                 generateAlarm(alarmSound);
+            } else {
+                console.info("alarm was disabled locally", latestSGV.y, browserSettings);
             }
             brushInProgress = false;
             updateChart(false);
         });
         socket.on('urgent_alarm', function () {
-            if (browserSettings.alarmLow) {
+            console.info("urgent alarm received from server");
+            var enabled = (isAlarmForHigh() && browserSettings.alarmUrgentHigh) || (isAlarmForLow() && browserSettings.alarmUrgentLow);
+            if (enabled) {
                 console.log("Urgent alarm raised!");
                 currentAlarmType = 'urgent_alarm';
                 generateAlarm(urgentAlarmSound);
+            } else {
+                console.info("urgent alarm was disabled locally", latestSGV.y, browserSettings);
             }
             brushInProgress = false;
             updateChart(false);
@@ -1228,7 +1304,6 @@
         });
     }
 
-    var app = {};
     $.ajax("/api/v1/status.json", {
         success: function (xhr) {
             app = { name: xhr.name
@@ -1236,6 +1311,7 @@
                 , head: xhr.head
                 , apiEnabled: xhr.apiEnabled
                 , thresholds: xhr.thresholds
+                , units: xhr.units
                 , careportalEnabled: xhr.careportalEnabled
             };
         }
@@ -1247,6 +1323,7 @@
             $(".serverSettings").show();
         }
         $("#treatmentDrawerToggle").toggle(app.careportalEnabled);
+        browserSettings = getBrowserSettings(browserStorage);
         init();
     });
 

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -17,6 +17,8 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         , FORMAT_TIME_24 = '%H:%M%'
         , FORMAT_TIME_SCALE = '%I %p'
         , WIDTH_TIME_HIDDEN = 500
+        , WIDTH_SMALL_DOTS = WIDTH_TIME_HIDDEN
+        , WIDTH_BIG_DOTS = 800
         , MINUTES_SINCE_LAST_UPDATE_WARN = 10
         , MINUTES_SINCE_LAST_UPDATE_URGENT = 20;
 
@@ -423,7 +425,16 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 var device = d.device && d.device.toLowerCase();
                 return (device == 'shugatrak' ? '#a4c2db' : 'white');
             })
-            .attr('r', function(d) { if (d.type == 'mbg') return 6; else return 4;})
+            .attr('r', function(d) {
+                if (d.type == 'mbg')
+                    return 6;
+                else if ($(window).width() > WIDTH_BIG_DOTS)
+                    return 4;
+                else if ($(window).width() < WIDTH_SMALL_DOTS)
+                    return 2;
+                else
+                    return 3;
+            })
             .on('mouseover', function (d) {
                 if (d.type != "sgv" && d.type != 'mbg') return;
 

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -2,9 +2,10 @@
 var app = {}, browserSettings = {}, browserStorage = $.localStorage;
 
 (function () {
-    "use strict";
+    'use strict';
 
     var BRUSH_TIMEOUT = 300000 // 5 minutes in ms
+        , TOOLTIP_TRANS_MS = 200 // milliseconds
         , UPDATE_TRANS_MS = 750 // milliseconds
         , ONE_MIN_IN_MS = 60000
         , FIVE_MINS_IN_MS = 300000
@@ -38,7 +39,8 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         , alarmSound = 'alarm.mp3'
         , urgentAlarmSound = 'alarm2.mp3';
 
-    var tooltip
+    var jqWindow
+        , tooltip
         , tickValues
         , charts
         , futureOpacity
@@ -68,7 +70,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
     function getTimeFormat(isForScale) {
         var timeFormat = FORMAT_TIME_12;
         if (browserSettings.timeFormat) {
-            if (browserSettings.timeFormat == "24") {
+            if (browserSettings.timeFormat == '24') {
                 timeFormat = FORMAT_TIME_24;
             }
         }
@@ -81,20 +83,20 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
     }
 
     var x2TickFormat = d3.time.format.multi([
-        [".%L", function(d) { return d.getMilliseconds(); }],
-        [":%S", function(d) { return d.getSeconds(); }],
-        ["%I:%M", function(d) { return d.getMinutes(); }],
-        [(getTimeFormat() == FORMAT_TIME_12) ? "%I %p": '%H:%M%', function(d) { return d.getHours(); }],
-        ["%a %d", function(d) { return d.getDay() && d.getDate() != 1; }],
-        ["%b %d", function(d) { return d.getDate() != 1; }],
-        ["%B", function(d) { return d.getMonth(); }],
-        ["%Y", function() { return true; }]
+        ['.%L', function(d) { return d.getMilliseconds(); }],
+        [':%S', function(d) { return d.getSeconds(); }],
+        ['%I:%M', function(d) { return d.getMinutes(); }],
+        [(getTimeFormat() == FORMAT_TIME_12) ? '%I %p': '%H:%M%', function(d) { return d.getHours(); }],
+        ['%a %d', function(d) { return d.getDay() && d.getDate() != 1; }],
+        ['%b %d', function(d) { return d.getDate() != 1; }],
+        ['%B', function(d) { return d.getMonth(); }],
+        ['%Y', function() { return true; }]
     ]);
 
 
   // lixgbg: Convert mg/dL BG value to metric mmol
     function scaleBg(bg) {
-        if (browserSettings.units == "mmol") {
+        if (browserSettings.units == 'mmol') {
             return (Math.round((bg / 18) * 10) / 10).toFixed(1);
         } else {
             return bg;
@@ -221,10 +223,10 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         var focusData = data.slice();
 
         if (alarmInProgress) {
-            if ($(window).width() > WIDTH_TIME_HIDDEN) {
-                $(".time").show();
+            if (jqWindow.width() > WIDTH_TIME_HIDDEN) {
+                $('.time').show();
             } else {
-                $(".time").hide();
+                $('.time').hide();
             }
         }
 
@@ -246,7 +248,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                     d.type == 'sgv';
             });
             // sometimes nowDataRaw contains duplicates.  uniq it.
-            var lastDate = new Date("1/1/1970");
+            var lastDate = new Date('1/1/1970');
             var nowData = nowDataRaw.filter(function(n) {
                 if ( (lastDate.getTime() + ONE_MIN_IN_MS) < n.date.getTime()) {
                     lastDate = n.date;
@@ -267,20 +269,20 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 else
                     $('.container .currentBG').text(focusPoint.sgv);
                     var retroDelta = scaleBg(focusPoint.y) - scaleBg(prevfocusPoint.y);
-                    if (browserSettings.units == "mmol") {
+                    if (browserSettings.units == 'mmol') {
                         retroDelta = retroDelta.toFixed(1);
                     }
                     if (retroDelta < 0) {
                         var retroDeltaString = retroDelta;
                     }
                     else {
-                        var retroDeltaString = "+" + retroDelta;
+                        var retroDeltaString = '+' + retroDelta;
                     }
-                    if (browserSettings.units == "mmol") {
-                    var retroDeltaString = retroDeltaString + " mmol/L"
+                    if (browserSettings.units == 'mmol') {
+                    var retroDeltaString = retroDeltaString + ' mmol/L'
                     }
                     else {
-                    var retroDeltaString = retroDeltaString + " mg/dL"
+                    var retroDeltaString = retroDeltaString + ' mg/dL'
                     }
 
                 $('.container .currentBG').css('text-decoration','line-through');
@@ -290,7 +292,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 $('.container .currentDirection').html(focusPoint.direction)
             } else {
                 $('.container .currentBG')
-                    .text("---")
+                    .text('---')
                     .css('text-decoration','');
                 $('.container .currentDelta').text('');
             }
@@ -298,7 +300,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 .text(formatTime(new Date(brushExtent[1] - THIRTY_MINS_IN_MS)))
                 .css('text-decoration','line-through');
 
-            $('#lastEntry').text("RETRO").removeClass('current');
+            $('#lastEntry').text('RETRO').removeClass('current');
 
             $('.container #noButton .currentBG').css({color: 'grey'});
             $('.container #noButton .currentDelta').css({color: 'grey'});
@@ -338,7 +340,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                     default: errorDisplay = '?' + parseInt(errorCode) + '?'; break;
                 }
 
-                $('#lastEntry').text("CGM ERROR").removeClass('current').addClass("urgent");
+                $('#lastEntry').text('CGM ERROR').removeClass('current').addClass('urgent');
 
                 $('.container .currentBG').html(errorDisplay)
                     .css('text-decoration', '');
@@ -356,28 +358,29 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 $('#lastEntry').text(timeAgo(secsSinceLast)).toggleClass('current', secsSinceLast < 10 * 60);
 
                 //in this case the SGV is unscaled
-                if (latestSGV.y < 40)
+                if (latestSGV.y < 40) {
                     $('.container .currentBG').text('LOW');
-                else if (latestSGV.y > 400)
+                } else if (latestSGV.y > 400) {
                     $('.container .currentBG').text('HIGH');
-                else
+                } else {
                     $('.container .currentBG').text(scaleBg(latestSGV.y));
-		            var bgDelta = scaleBg(latestSGV.y) - scaleBg(prevSGV.y);
-                    if (browserSettings.units == "mmol") {
-                        bgDelta = bgDelta.toFixed(1);
-                    }
-                    if (bgDelta < 0) {
-                        var bgDeltaString = bgDelta;
-                    }
-		            else {
-			            var bgDeltaString = "+" + bgDelta;
-		            }
-                    if (browserSettings.units == "mmol") {
-                        var bgDeltaString = bgDeltaString + " mmol/L"
-                    }
-                    else {
-                        var bgDeltaString = bgDeltaString + " mg/dL"
-                    }
+                }
+
+                var bgDelta = scaleBg(latestSGV.y) - scaleBg(prevSGV.y);
+                if (browserSettings.units == 'mmol') {
+                    bgDelta = bgDelta.toFixed(1);
+                }
+
+                var bgDeltaString = bgDelta;
+                if (bgDelta >= 0) {
+                    bgDeltaString = '+' + bgDelta;
+                }
+
+                if (browserSettings.units == 'mmol') {
+                    bgDeltaString = bgDeltaString + ' mmol/L'
+                } else {
+                    bgDeltaString = bgDeltaString + ' mg/dL'
+                }
 
                 $('.container .currentBG').css('text-decoration', '');
                 $('.container .currentDelta')
@@ -405,15 +408,10 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         // selects all our data into data and uses date function to get current max date
         var focusCircles = focus.selectAll('circle').data(focusData, dateFn);
 
-        var focusDotRadius = function(d) {
-            if (d.type == 'mbg')
-                return 6;
-            else if ($(window).width() > WIDTH_BIG_DOTS)
-                return 4;
-            else if ($(window).width() < WIDTH_SMALL_DOTS)
-                return 2;
-            else
-                return 3;
+        var dotRadius = function(type) {
+            var radius = prevChartWidth > WIDTH_BIG_DOTS ? 4 : (prevChartWidth < WIDTH_SMALL_DOTS ? 2 : 3);
+            if (type == 'mbg') radius *= 2;
+            return radius;
         };
 
         // if already existing then transition each circle to its new position
@@ -423,7 +421,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             .attr('cx', function (d) { return xScale(d.date); })
             .attr('cy', function (d) { return yScale(d.sgv); })
             .attr('fill', function (d) { return d.color; })
-            .attr('r', focusDotRadius)
+            .attr('r', function (d) {return dotRadius(d.type); })
             .attr('opacity', function (d) { return futureOpacity(d.date.getTime() - latestSGV.x); });
 
         // if new circle then just display
@@ -437,25 +435,25 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 var device = d.device && d.device.toLowerCase();
                 return (device == 'dexcom' ? 'white' : '#0099ff');
             })
-            .attr('r', focusDotRadius)
+            .attr('r', function (d) {return dotRadius(d.type); })
             .on('mouseover', function (d) {
-                if (d.type != "sgv" && d.type != 'mbg') return;
+                if (d.type != 'sgv' && d.type != 'mbg') return;
 
                 var device = d.device && d.device.toLowerCase();
-                var bgType = (d.type == "sgv" ? 'CGM' : (device == 'dexcom' ? 'Calibration' : 'Meter'));
+                var bgType = (d.type == 'sgv' ? 'CGM' : (device == 'dexcom' ? 'Calibration' : 'Meter'));
 
-                tooltip.transition().duration(200).style("opacity", .9);
+                tooltip.transition().duration(TOOLTIP_TRANS_MS).style('opacity', .9);
                 tooltip.html('<strong>' + bgType + ' BG:</strong> ' + d.sgv +
                     (d.type == 'mbg' ? '<br/><strong>Device: </strong>' + d.device : '') +
                     '<br/><strong>Time:</strong> ' + formatTime(d.date))
-                    .style("left", (d3.event.pageX) + "px")
-                    .style("top", (d3.event.pageY - 28) + "px");
+                    .style('left', (d3.event.pageX) + 'px')
+                    .style('top', (d3.event.pageY - 28) + 'px');
             })
             .on('mouseout', function (d) {
-                if (d.type != "sgv" && d.type != 'mbg') return;
+                if (d.type != 'sgv' && d.type != 'mbg') return;
                 tooltip.transition()
-                    .duration(500)
-                    .style("opacity", 0);
+                    .duration(TOOLTIP_TRANS_MS)
+                    .style('opacity', 0);
             });
 
         focusCircles.exit()
@@ -465,12 +463,11 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         d3.selectAll('.path').remove();
 
         // add treatment bubbles
-
-        var bubbleSize = prevChartWidth < 400 ? 4 : (prevChartWidth < 600 ? 3 : 2);
+        // a higher bubbleScale will produce smaller bubbles (it's not a radius like focusDotRadius)
+        var bubbleScale = prevChartWidth < WIDTH_SMALL_DOTS ? 4 : (prevChartWidth < WIDTH_BIG_DOTS ? 3 : 2);
         focus.selectAll('circle')
             .data(treatments)
-            .each(function (d) { drawTreatment(d, bubbleSize, true) });
-
+            .each(function (d) { drawTreatment(d, bubbleScale, true) });
 
         // transition open-top line to correct location
         focus.select('.open-top')
@@ -535,25 +532,25 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             treatCircles.enter().append('circle')
                   .attr('cx', function (d) { return xScale(d.created_at); })
                   .attr('cy', function (d) { return yScale(scaleBg(d.glucose || calcBGByTime(d.created_at.getTime()))); })
-                  .attr("r", 6)
+                  .attr('r', function () { return dotRadius('mbg'); })
                   .attr('stroke-width', 2)
                   .attr('stroke', function (d) { return d.glucose ? 'grey' : 'white'; })
                   .attr('fill', function (d) { return d.glucose ? 'red' : 'grey'; })
                   .on('mouseover', function (d) {
-                      tooltip.transition().duration(200).style("opacity", .9);
-                      tooltip.html("<strong>Time:</strong> " + formatTime(d.created_at) + "<br/>" +
-                          (d.eventType ? "<strong>Treatment type:</strong> " + d.eventType + "<br/>" : '') +
-                          (d.glucose ? "<strong>BG:</strong> " + d.glucose + (d.glucoseType ? ' (' + d.glucoseType + ')': '') + "<br/>" : '') +
-                          (d.enteredBy ? "<strong>Entered by:</strong> " + d.enteredBy + "<br/>" : '') +
-                          (d.notes ? "<strong>Notes:</strong> " + d.notes : '')
+                      tooltip.transition().duration(TOOLTIP_TRANS_MS).style('opacity', .9);
+                      tooltip.html('<strong>Time:</strong> ' + formatTime(d.created_at) + '<br/>' +
+                          (d.eventType ? '<strong>Treatment type:</strong> ' + d.eventType + '<br/>' : '') +
+                          (d.glucose ? '<strong>BG:</strong> ' + d.glucose + (d.glucoseType ? ' (' + d.glucoseType + ')': '') + '<br/>' : '') +
+                          (d.enteredBy ? '<strong>Entered by:</strong> ' + d.enteredBy + '<br/>' : '') +
+                          (d.notes ? '<strong>Notes:</strong> ' + d.notes : '')
                       )
-                      .style("left", (d3.event.pageX) + "px")
-                      .style("top", (d3.event.pageY - 28) + "px");
+                      .style('left', (d3.event.pageX) + 'px')
+                      .style('top', (d3.event.pageY - 28) + 'px');
                   })
-                  .on('mouseout', function (d) {
+                  .on('mouseout', function () {
                       tooltip.transition()
-                          .duration(500)
-                          .style("opacity", 0);
+                          .duration(TOOLTIP_TRANS_MS)
+                          .style('opacity', 0);
                   });
             
             treatCircles.attr('clip-path', 'url(#clip)');
@@ -881,7 +878,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             .attr('fill', function (d) { return d.color; })
             .style('opacity', function (d) { return highlightBrushPoints(d) })
             .attr('stroke-width', function (d) {if (d.type == 'mbg') return 2; else return 0; })
-            .attr('stroke', function (d) { return "white"; })
+            .attr('stroke', function (d) { return 'white'; })
             .attr('r', function(d) { if (d.type == 'mbg') return 4; else return 2;});
 
         contextCircles.exit()
@@ -895,7 +892,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
     function sgvToColor(sgv) {
         var color = 'grey';
 
-        if (browserSettings.theme == "colors") {
+        if (browserSettings.theme == 'colors') {
             if (sgv > app.thresholds.bg_high) {
                 color = 'red';
             } else if (sgv > app.thresholds.bg_target_top) {
@@ -922,22 +919,22 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         });
         var bgButton = $('#bgButton');
         bgButton.show();
-        bgButton.toggleClass("urgent", file == urgentAlarmSound);
+        bgButton.toggleClass('urgent', file == urgentAlarmSound);
         var noButton = $('#noButton');
         noButton.hide();
         $('.container .currentBG').text();
 
-        if ($(window).width() <= WIDTH_TIME_HIDDEN) {
-            $(".time").hide();
+        if (jqWindow.width() <= WIDTH_TIME_HIDDEN) {
+            $('.time').hide();
         }
     }
 
     function playAlarm(audio) {
         // ?mute=true disables alarms to testers.
-        if (querystring.mute != "true") {
+        if (querystring.mute != 'true') {
             audio.play();
         } else {
-            showNotification("Alarm is muted per your request. (?mute=true)");
+            showNotification('Alarm is muted per your request. (?mute=true)');
         }
     }
 
@@ -953,7 +950,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             $(this).removeClass('playing');
         });
 
-        $(".time").show();
+        $('.time').show();
 
         // only emit ack if client invoke by button press
         if (isClient) {
@@ -983,18 +980,18 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         else                               parts = { label: 'a long time ago' };
 
         if (offset > (MINUTE * MINUTES_SINCE_LAST_UPDATE_URGENT)) {
-            var lastEntry = $("#lastEntry");
-            lastEntry.removeClass("warn");
-            lastEntry.addClass("urgent");
+            var lastEntry = $('#lastEntry');
+            lastEntry.removeClass('warn');
+            lastEntry.addClass('urgent');
 
-            $(".bgStatus").removeClass("current");
+            $('.bgStatus').removeClass('current');
         } else if (offset > (MINUTE * MINUTES_SINCE_LAST_UPDATE_WARN)) {
-            var lastEntry = $("#lastEntry");
-            lastEntry.removeClass("urgent");
-            lastEntry.addClass("warn");
+            var lastEntry = $('#lastEntry');
+            lastEntry.removeClass('urgent');
+            lastEntry.addClass('warn');
         } else {
-            $(".bgStatus").addClass("current");
-            $("#lastEntry").removeClass("warn urgent");
+            $('.bgStatus').addClass('current');
+            $('#lastEntry').removeClass('warn urgent');
         }
 
         if (parts.value)
@@ -1006,8 +1003,9 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
 
     function calcBGByTime(time) {
         var closeBGs = data.filter(function(d) {
-            if (!d.y) return false;
-            else {
+            if (!d.y) {
+                return false;
+            } else {
                 return Math.abs((new Date(d.date)).getTime() - time) <= SIX_MINS_IN_MS;
             }
         });
@@ -1060,21 +1058,21 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             .append('g')
             .attr('transform', 'translate(' + xScale(treatment.created_at.getTime()) + ', ' + yScale(scaleBg(treatment.glucose || calcBGByTime(treatment.created_at.getTime()))) + ')')
             .on('mouseover', function () {
-                tooltip.transition().duration(200).style("opacity", .9);
-                tooltip.html("<strong>Time:</strong> " + formatTime(treatment.created_at) + "<br/>" + "<strong>Treatment type:</strong> " + treatment.eventType + "<br/>" +
-                        (treatment.carbs ? "<strong>Carbs:</strong> " + treatment.carbs + "<br/>" : '') +
-                        (treatment.insulin ? "<strong>Insulin:</strong> " + treatment.insulin + "<br/>" : '') +
-                        (treatment.glucose ? "<strong>BG:</strong> " + treatment.glucose + (treatment.glucoseType ? ' (' + treatment.glucoseType + ')': '') + "<br/>" : '') +
-                        (treatment.enteredBy ? "<strong>Entered by:</strong> " + treatment.enteredBy + "<br/>" : '') +
-                        (treatment.notes ? "<strong>Notes:</strong> " + treatment.notes : '')
+                tooltip.transition().duration(200).style('opacity', .9);
+                tooltip.html('<strong>Time:</strong> ' + formatTime(treatment.created_at) + '<br/>' + '<strong>Treatment type:</strong> ' + treatment.eventType + '<br/>' +
+                        (treatment.carbs ? '<strong>Carbs:</strong> ' + treatment.carbs + '<br/>' : '') +
+                        (treatment.insulin ? '<strong>Insulin:</strong> ' + treatment.insulin + '<br/>' : '') +
+                        (treatment.glucose ? '<strong>BG:</strong> ' + treatment.glucose + (treatment.glucoseType ? ' (' + treatment.glucoseType + ')': '') + '<br/>' : '') +
+                        (treatment.enteredBy ? '<strong>Entered by:</strong> ' + treatment.enteredBy + '<br/>' : '') +
+                        (treatment.notes ? '<strong>Notes:</strong> ' + treatment.notes : '')
                 )
-                .style("left", (d3.event.pageX) + "px")
-                .style("top", (d3.event.pageY - 28) + "px");
+                .style('left', (d3.event.pageX) + 'px')
+                .style('top', (d3.event.pageY - 28) + 'px');
             })
             .on('mouseout', function () {
                 tooltip.transition()
                     .duration(500)
-                    .style("opacity", 0);
+                    .style('opacity', 0);
             });
         var arcs = treatmentDots.append('path')
             .attr('class', 'path')
@@ -1126,7 +1124,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             var y = [Math.log(actual[actual.length-1].sgv / BG_REF), Math.log(actual[actual.length-1].sgv / BG_REF)];
         } else {
             var elapsedMins = (actual[actual.length-1].date - actual[actual.length-1-lookback].date) / ONE_MINUTE;
-            // construct a "5m ago" sgv offset from current sgv by the average change over the lookback interval
+            // construct a '5m ago' sgv offset from current sgv by the average change over the lookback interval
             var lookbackSgvChange = actual[lookback].sgv-actual[0].sgv;
             var fiveMinAgoSgv = actual[lookback].sgv - lookbackSgvChange/elapsedMins*5;
             y = [Math.log(fiveMinAgoSgv / BG_REF), Math.log(actual[lookback].sgv / BG_REF)];
@@ -1141,7 +1139,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         var AR = [-0.723, 1.716];
         var dt = actual[lookback].date.getTime();
         var predictedColor = 'blue';
-        if (browserSettings.theme == "colors") {
+        if (browserSettings.theme == 'colors') {
             predictedColor = 'cyan';
         }
         for (var i = 0; i < CONE.length; i++) {
@@ -1162,19 +1160,22 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             predicted.forEach(function (d) {
                 d.type = 'forecast';
                 if (d.sgv < BG_MIN)
-                    d.color = "transparent";
+                    d.color = 'transparent';
             })
         }
         return predicted;
     }
 
     function init() {
-        tooltip = d3.select("body").append("div")
-            .attr("class", "tooltip")
-            .style("opacity", 0);
+
+        jqWindow = $(window);
+
+        tooltip = d3.select('body').append('div')
+            .attr('class', 'tooltip')
+            .style('opacity', 0);
 
         // Tick Values
-        if (browserSettings.units == "mmol") {
+        if (browserSettings.units == 'mmol') {
             tickValues = [
                   2.0
                 , Math.round(scaleBg(app.thresholds.bg_low))
@@ -1235,14 +1236,14 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             }, 100);
         };
 
-        var silenceDropdown = new Dropdown(".dropdown-menu");
+        var silenceDropdown = new Dropdown('.dropdown-menu');
 
         $('#bgButton').click(function (e) {
             silenceDropdown.open(e);
         });
 
-        $("#silenceBtn").find("a").click(function (e) {
-            stopAlarm(true, $(this).data("snooze-time"));
+        $('#silenceBtn').find('a').click(function (e) {
+            stopAlarm(true, $(this).data('snooze-time'));
             e.preventDefault();
         });
 
@@ -1281,8 +1282,8 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 // TODO: This is a kludge to advance the time as data becomes stale by making old predictor clear (using color = 'none')
                 // This shouldn't have to be sent and can be fixed by using xScale.domain([x0,x1]) function with
                 // 2 days before now as x0 and 30 minutes from now for x1 for context plot, but this will be
-                // required to happen when "now" event is sent from websocket.js every minute.  When fixed,
-                // remove all "color != 'none'" code
+                // required to happen when 'now' event is sent from websocket.js every minute.  When fixed,
+                // remove all 'color != 'none'' code
                 data = data.concat(d[1].map(function (obj) { return { date: new Date(obj.x), y: obj.y, sgv: scaleBg(obj.y), color: 'none', type: 'server-forecast'} }));
 
                 //Add MBG's also, pretend they are SGV's
@@ -1290,7 +1291,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
 
                 data.forEach(function (d) {
                     if (d.y < 39)
-                        d.color = "transparent";
+                        d.color = 'transparent';
                 });
 
                 treatments = d[3];
@@ -1328,27 +1329,27 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         }
 
         socket.on('alarm', function () {
-            console.info("alarm received from server");
+            console.info('alarm received from server');
             var enabled = (isAlarmForHigh() && browserSettings.alarmHigh) || (isAlarmForLow() && browserSettings.alarmLow);
             if (enabled) {
-                console.log("Alarm raised!");
+                console.log('Alarm raised!');
                 currentAlarmType = 'alarm';
                 generateAlarm(alarmSound);
             } else {
-                console.info("alarm was disabled locally", latestSGV.y, browserSettings);
+                console.info('alarm was disabled locally', latestSGV.y, browserSettings);
             }
             brushInProgress = false;
             updateChart(false);
         });
         socket.on('urgent_alarm', function () {
-            console.info("urgent alarm received from server");
+            console.info('urgent alarm received from server');
             var enabled = (isAlarmForHigh() && browserSettings.alarmUrgentHigh) || (isAlarmForLow() && browserSettings.alarmUrgentLow);
             if (enabled) {
-                console.log("Urgent alarm raised!");
+                console.log('Urgent alarm raised!');
                 currentAlarmType = 'urgent_alarm';
                 generateAlarm(urgentAlarmSound);
             } else {
-                console.info("urgent alarm was disabled locally", latestSGV.y, browserSettings);
+                console.info('urgent alarm was disabled locally', latestSGV.y, browserSettings);
             }
             brushInProgress = false;
             updateChart(false);
@@ -1373,7 +1374,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         });
     }
 
-    $.ajax("/api/v1/status.json", {
+    $.ajax('/api/v1/status.json', {
         success: function (xhr) {
             app = { name: xhr.name
                 , version: xhr.version
@@ -1385,13 +1386,13 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             };
         }
     }).done(function() {
-        $(".appName").text(app.name);
-        $(".version").text(app.version);
-        $(".head").text(app.head);
+        $('.appName').text(app.name);
+        $('.version').text(app.version);
+        $('.head').text(app.head);
         if (app.apiEnabled) {
-            $(".serverSettings").show();
+            $('.serverSettings').show();
         }
-        $("#treatmentDrawerToggle").toggle(app.careportalEnabled);
+        $('#treatmentDrawerToggle').toggle(app.careportalEnabled);
         browserSettings = getBrowserSettings(browserStorage);
         init();
     });

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -35,7 +35,8 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         , alarmSound = 'alarm.mp3'
         , urgentAlarmSound = 'alarm2.mp3';
 
-    var tickValues
+    var div
+        , tickValues
         , charts
         , futureOpacity
         , focus
@@ -1100,7 +1101,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
     }
 
     function init() {
-        var div = d3.select("body").append("div")
+        div = d3.select("body").append("div")
             .attr("class", "tooltip")
             .style("opacity", 0);
 

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -435,7 +435,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             .attr('stroke-width', function (d) {if (d.type == 'mbg') return 2; else return 0; })
             .attr('stroke', function (d) {
                 var device = d.device && d.device.toLowerCase();
-                return (device == 'shugatrak' ? '#a4c2db' : 'white');
+                return (device == 'dexcom' ? 'white' : '#0099ff');
             })
             .attr('r', focusDotRadius)
             .on('mouseover', function (d) {
@@ -528,31 +528,21 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             // if already existing then transition each circle to its new position
             treatCircles.transition()
                   .duration(UPDATE_TRANS_MS)
-                  .attr('x', function (d) { return xScale(new Date(d.created_at)); })
-                  .attr('y', function (d) { return yScale(scaleBg(500)); })
-                  .attr("width", 15)
-                  .attr("height", 15)
-                  .attr("rx", 6)
-                  .attr("ry", 6)
-                  .attr('stroke-width', 2)
-                  .attr('stroke', function (d) { return "white"; })
-                  .attr('fill', function (d) { return "grey"; });
-
+                  .attr('cx', function (d) { return xScale(new Date(d.created_at)); })
+                  .attr('cy', function (d) { return yScale(scaleBg(d.glucose || calcBGByTime(d.created_at.getTime()))); });
 
             // if new circle then just display
-            treatCircles.enter().append('rect')
-                  .attr('x', function (d) { return xScale(d.created_at); })
-                  .attr('y', function (d) { return yScale(scaleBg(500)); })
-                  .attr("width", 15)
-                  .attr("height", 15)
-                  .attr("rx", 6)
-                  .attr("ry", 6)
+            treatCircles.enter().append('circle')
+                  .attr('cx', function (d) { return xScale(d.created_at); })
+                  .attr('cy', function (d) { return yScale(scaleBg(d.glucose || calcBGByTime(d.created_at.getTime()))); })
+                  .attr("r", 6)
                   .attr('stroke-width', 2)
-                  .attr('stroke', function (d) { return "white"; })
-                  .attr('fill', function (d) { return "grey"; })
+                  .attr('stroke', function (d) { return d.glucose ? 'grey' : 'white'; })
+                  .attr('fill', function (d) { return d.glucose ? 'red' : 'grey'; })
                   .on('mouseover', function (d) {
                       tooltip.transition().duration(200).style("opacity", .9);
-                      tooltip.html("<strong>Time:</strong> " + formatTime(d.created_at) + "<br/>" + "<strong>Treatment type:</strong> " + d.eventType + "<br/>" +
+                      tooltip.html("<strong>Time:</strong> " + formatTime(d.created_at) + "<br/>" +
+                          (d.eventType ? "<strong>Treatment type:</strong> " + d.eventType + "<br/>" : '') +
                           (d.glucose ? "<strong>BG:</strong> " + d.glucose + (d.glucoseType ? ' (' + d.glucoseType + ')': '') + "<br/>" : '') +
                           (d.enteredBy ? "<strong>Entered by:</strong> " + d.enteredBy + "<br/>" : '') +
                           (d.notes ? "<strong>Notes:</strong> " + d.notes : '')
@@ -1027,7 +1017,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             totalBG += d.y;
         });
 
-        return totalBG ? (totalBG / closeBGs.length) : 400;
+        return totalBG ? (totalBG / closeBGs.length) : 450;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -15,7 +15,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         , FORMAT_TIME_12 = '%I:%M'
         , FORMAT_TIME_24 = '%H:%M%'
         , FORMAT_TIME_SCALE = '%I %p'
-        , WIDTH_TIME_HIDDEN = 600
+        , WIDTH_TIME_HIDDEN = 500
         , MINUTES_SINCE_LAST_UPDATE_WARN = 10
         , MINUTES_SINCE_LAST_UPDATE_URGENT = 20;
 

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -1105,6 +1105,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
             label.append('text')
                 .style('font-size', 30 / scale)
                 .style('font-family', 'Arial')
+                .style('text-shadow', '0px 0px 10px rgba(0, 0, 0, 1)')
                 .attr('text-anchor', 'middle')
                 .attr('dy', '.35em')
                 .attr('transform', function (d) {

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -1255,7 +1255,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         //with predicted alarms, latestSGV may still be in target so to see if the alarm
         //  is for a LOW we can only check if it's <= the top of the target
         function isAlarmForLow() {
-            return latestSGV.y <= app.thresholds.bg_target_top;
+            return !!errorCode || latestSGV.y <= app.thresholds.bg_target_top;
         }
 
         socket.on('alarm', function () {

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -1,92 +1,56 @@
 (function () {
     "use strict";
 
-    var latestSGV,
-        prevSGV,
-        errorCode,
-        treatments,
-        padding = { top: 20, right: 10, bottom: 30, left: 10 },
-        opacity = {current: 1, DAY: 1, NIGHT: 0.5},
-        now = Date.now(),
-        data = [],
-        dateFn = function (d) { return new Date(d.date) },
-        xScale, xScale2, yScale, yScale2,
-        xAxis, yAxis, xAxis2, yAxis2,
-        prevChartWidth = 0,
-        prevChartHeight = 0,
-        focusHeight,
-        contextHeight,
-        UPDATE_TRANS_MS = 750, // milliseconds
-        brush,
-        BRUSH_TIMEOUT = 300000,  // 5 minutes in ms
-        brushTimer,
-        brushInProgress = false,
-        clip,
-        ONE_MIN_IN_MS = 60000,
-        FIVE_MINS_IN_MS = 300000,
-        TWENTY_FIVE_MINS_IN_MS = 1500000,
-        THIRTY_MINS_IN_MS = 1800000,
-        FORTY_MINS_IN_MS = 2400000,
-        FORTY_TWO_MINS_IN_MS = 2520000,
-        SIXTY_MINS_IN_MS = 3600000,
-        FOCUS_DATA_RANGE_MS = 12600000, // 3.5 hours of actual data
-        FORMAT_TIME_12 = '%I:%M',
-        FORMAT_TIME_24 = '%H:%M%',
-        FORMAT_TIME_SCALE = '%I %p',
-        audio = document.getElementById('audio'),
-        alarmInProgress = false,
-        currentAlarmType = null,
-        alarmSound = 'alarm.mp3',
-        urgentAlarmSound = 'alarm2.mp3',
-        WIDTH_TIME_HIDDEN = 600,
-        MINUTES_SINCE_LAST_UPDATE_WARN = 10,
-        MINUTES_SINCE_LAST_UPDATE_URGENT = 20;
+    var BRUSH_TIMEOUT = 300000 // 5 minutes in ms
+        , UPDATE_TRANS_MS = 750 // milliseconds
+        , ONE_MIN_IN_MS = 60000
+        , FIVE_MINS_IN_MS = 300000
+        , TWENTY_FIVE_MINS_IN_MS = 1500000
+        , THIRTY_MINS_IN_MS = 1800000
+        , SIXTY_MINS_IN_MS = 3600000
+        , FOCUS_DATA_RANGE_MS = 12600000 // 3.5 hours of actual data
+        , FORMAT_TIME_12 = '%I:%M'
+        , FORMAT_TIME_24 = '%H:%M%'
+        , FORMAT_TIME_SCALE = '%I %p'
+        , WIDTH_TIME_HIDDEN = 600
+        , MINUTES_SINCE_LAST_UPDATE_WARN = 10
+        , MINUTES_SINCE_LAST_UPDATE_URGENT = 20;
 
-    // Tick Values
-    var tickValues = [40, 60, 80, 120, 180, 300, 400];
-    if (browserSettings.units == "mmol") {
-        tickValues = [2.0, 3.0, 4.0, 6.0, 10.0, 15.0, 22.0];
-    }
+    var socket
+        , isInitialData = false
+        , latestSGV
+        , prevSGV
+        , errorCode
+        , treatments
+        , padding = { top: 20, right: 10, bottom: 30, left: 10 }
+        , opacity = {current: 1, DAY: 1, NIGHT: 0.5}
+        , now = Date.now()
+        , data = []
+        , audio = document.getElementById('audio')
+        , alarmInProgress = false
+        , currentAlarmType = null
+        , alarmSound = 'alarm.mp3'
+        , urgentAlarmSound = 'alarm2.mp3';
 
-    var div = d3.select("body").append("div")
-      .attr("class", "tooltip")
-      .style("opacity", 0);
-    //TODO: get these from the config
-    var targetTop = 180,
-        targetBottom = 80;
+    var targetTop
+        , targetBottom
+        , tickValues
+        , charts
+        , futureOpacity
+        , focus
+        , context
+        , xScale, xScale2, yScale, yScale2
+        , xAxis, yAxis, xAxis2, yAxis2
+        , prevChartWidth = 0
+        , prevChartHeight = 0
+        , focusHeight
+        , contextHeight
+        , dateFn = function (d) { return new Date(d.date) }
+        , brush
+        , brushTimer
+        , brushInProgress = false
+        , clip;
 
-    var futureOpacity = d3.scale.linear( )
-        .domain([TWENTY_FIVE_MINS_IN_MS, SIXTY_MINS_IN_MS])
-        .range([0.8, 0.1]);
-
-    // create svg and g to contain the chart contents
-    var charts = d3.select('#chartContainer').append('svg')
-        .append('g')
-        .attr('class', 'chartContainer')
-        .attr('transform', 'translate(' + padding.left + ',' + padding.top + ')');
-
-    var focus = charts.append('g');
-
-    // create the x axis container
-    focus.append('g')
-        .attr('class', 'x axis');
-
-    // create the y axis container
-    focus.append('g')
-        .attr('class', 'y axis');
-
-    var context = charts.append('g');
-
-    // create the x axis container
-    context.append('g')
-        .attr('class', 'x axis');
-
-    // create the y axis container
-    context.append('g')
-        .attr('class', 'y axis');
-
-
-    // Remove leading zeros from the time (eg. 08:40 = 8:40) & lowercase the am/pm
     function formatTime(time) {
         var timeFormat = getTimeFormat();
         time = d3.time.format(timeFormat)(time);
@@ -643,9 +607,9 @@
                 focus.append('line')
                     .attr('class', 'high-line')
                     .attr('x1', xScale(dataRange[0]))
-                    .attr('y1', yScale(scaleBg(180)))
+                    .attr('y1', yScale(scaleBg(targetTop)))
                     .attr('x2', xScale(dataRange[1]))
-                    .attr('y2', yScale(scaleBg(180)))
+                    .attr('y2', yScale(scaleBg(targetTop)))
                     .style('stroke-dasharray', ('3, 3'))
                     .attr('stroke', 'grey');
 
@@ -653,9 +617,9 @@
                 focus.append('line')
                     .attr('class', 'low-line')
                     .attr('x1', xScale(dataRange[0]))
-                    .attr('y1', yScale(scaleBg(80)))
+                    .attr('y1', yScale(scaleBg(targetBottom)))
                     .attr('x2', xScale(dataRange[1]))
-                    .attr('y2', yScale(scaleBg(80)))
+                    .attr('y2', yScale(scaleBg(targetBottom)))
                     .style('stroke-dasharray', ('3, 3'))
                     .attr('stroke', 'grey');
 
@@ -689,9 +653,9 @@
                 context.append('line')
                     .attr('class', 'high-line')
                     .attr('x1', xScale(dataRange[0]))
-                    .attr('y1', yScale2(scaleBg(180)))
+                    .attr('y1', yScale2(scaleBg(targetTop)))
                     .attr('x2', xScale(dataRange[1]))
-                    .attr('y2', yScale2(scaleBg(180)))
+                    .attr('y2', yScale2(scaleBg(targetTop)))
                     .style('stroke-dasharray', ('3, 3'))
                     .attr('stroke', 'grey');
 
@@ -699,9 +663,9 @@
                 context.append('line')
                     .attr('class', 'low-line')
                     .attr('x1', xScale(dataRange[0]))
-                    .attr('y1', yScale2(scaleBg(80)))
+                    .attr('y1', yScale2(scaleBg(targetBottom)))
                     .attr('x2', xScale(dataRange[1]))
-                    .attr('y2', yScale2(scaleBg(80)))
+                    .attr('y2', yScale2(scaleBg(targetBottom)))
                     .style('stroke-dasharray', ('3, 3'))
                     .attr('stroke', 'grey');
 
@@ -746,18 +710,18 @@
                     .transition()
                     .duration(UPDATE_TRANS_MS)
                     .attr('x1', xScale(currentBrushExtent[0]))
-                    .attr('y1', yScale(scaleBg(180)))
+                    .attr('y1', yScale(scaleBg(targetTop)))
                     .attr('x2', xScale(currentBrushExtent[1]))
-                    .attr('y2', yScale(scaleBg(180)));
+                    .attr('y2', yScale(scaleBg(targetTop)));
 
                 // transition low line to correct location
                 focus.select('.low-line')
                     .transition()
                     .duration(UPDATE_TRANS_MS)
                     .attr('x1', xScale(currentBrushExtent[0]))
-                    .attr('y1', yScale(scaleBg(80)))
+                    .attr('y1', yScale(scaleBg(targetBottom)))
                     .attr('x2', xScale(currentBrushExtent[1]))
-                    .attr('y2', yScale(scaleBg(80)));
+                    .attr('y2', yScale(scaleBg(targetBottom)));
 
                 // transition open-top line to correct location
                 focus.select('.open-top')
@@ -860,128 +824,6 @@
             .call(xAxis2);
     }
 
-    // look for resize but use timer to only call the update script when a resize stops
-    var resizeTimer;
-    window.onresize = function () {
-        clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(function () {
-            updateChart(false);
-        }, 100);
-    };
-
-    var silenceDropdown = new Dropdown(".dropdown-menu");
-
-    $('#bgButton').click(function (e) {
-        silenceDropdown.open(e);
-    });
-
-    $("#silenceBtn").find("a").click(function (e) {
-        stopAlarm(true, $(this).data("snooze-time"));
-        e.preventDefault();
-    });
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Client-side code to connect to server and handle incoming data
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    var isInitialData = false;
-    var socket = io.connect();
-
-    socket.on('now', function (d) {
-        now = d;
-        var dateTime = new Date(now);
-        $('#currentTime').text(formatTime(dateTime));
-
-        // Dim the screen by reducing the opacity when at nighttime
-        if (browserSettings.nightMode) {
-            if (opacity.current != opacity.NIGHT && (dateTime.getHours() > 21 || dateTime.getHours() < 7)) {
-                $('body').css({ 'opacity': opacity.NIGHT });
-            } else {
-                $('body').css({ 'opacity': opacity.DAY });
-            }
-        }
-    });
-
-    socket.on('sgv', function (d) {
-        if (d.length > 1) {
-            errorCode = d.length >= 5 ? d[4] : undefined;
-
-            // change the next line so that it uses the prediction if the signal gets lost (max 1/2 hr)
-            if (d[0].length) {
-                latestSGV = d[0][d[0].length - 1];
-                prevSGV = d[0][d[0].length - 2];
-
-                //TODO: alarmHigh/alarmLow probably shouldn't be here
-                if (browserSettings.alarmHigh) {
-                    $('.container .current').toggleClass('high', latestSGV.y > 180);
-                }
-                if (browserSettings.alarmLow) {
-                    $('.container .current').toggleClass('low', latestSGV.y < 70);
-                }
-            }
-            data = d[0].map(function (obj) {
-                return { date: new Date(obj.x), y: obj.y, sgv: scaleBg(obj.y), direction: obj.direction, color: sgvToColor(obj.y), type: 'sgv'}
-            });
-            // TODO: This is a kludge to advance the time as data becomes stale by making old predictor clear (using color = 'none')
-            // This shouldn't have to be sent and can be fixed by using xScale.domain([x0,x1]) function with
-            // 2 days before now as x0 and 30 minutes from now for x1 for context plot, but this will be
-            // required to happen when "now" event is sent from websocket.js every minute.  When fixed,
-            // remove all "color != 'none'" code
-            data = data.concat(d[1].map(function (obj) { return { date: new Date(obj.x), y: obj.y, sgv: scaleBg(obj.y), color: 'none', type: 'server-forecast'} }));
-
-            //Add MBG's also, pretend they are SGV's
-            data = data.concat(d[2].map(function (obj) { return { date: new Date(obj.x), y: obj.y, sgv: scaleBg(obj.y), color: 'red', type: 'mbg'} }));
-            
-            data.forEach(function (d) {
-                if (d.y < 39)
-                    d.color = "transparent";
-            });
-
-            treatments = d[3];
-            treatments.forEach(function (d) {
-                d.created_at = new Date(d.created_at);
-            });
-
-            if (!isInitialData) {
-                isInitialData = true;
-                initializeCharts();
-            }
-            else {
-                updateChart(false);
-            }
-        }
-    });
-
-    // bgDelta and retroDelta to follow sgv color
-    // instead of Scott Leibrand's wip/iob-cob settings below
-
-    // delta >= 10 = yellow
-    // delta <= -10 = red
-    // delta < 10 and > -10 = SGV color
-
-    // function deltaToColor(delta) {
-    //    var color = 'grey';
-
-    //    if (browserSettings.theme == "colors") {
-    //        //if (Math.abs(delta) > 10) {
-    //        //    color = 'red';
-    //        if (Math.abs(delta) > 10) {
-    //            color = 'yellow';
-    //        //} else if (Math.abs(delta) > 5) {
-    //        //    color = 'yellow';
-    //        } else if (Math.abs(delta) < -10) {
-    //            color = 'red';
-    //        } else {
-    //            //color = '#4cff00';
-    //            //color = 'grey';
-    //            color = sgvToColor(sgv);
-    //        }
-    //    }
-    //
-    //    return color;
-    // }
-
     function sgvToColor(sgv) {
         var color = 'grey';
 
@@ -997,50 +839,6 @@
 
         return color;
     }
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Alarms and Text handling
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    socket.on('connect', function () {
-        console.log('Client connected to server.')
-    });
-    socket.on('alarm', function () {
-        if (browserSettings.alarmHigh) {
-            console.log("Alarm raised!");
-            currentAlarmType = 'alarm';
-            generateAlarm(alarmSound);
-        }
-        brushInProgress = false;
-        updateChart(false);
-    });
-    socket.on('urgent_alarm', function () {
-        if (browserSettings.alarmLow) {
-            console.log("Urgent alarm raised!");
-            currentAlarmType = 'urgent_alarm';
-            generateAlarm(urgentAlarmSound);
-        }
-        brushInProgress = false;
-        updateChart(false);
-    });
-    socket.on('clear_alarm', function () {
-        if (alarmInProgress) {
-            console.log('clearing alarm');
-            stopAlarm();
-        }
-    });
-
-
-    $('#testAlarms').click(function(event) {
-        d3.selectAll('.audio.alarms audio').each(function () {
-            var audio = this;
-            playAlarm(audio);
-            setTimeout(function() {
-                audio.pause();
-            }, 4000);
-        });
-        event.preventDefault();
-    });
 
     function generateAlarm(file) {
         alarmInProgress = true;
@@ -1132,8 +930,6 @@
             return parts.label;
 
     }
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //draw a compact visualization of a treatment (carbs, insulin)
@@ -1261,4 +1057,197 @@
         }
         return predicted;
     }
+
+    function init() {
+        var div = d3.select("body").append("div")
+            .attr("class", "tooltip")
+            .style("opacity", 0);
+
+        targetTop = app.thresholds.bg_target_top;
+        targetBottom = app.thresholds.bg_target_bottom;
+
+        // Tick Values
+        tickValues = [40, 60, targetBottom, 120, targetTop, 300, 400];
+        if (browserSettings.units == "mmol") {
+            tickValues = [2.0, 3.0, Math.round(scaleBg(targetBottom)), 6.0, Math.round(scaleBg(targetTop)), 15.0, 22.0];
+        }
+
+        futureOpacity = d3.scale.linear( )
+            .domain([TWENTY_FIVE_MINS_IN_MS, SIXTY_MINS_IN_MS])
+            .range([0.8, 0.1]);
+
+        // create svg and g to contain the chart contents
+        charts = d3.select('#chartContainer').append('svg')
+            .append('g')
+            .attr('class', 'chartContainer')
+            .attr('transform', 'translate(' + padding.left + ',' + padding.top + ')');
+
+        focus = charts.append('g');
+
+        // create the x axis container
+        focus.append('g')
+            .attr('class', 'x axis');
+
+        // create the y axis container
+        focus.append('g')
+            .attr('class', 'y axis');
+
+        context = charts.append('g');
+
+        // create the x axis container
+        context.append('g')
+            .attr('class', 'x axis');
+
+        // create the y axis container
+        context.append('g')
+            .attr('class', 'y axis');
+
+        // look for resize but use timer to only call the update script when a resize stops
+        var resizeTimer;
+        window.onresize = function () {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(function () {
+                updateChart(false);
+            }, 100);
+        };
+
+        var silenceDropdown = new Dropdown(".dropdown-menu");
+
+        $('#bgButton').click(function (e) {
+            silenceDropdown.open(e);
+        });
+
+        $("#silenceBtn").find("a").click(function (e) {
+            stopAlarm(true, $(this).data("snooze-time"));
+            e.preventDefault();
+        });
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Client-side code to connect to server and handle incoming data
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        socket = io.connect();
+
+        socket.on('now', function (d) {
+            now = d;
+            var dateTime = new Date(now);
+            $('#currentTime').text(formatTime(dateTime));
+
+            // Dim the screen by reducing the opacity when at nighttime
+            if (browserSettings.nightMode) {
+                if (opacity.current != opacity.NIGHT && (dateTime.getHours() > 21 || dateTime.getHours() < 7)) {
+                    $('body').css({ 'opacity': opacity.NIGHT });
+                } else {
+                    $('body').css({ 'opacity': opacity.DAY });
+                }
+            }
+        });
+
+        socket.on('sgv', function (d) {
+            if (d.length > 1) {
+                errorCode = d.length >= 5 ? d[4] : undefined;
+
+                // change the next line so that it uses the prediction if the signal gets lost (max 1/2 hr)
+                if (d[0].length) {
+                    latestSGV = d[0][d[0].length - 1];
+                    prevSGV = d[0][d[0].length - 2];
+                }
+                data = d[0].map(function (obj) {
+                    return { date: new Date(obj.x), y: obj.y, sgv: scaleBg(obj.y), direction: obj.direction, color: sgvToColor(obj.y), type: 'sgv'}
+                });
+                // TODO: This is a kludge to advance the time as data becomes stale by making old predictor clear (using color = 'none')
+                // This shouldn't have to be sent and can be fixed by using xScale.domain([x0,x1]) function with
+                // 2 days before now as x0 and 30 minutes from now for x1 for context plot, but this will be
+                // required to happen when "now" event is sent from websocket.js every minute.  When fixed,
+                // remove all "color != 'none'" code
+                data = data.concat(d[1].map(function (obj) { return { date: new Date(obj.x), y: obj.y, sgv: scaleBg(obj.y), color: 'none', type: 'server-forecast'} }));
+
+                //Add MBG's also, pretend they are SGV's
+                data = data.concat(d[2].map(function (obj) { return { date: new Date(obj.x), y: obj.y, sgv: scaleBg(obj.y), color: 'red', type: 'mbg'} }));
+
+                data.forEach(function (d) {
+                    if (d.y < 39)
+                        d.color = "transparent";
+                });
+
+                treatments = d[3];
+                treatments.forEach(function (d) {
+                    d.created_at = new Date(d.created_at);
+                });
+
+                if (!isInitialData) {
+                    isInitialData = true;
+                    initializeCharts();
+                }
+                else {
+                    updateChart(false);
+                }
+            }
+        });
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Alarms and Text handling
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        socket.on('connect', function () {
+            console.log('Client connected to server.')
+        });
+        socket.on('alarm', function () {
+            if (browserSettings.alarmHigh) {
+                console.log("Alarm raised!");
+                currentAlarmType = 'alarm';
+                generateAlarm(alarmSound);
+            }
+            brushInProgress = false;
+            updateChart(false);
+        });
+        socket.on('urgent_alarm', function () {
+            if (browserSettings.alarmLow) {
+                console.log("Urgent alarm raised!");
+                currentAlarmType = 'urgent_alarm';
+                generateAlarm(urgentAlarmSound);
+            }
+            brushInProgress = false;
+            updateChart(false);
+        });
+        socket.on('clear_alarm', function () {
+            if (alarmInProgress) {
+                console.log('clearing alarm');
+                stopAlarm();
+            }
+        });
+
+
+        $('#testAlarms').click(function(event) {
+            d3.selectAll('.audio.alarms audio').each(function () {
+                var audio = this;
+                playAlarm(audio);
+                setTimeout(function() {
+                    audio.pause();
+                }, 4000);
+            });
+            event.preventDefault();
+        });
+    }
+
+    var app = {};
+    $.ajax("/api/v1/status.json", {
+        success: function (xhr) {
+            app = { name: xhr.name
+                , version: xhr.version
+                , head: xhr.head
+                , apiEnabled: xhr.apiEnabled
+                , thresholds: xhr.thresholds
+                , careportalEnabled: xhr.careportalEnabled
+            };
+        }
+    }).done(function() {
+        $(".appName").text(app.name);
+        $(".version").text(app.version);
+        $(".head").text(app.head);
+        if (app.apiEnabled) {
+            $(".serverSettings").show();
+        }
+        $("#treatmentDrawerToggle").toggle(app.careportalEnabled);
+        init();
+    });
+
 })();

--- a/static/js/ui-utils.js
+++ b/static/js/ui-utils.js
@@ -10,28 +10,6 @@ var defaultSettings = {
 	"timeFormat": "12"
 };
 
-var app = {};
-$.ajax("/api/v1/status.json", {
-	success: function (xhr) {
-		app = {
-			"name": xhr.name,
-			"version": xhr.version,
-			"head": xhr.head,
-			"apiEnabled": xhr.apiEnabled,
-			"careportalEnabled": xhr.careportalEnabled
-		}
-	}
-}).done(function() {
-	$(".appName").text(app.name);
-	$(".version").text(app.version);
-	$(".head").text(app.head);
-	if (app.apiEnabled) {
-		$(".serverSettings").show();
-	}
-	$("#treatmentDrawerToggle").toggle(app.careportalEnabled);
-});
-
-
 function getBrowserSettings(storage) {
 	var json = {};
 	try {


### PR DESCRIPTION
Many users don't understand the current Loss/PredictAR based alarms, they also want to be able to set their own target range instead of the default 80-180.

This PR aims to make the target range and alarm types configurable, this should address most of #271.  To do this 5 new ENV variables have been added.

   * `BG_HIGH` - default: **260**, the high BG outside the target range that is considered urgent
   * `BG_TARGET_TOP` - default: **180**, the top of the target range, also used to draw the line on the chart
   * `BG_TARGET_BOTTOM` - default: **80**, the bottom of the target range, also used to draw the line on the chart
   * `BG_LOW` - default: **55**, the low BG outside the target range that is considered urgent
   * `ALARM_TYPES` - default to **simple** if any `BG_`* ENV's are set, otherwise default to **predict**.  There currently 2 alarm types are supported, and can be used independently are separately.  The `simple` alarm type only compares the current BG to `BG_` thresholds above, the `predict` alarm type works as before by using a highly tuned formula that forecasts where the BG is going based on it's trend. 
