### PR TITLE
make sure all alarms are cleared

### DIFF
--- a/static/js/client.js
+++ b/static/js/client.js
@@ -945,7 +945,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
         bgButton.hide();
         var noButton = $('#noButton');
         noButton.show();
-        d3.select('audio.playing').each(function (d, i) {
+        d3.selectAll('audio.playing').each(function (d, i) {
             var audio = this;
             audio.pause();
             $(this).removeClass('playing');


### PR DESCRIPTION
Fixes bug where only the first alarm was clear but both urgent and warning were playing

Currently if an urgent alarm goes un-ack'd, and then the condition improves some causing the warning alarm to trigger both sounds will play.  When the user ack's the alarms only 1 of the alarms will stop. They would then have to restart the browser to stop the other alarm.