### PR TITLE
Option(s) to Enable Raw Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Use the [autoconfigure tool][autoconfigure] to sync an uploader to your config.
 
 #### Features/Labs
 
-  * `ENABLE` - Used to enable optional features, currently supports: `careportal`
+  * `ENABLE` - Used to enable optional features, currently supports: `careportal`, `rawbg` (also `rawbg-on` to auto show raw)
   * `API_SECRET` - A secret passphrase that must be at least 12 characters long, required to enable `POST` and `PUT`; also required for the Care Portal
   * `BG_HIGH` (`260`) - must be set using mg/dl units; the high BG outside the target range that is considered urgent
   * `BG_TARGET_TOP` (`180`) - must be set using mg/dl units; the top of the target range, also used to draw the line on the chart

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -24,6 +24,7 @@ function create (env, entries, settings, treatments, devicestatus) {
   }
 
   if (env.enable) {
+    app.enabledOptions = env.enable;
     env.enable.toLowerCase().split(' ').forEach(function (value) {
       var enable = value.trim();
       console.info("enabling feature:", enable);

--- a/lib/api/status.js
+++ b/lib/api/status.js
@@ -13,6 +13,7 @@ function configure (app, wares) {
       var info = { status: 'ok'
           , apiEnabled: app.enabled('api')
           , careportalEnabled: app.enabled('api') && app.enabled('careportal')
+          , enabledOptions: app.enabledOptions
           , units: app.get('units')
           , head: wares.get_head( )
           , version: app.get('version')

--- a/lib/pebble.js
+++ b/lib/pebble.js
@@ -45,13 +45,16 @@ function pebble (req, res) {
     var calData = [ ];
 
     results.forEach(function(element, index, array) {
-        var next = null;
-        if (index + 1 < results.length) {
-          next = results[index + 1];
-        }
         if (element) {
             var obj = {};
             if (element.sgv) {
+                var next = null;
+                var sgvs = results.filter(function(d) {
+                    return !!d.sgv;
+                });
+                if (index + 1 < sgvs.length) {
+                    next = sgvs[index + 1];
+                }
                 obj.sgv = scaleBg(element.sgv).toString();
                 obj.bgdelta = (next ? (scaleBg(element.sgv) - scaleBg(next.sgv) ) : 0);
                 if (useMetricBg) {
@@ -61,10 +64,7 @@ function pebble (req, res) {
                     obj.trend = directionToTrend(element.direction);
                     obj.direction = element.direction;
                 }
-                // obj.y = element.sgv;
-                // obj.x = element.date;
                 obj.datetime = element.date;
-                obj.battery = uploaderBattery ? "" + uploaderBattery : undefined;
                 if (req.rawbg) {
                     obj.filtered = element.filtered;
                     obj.unfiltered = element.unfiltered;
@@ -78,7 +78,14 @@ function pebble (req, res) {
             }
         }
     });
-    var result = { status: [ {now:now}], bgs: sgvData.slice(0, 1), cals: calData.slice(0, 1) };
+
+    var count = parseInt(req.query.count) || 1;
+
+    var bgs = sgvData.slice(0, count);
+    //for compatibility we're keeping battery here, but it would be better somewhere else
+    bgs[0].battery = uploaderBattery ? "" + uploaderBattery : undefined;
+
+    var result = { status: [ {now:now}], bgs: bgs, cals: calData.slice(0, count) };
     res.setHeader('content-type', 'application/json');
     res.write(JSON.stringify(result));
     res.end( );

--- a/lib/pebble.js
+++ b/lib/pebble.js
@@ -68,6 +68,7 @@ function pebble (req, res) {
                 if (req.rawbg) {
                     obj.filtered = element.filtered;
                     obj.unfiltered = element.unfiltered;
+                    obj.noise = element.noise;
                     obj.rssi = element.rssi;
                 }
                 // obj.date = element.date.toString( );

--- a/lib/pebble.js
+++ b/lib/pebble.js
@@ -20,8 +20,7 @@ function directionToTrend (direction) {
 }
 
 function pebble (req, res) {
-  var FORTY_MINUTES = 2400000;
-  var cgmData = [ ];
+  var ONE_DAY = 24 * 60 * 60 * 1000;
   var uploaderBattery;
 
   function requestMetric() {
@@ -42,6 +41,9 @@ function pebble (req, res) {
 
   function get_latest (err, results) {
     var now = Date.now();
+    var sgvData = [ ];
+    var calData = [ ];
+
     results.forEach(function(element, index, array) {
         var next = null;
         if (index + 1 < results.length) {
@@ -49,25 +51,33 @@ function pebble (req, res) {
         }
         if (element) {
             var obj = {};
-            if (!element.sgv) return;
-            obj.sgv = scaleBg(element.sgv).toString( );
-            obj.bgdelta = (next ? (scaleBg(element.sgv) - scaleBg(next.sgv) ) : 0);
-            if (useMetricBg) {
-                obj.bgdelta = obj.bgdelta.toFixed(1);
+            if (element.sgv) {
+                obj.sgv = scaleBg(element.sgv).toString();
+                obj.bgdelta = (next ? (scaleBg(element.sgv) - scaleBg(next.sgv) ) : 0);
+                if (useMetricBg) {
+                    obj.bgdelta = obj.bgdelta.toFixed(1);
+                }
+                if ('direction' in element) {
+                    obj.trend = directionToTrend(element.direction);
+                    obj.direction = element.direction;
+                }
+                // obj.y = element.sgv;
+                // obj.x = element.date;
+                obj.datetime = element.date;
+                obj.battery = uploaderBattery ? "" + uploaderBattery : undefined;
+                if (req.rawbg) {
+                    obj.filtered = element.filtered;
+                    obj.unfiltered = element.unfiltered;
+                    obj.rssi = element.rssi;
+                }
+                // obj.date = element.date.toString( );
+                sgvData.push(obj);
+            } else if (req.rawbg && element.type == 'cal') {
+                calData.push(element);
             }
-            if ('direction' in element) {
-              obj.trend = directionToTrend(element.direction);
-              obj.direction = element.direction;
-            }
-            // obj.y = element.sgv;
-            // obj.x = element.date;
-            obj.datetime = element.date;
-            obj.battery = uploaderBattery ? "" + uploaderBattery : undefined;
-            // obj.date = element.date.toString( );
-            cgmData.push(obj);
         }
     });
-    var result = { status: [ {now:now}], bgs: cgmData.slice(0, 1) };
+    var result = { status: [ {now:now}], bgs: sgvData.slice(0, 1), cals: calData.slice(0, 1) };
     res.setHeader('content-type', 'application/json');
     res.write(JSON.stringify(result));
     res.end( );
@@ -80,13 +90,16 @@ function pebble (req, res) {
         console.error("req.devicestatus.tail", err);
       }
 
-      req.entries.list({count: 2, find: { "sgv": { $exists: true }}}, get_latest);
+      var earliest_data = Date.now() - ONE_DAY;
+      var q = { find: {"date": {"$gte": earliest_data}} };
+      req.entries.list(q, get_latest);
   });
 }
-function configure (entries, devicestatus) {
+function configure (entries, devicestatus, env) {
   function middle (req, res, next) {
     req.entries = entries;
     req.devicestatus = devicestatus;
+    req.rawbg = env.enable.indexOf('rawbg') > -1;
     next( );
   }
   return [middle, pebble];

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -28,6 +28,7 @@ var dir2Char = {
   var cgmData = [],
     treatmentData = [],
     mbgData = [],
+    calData = [],
     patientData = [];
 
   function start ( ) {
@@ -164,7 +165,18 @@ function update() {
                   obj.d = element.dateString;
                   obj.device = element.device;
                   obj.direction = directionToChar(element.direction);
+                  obj.filtered = element.filtered;
+                  obj.unfiltered = element.unfiltered;
+                  obj.rssi = element.rssi;
                   cgmData.push(obj);
+              } else if (element.slope) {
+                  var obj = {};
+                  obj.x = element.date;
+                  obj.d = element.dateString;
+                  obj.scale = element.scale;
+                  obj.intercept = element.intercept;
+                  obj.slope = element.slope;
+                  calData.push(obj);
               }
           }
       });
@@ -191,6 +203,7 @@ function loadData() {
         actualCurrent,
         treatment = [],
         mbg = [],
+        cal = [],
         errorCode;
 
     if (cgmData) {
@@ -204,7 +217,7 @@ function loadData() {
         // sgv less than or equal to 10 means error code
         // or warm up period code, so ignore
         actual = actual.filter(function (a) {
-            return a.y > 10;
+            return (a.y > 10 || a.unfiltered > 0);
         })
     }
 
@@ -218,6 +231,13 @@ function loadData() {
     if (mbgData) {
         mbg = mbgData.slice();
         mbg.sort(function(a, b) {
+            return a.x - b.x;
+        });
+    }
+
+    if (calData) {
+        cal = calData.slice(calData.length-200, calData.length);
+        cal.sort(function(a, b) {
             return a.x - b.x;
         });
     }
@@ -255,8 +275,8 @@ function loadData() {
         //TODO: need to consider when data being sent has less than the 2 day minimum
 
         // consolidate and send the data to the client
-        var shouldEmit = is_different(actual, predicted, mbg, treatment, errorCode);
-        patientData = [actual, predicted, mbg, treatment, errorCode];
+        var shouldEmit = is_different(actual, predicted, mbg, treatment, errorCode, cal);
+        patientData = [actual, predicted, mbg, treatment, errorCode, cal];
         console.log('patientData', patientData.length);
         if (shouldEmit) {
           emitData( );

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -213,12 +213,6 @@ function loadData() {
         });
 
         actualCurrent = actual.length > 0 ? actual[actual.length - 1].y : null;
-
-        // sgv less than or equal to 10 means error code
-        // or warm up period code, so ignore
-        actual = actual.filter(function (a) {
-            return (a.y > 10 || a.unfiltered > 0);
-        })
     }
 
     if (treatmentData) {
@@ -275,8 +269,8 @@ function loadData() {
         //TODO: need to consider when data being sent has less than the 2 day minimum
 
         // consolidate and send the data to the client
-        var shouldEmit = is_different(actual, predicted, mbg, treatment, errorCode, cal);
-        patientData = [actual, predicted, mbg, treatment, errorCode, cal];
+        var shouldEmit = is_different(actual, predicted, mbg, treatment, cal);
+        patientData = [actual, predicted, mbg, treatment, cal];
         console.log('patientData', patientData.length);
         if (shouldEmit) {
           emitData( );
@@ -331,7 +325,7 @@ function loadData() {
     }
 }
 
-  function is_different (actual, predicted, mbg, treatment, errorCode) {
+  function is_different (actual, predicted, mbg, treatment, cal) {
     if (patientData && patientData.length < 3) {
       return true;
     }
@@ -340,14 +334,14 @@ function loadData() {
       , predicted: patientData[1].slice(-1).pop( )
       , mbg: patientData[2].slice(-1).pop( )
       , treatment: patientData[3].slice(-1).pop( )
-      , errorCode: patientData.length >= 5 ? patientData[4] : 0
+      , cal: patientData[4].slice(-1).pop( )
     };
     var last = {
         actual: actual.slice(-1).pop( )
       , predicted: predicted.slice(-1).pop( )
       , mbg: mbg.slice(-1).pop( )
       , treatment: treatment.slice(-1).pop( )
-      , errorCode: errorCode
+      , cal: cal.slice(-1).pop( )
     };
 
     // textual diff of objects

--- a/server.js
+++ b/server.js
@@ -71,7 +71,7 @@ app.enable('trust proxy'); // Allows req.secure test on heroku https connections
 app.use('/api/v1', api);
 
 // pebble data
-app.get('/pebble', pebble(entriesStorage, devicestatusStorage));
+app.get('/pebble', pebble(entriesStorage, devicestatusStorage, env));
 
 //app.get('/package.json', software);
 

--- a/static/index.html
+++ b/static/index.html
@@ -85,6 +85,10 @@
                         <dt>Night Mode <a class="tip" original-title="When enabled the page will be dimmed from 10pm - 6am."><i class="icon-help-circled"></i></a></dt>
                         <dd><input type="checkbox" name="nightmode-browser" id="nightmode-browser" /><label for="nightmode-browser">Enable</label></dd>
                     </dl>
+                    <dl id="show-rawbg-option" class="toggle">
+                      <dt>Show Raw BG Data <a class="tip" original-title="When enabled small white dots will be disaplyed for raw BG data"><i class="icon-help-circled"></i></a></dt>
+                      <dd><input type="checkbox" name="show-rawbg" id="show-rawbg" /><label for="show-rawbg">Enable</label></dd>
+                    </dl>
                     <dl>
                         <dt>Custom Title</dt>
                         <dd><input type="text" id="customTitle" value="Nightscout" /></dd>

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -1333,7 +1333,8 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 cal = d[5][d[5].length-1];
 
                 var temp1 = [ ];
-                if (cal) {
+                if (cal && app.enabledOptions && app.enabledOptions.indexOf('rawbg' > -1) && browserSettings.showRawbg == true) {
+                    console.info(">>>>browserSettings.showRawbg", browserSettings.showRawbg);
                     temp1 = d[0].map(function (obj) {
                         var rawBg = rawIsigToRawBg(obj.unfiltered
                             , cal.scale || [ ]
@@ -1446,6 +1447,7 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 , version: xhr.version
                 , head: xhr.head
                 , apiEnabled: xhr.apiEnabled
+                , enabledOptions: xhr.enabledOptions
                 , thresholds: xhr.thresholds
                 , alarm_types: xhr.alarm_types
                 , units: xhr.units

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -284,7 +284,9 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
                 var prevfocusPoint = nowData[nowData.length - 2];
 
                 //in this case the SGV is scaled
-                if (focusPoint.y < 40) {
+                if (focusPoint.y < 39) {
+                    $('.container .currentBG').text('');
+                } else if (focusPoint.y == 39) {
                     $('.container .currentBG').text('LOW');
                 } else if (focusPoint.y > 400) {
                     $('.container .currentBG').text('HIGH');

--- a/static/js/ui-utils.js
+++ b/static/js/ui-utils.js
@@ -36,6 +36,7 @@ function getBrowserSettings(storage) {
 			"alarmLow": storage.get("alarmLow"),
 			"alarmUrgentLow": storage.get("alarmUrgentLow"),
 			"nightMode": storage.get("nightMode"),
+			"showRawbg": storage.get("showRawbg")
 			"customTitle": storage.get("customTitle"),
 			"theme": storage.get("theme"),
 			"timeFormat": storage.get("timeFormat")
@@ -61,6 +62,15 @@ function getBrowserSettings(storage) {
 		json.nightMode = setDefault(json.nightMode, defaultSettings.nightMode);
 		$("#nightmode-browser").prop("checked", json.nightMode);
 
+        if (app.enabledOptions.indexOf('rawbg') == -1) {
+            json.showRawbg = false;
+            $("#show-rawbg-option").hide();
+        } else {
+            $("#show-rawbg-option").show();
+            json.showRawbg = setDefault(json.showRawbg, (app.enabledOptions.indexOf('rawbg-on') > -1));
+            $("#show-rawbg").prop("checked", json.showRawbg);
+        }
+
 		if (json.customTitle) {
 			$("h1.customTitle").text(json.customTitle);
 			$("input#customTitle").prop("value", json.customTitle);
@@ -72,7 +82,7 @@ function getBrowserSettings(storage) {
         } else {
             $("#theme-default-browser").prop("checked", true);
         }
-		
+
 		json.timeFormat = setDefault(json.timeFormat, defaultSettings.timeFormat);
 		
 		if (json.timeFormat == "24") {
@@ -348,6 +358,7 @@ $("input#save").click(function(event) {
 		"alarmLow": $("#alarm-low-browser").prop("checked"),
 		"alarmUrgentLow": $("#alarm-urgentlow-browser").prop("checked"),
 		"nightMode": $("#nightmode-browser").prop("checked"),
+		"showRawbg": $("#show-rawbg").prop("checked"),
 		"customTitle": $("input#customTitle").prop("value"),
 		"theme": $("input:radio[name=theme-browser]:checked").val(),
 		"timeFormat": $("input:radio[name=timeformat-browser]:checked").val()

--- a/static/js/ui-utils.js
+++ b/static/js/ui-utils.js
@@ -36,7 +36,7 @@ function getBrowserSettings(storage) {
 			"alarmLow": storage.get("alarmLow"),
 			"alarmUrgentLow": storage.get("alarmUrgentLow"),
 			"nightMode": storage.get("nightMode"),
-			"showRawbg": storage.get("showRawbg")
+			"showRawbg": storage.get("showRawbg"),
 			"customTitle": storage.get("customTitle"),
 			"theme": storage.get("theme"),
 			"timeFormat": storage.get("timeFormat")

--- a/tests/api.status.test.js
+++ b/tests/api.status.test.js
@@ -22,7 +22,6 @@ describe('Status REST api', function ( ) {
 
   it('should be a module', function ( ) {
     api.should.be.ok;
-
   });
 
   it('/status.json', function (done) {

--- a/tests/api.status.test.js
+++ b/tests/api.status.test.js
@@ -36,6 +36,37 @@ describe('Status REST api', function ( ) {
       });
   });
 
+  it('/status.html', function (done) {
+    request(this.app)
+      .get('/api/status.html')
+      .end(function(err, res) {
+        res.type.should.equal('text/html');
+        res.statusCode.should.equal(200);
+        done()
+      });
+  });
+
+  it('/status.js', function (done) {
+    request(this.app)
+      .get('/api/status.js')
+      .end(function(err, res) {
+        res.type.should.equal('application/javascript');
+        res.statusCode.should.equal(200);
+        res.text.should.startWith('this.serverSettings =');
+        done()
+      });
+  });
+
+  it('/status.png', function (done) {
+    request(this.app)
+      .get('/api/status.png')
+      .end(function(err, res) {
+        res.headers.location.should.equal('http://img.shields.io/badge/Nightscout-OK-green.png');
+        res.statusCode.should.equal(302);
+        done()
+      });
+  });
+
 
 });
 

--- a/tests/api.status.test.js
+++ b/tests/api.status.test.js
@@ -1,0 +1,42 @@
+
+var request = require('supertest');
+var should = require('should');
+
+describe('Status REST api', function ( ) {
+  var api = require('../lib/api/');
+  before(function (done) {
+    var env = require('../env')( );
+    env.enable = "careportal rawbg";
+    env.api_secret = 'this is my long pass phrase';
+    this.wares = require('../lib/middleware/')(env);
+    var store = require('../lib/storage')(env);
+    this.app = require('express')( );
+    this.app.enable('api');
+    var self = this;
+    store(function ( ) {
+      var entriesStorage = require('../lib/entries').storage(env.mongo_collection, store);
+      self.app.use('/api', api(env, entriesStorage));
+      done();
+    });
+  });
+
+  it('should be a module', function ( ) {
+    api.should.be.ok;
+
+  });
+
+  it('/status.json', function (done) {
+    request(this.app)
+      .get('/api/status.json')
+      .expect(200)
+      .end(function (err, res)  {
+        res.body.apiEnabled.should.equal(true);
+        res.body.careportalEnabled.should.equal(true);
+        res.body.enabledOptions.should.equal('careportal rawbg');
+        done( );
+      });
+  });
+
+
+});
+

--- a/tests/pebble.test.js
+++ b/tests/pebble.test.js
@@ -1,0 +1,168 @@
+
+var request = require('supertest');
+var should = require('should');
+
+//Mock entries
+var entries = {
+  list: function(q, callback) {
+    var results = [
+      { device: 'dexcom',
+        date: 1422727301000,
+        dateString: 'Sat Jan 31 10:01:41 PST 2015',
+        sgv: 82,
+        direction: 'Flat',
+        type: 'sgv',
+        filtered: 113984,
+        unfiltered: 111920,
+        rssi: 179,
+        noise: 1
+      },
+      { device: 'dexcom',
+        date: 1422647711000,
+        dateString: 'Fri Jan 30 11:55:11 PST 2015',
+        slope: 895.8571693029189,
+        intercept: 34281.06876195567,
+        scale: 1,
+        type: 'cal'
+      },
+      { device: 'dexcom',
+        date: 1422727001000,
+        dateString: 'Sat Jan 31 09:56:41 PST 2015',
+        sgv: 84,
+        direction: 'Flat',
+        type: 'sgv',
+        filtered: 115680,
+        unfiltered: 113552,
+        rssi: 179,
+        noise: 1
+      },
+      { device: 'dexcom',
+        date: 1422726701000,
+        dateString: 'Sat Jan 31 09:51:41 PST 2015',
+        sgv: 86,
+        direction: 'Flat',
+        type: 'sgv',
+        filtered: 117808,
+        unfiltered: 114640,
+        rssi: 169,
+        noise: 1
+      },
+      { device: 'dexcom',
+        date: 1422726401000,
+        dateString: 'Sat Jan 31 09:46:41 PST 2015',
+        sgv: 88,
+        direction: 'Flat',
+        type: 'sgv',
+        filtered: 120464,
+        unfiltered: 116608,
+        rssi: 175,
+        noise: 1
+      },
+      { device: 'dexcom',
+        date: 1422726101000,
+        dateString: 'Sat Jan 31 09:41:41 PST 2015',
+        sgv: 91,
+        direction: 'Flat',
+        type: 'sgv',
+        filtered: 124048,
+        unfiltered: 118880,
+        rssi: 174,
+        noise: 1
+      }
+    ];
+    callback(null, results);
+  }
+};
+
+//Mock devicestatus
+var devicestatus = {
+  last: function(callback) {
+    callback(null, {uploaderBattery: 100});
+  }
+};
+
+describe('Pebble Endpoint without Raw', function ( ) {
+  var pebble = require('../lib/pebble');
+  before(function (done) {
+    var env = require('../env')( );
+    env.enable = "";
+    this.app = require('express')( );
+    this.app.enable('api');
+    this.app.use('/pebble', pebble(entries, devicestatus, env));
+    done();
+  });
+
+  it('should be a module', function ( ) {
+    pebble.should.be.ok;
+  });
+
+  it('/pebble', function (done) {
+    request(this.app)
+      .get('/pebble?count=2')
+      .expect(200)
+      .end(function (err, res)  {
+        var bgs = res.body.bgs;
+        bgs.length.should.equal(2);
+        var bg = bgs[0];
+        bg.sgv.should.equal('82');
+        bg.bgdelta.should.equal(-2);
+        bg.trend.should.equal(4);
+        bg.direction.should.equal('Flat');
+        bg.datetime.should.equal(1422727301000);
+        (bg.filtered == null).should.be.true;
+        (bg.unfiltered == null).should.be.true;
+        (bg.noise == null).should.be.true;
+        (bg.rssi == null).should.be.true;
+        bg.battery.should.equal('100');
+
+        res.body.cals.length.should.equal(0);
+        done( );
+      });
+  });
+});
+
+
+describe('Pebble Endpoint with Raw', function ( ) {
+  var pebbleRaw = require('../lib/pebble');
+  before(function (done) {
+    var envRaw = require('../env')( );
+    envRaw.enable = "rawbg";
+    this.appRaw = require('express')( );
+    this.appRaw.enable('api');
+    this.appRaw.use('/pebble', pebbleRaw(entries, devicestatus, envRaw));
+    done();
+  });
+
+  it('should be a module', function ( ) {
+    pebbleRaw.should.be.ok;
+  });
+
+  it('/pebble', function (done) {
+    request(this.appRaw)
+      .get('/pebble?count=2')
+      .expect(200)
+      .end(function (err, res)  {
+        var bgs = res.body.bgs;
+        bgs.length.should.equal(2);
+        var bg = bgs[0];
+        bg.sgv.should.equal('82');
+        bg.bgdelta.should.equal(-2);
+        bg.trend.should.equal(4);
+        bg.direction.should.equal('Flat');
+        bg.datetime.should.equal(1422727301000);
+        bg.filtered.should.equal(113984);
+        bg.unfiltered.should.equal(111920);
+        bg.noise.should.equal(1);
+        bg.rssi.should.equal(179);
+        bg.battery.should.equal('100');
+
+        res.body.cals.length.should.equal(1);
+        var cal = res.body.cals[0];
+        cal.slope.should.equal(895.8571693029189);
+        cal.intercept.should.equal(34281.06876195567);
+        cal.scale.should.equal(1);
+        done( );
+      });
+  });
+
+});

--- a/tests/pebble.test.js
+++ b/tests/pebble.test.js
@@ -109,10 +109,10 @@ describe('Pebble Endpoint without Raw', function ( ) {
         bg.trend.should.equal(4);
         bg.direction.should.equal('Flat');
         bg.datetime.should.equal(1422727301000);
-        (bg.filtered == null).should.be.true;
-        (bg.unfiltered == null).should.be.true;
-        (bg.noise == null).should.be.true;
-        (bg.rssi == null).should.be.true;
+        should.not.exist(bg.filtered);
+        should.not.exist(bg.unfiltered);
+        should.not.exist(bg.noise);
+        should.not.exist(bg.rssi);
         bg.battery.should.equal('100');
 
         res.body.cals.length.should.equal(0);


### PR DESCRIPTION
Goal is a have a lab that will allow more advanced users to enable raw data in the mainline version

**New `ENABLE` Option**:
`ENABLE="rawbg"` or `ENABLE="rawbg-on"` (to default to on)

**Tasks:**

  - [X] Port Basic Raw Data code from `wip/iob/cob` branch
  - [x] Refactor code that filters/sends errors codes
  - [x] Add options to enable Raw Data via the `ENABLE` env var
  - [x] Based on enable option and UI settings display show/hide Raw Data
  - [x] Based on enable option include/exclude `cal` records and filtered, unfiltered, and rssi rawbg fields in `/pebble` endpoint