### PR TITLE
Syntax error in "Enable Alarms" help prompt

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -75,7 +75,7 @@
                         <dd><input type="radio" name="timeformat-browser" id="24-browser" value="24" /><label for="24-browser">24 hours</label></dd>
                     </dl>
                     <dl class="toggle">
-                        <dt>Enable Alarms <a class="tip" original-title="When enabled the an alarm will sound."><i class="icon-help-circled"></i></a></dt>
+                        <dt>Enable Alarms <a class="tip" original-title="When enabled an alarm will sound."><i class="icon-help-circled"></i></a></dt>
                         <dd><input type="checkbox" id="alarm-urgenthigh-browser" /><label for="alarm-urgenthigh-browser">Urgent High Alarm</label></dd>
                         <dd><input type="checkbox" id="alarm-high-browser" /><label for="alarm-high-browser">High Alarm</label></dd>
                         <dd><input type="checkbox" id="alarm-low-browser" /><label for="alarm-low-browser">Low Alarm</label></dd>


### PR DESCRIPTION
I hope this is the correct *branch* to submit my pull request to this time!

Syntax error located when hovering over question mark next to "Enable Alarms" in preferences panel on web portal.

Adjusted phrase from: "When enabled the an alarm may sound" to "When enabled an alarm may sound"

Thanks for the opportunity to 'meddle' - an interesting experience.

Cheers
David