### PR TITLE
Store display units with treatment objects, for unit conversion / checking on load.

### DIFF
--- a/static/js/ui-utils.js
+++ b/static/js/ui-utils.js
@@ -253,6 +253,7 @@ function treatmentSubmit(event) {
     data.insulin = document.getElementById('insulinGiven').value;
     data.preBolus = document.getElementById('preBolus').value;
     data.notes = document.getElementById('notes').value;
+    data.units = browserSettings.units;
 
     var eventTimeDisplay = '';
     if ($('#treatment-form input[name=nowOrOther]:checked').val() != 'now') {


### PR DESCRIPTION
Tiny change that'll allow converting the stored values to different units as needed, without relying on the current browserSettings value.