### PR TITLE
create all docs before calling back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ static/bower_components/
 
 # istanbul output
 coverage/
+
+npm-debug.log

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -29,7 +29,9 @@ function configure (app, wares, entries) {
     // Middleware to format any response involving entries.
     function format_entries (req, res, next) {
       var output = es.readArray(res.entries || [ ]);
-      if (res.entries_err) return res.sendJSONStatus(res, consts.HTTP_INTERNAL_ERROR, 'Mongo Error', err);
+      if (res.entries_err) {
+        return res.sendJSONStatus(res, consts.HTTP_INTERNAL_ERROR, 'Mongo Error', res.entries_err);
+      }
       return res.format({
         text: function ( ) {
           es.pipeline(output, sgvdata.format( ), res);

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -115,7 +115,6 @@ function configure (app, wares, entries) {
         res.entries_err = err;
         return next( );
       });
-      return;
     }, format_entries);
 
     api.get('/entries/current', function(req, res, next) {
@@ -124,7 +123,6 @@ function configure (app, wares, entries) {
         res.entries_err = err;
         return next( );
       });
-      return;
     }, format_entries);
 
 
@@ -133,7 +131,6 @@ function configure (app, wares, entries) {
     api.post('/entries/preview', function (req, res, next) {
       req.persist_entries = false;
       next( );
-      return;
     }, insert_entries, format_entries);
 
     if (app.enabled('api')) {
@@ -141,7 +138,6 @@ function configure (app, wares, entries) {
       api.post('/entries/', wares.verifyAuthorization, function (req, res, next) {
         req.persist_entries = true;
         next( );
-        return;
       }, insert_entries, format_entries);
     }
 

--- a/lib/entries.js
+++ b/lib/entries.js
@@ -96,21 +96,23 @@ function storage(name, storage, pushover) {
 
   // store new documents using the storage mechanism
   function create (docs, fn) {
-      with_collection(function(err, collection) {
-        if (err) { fn(err); return; }
-        // potentially a batch insert
-        var firstErr = null,
-            totalCreated = 0;
+    with_collection(function(err, collection) {
+      if (err) { fn(err); return; }
+      // potentially a batch insert
+      var firstErr = null,
+          numDocs = docs.length,
+          totalCreated = 0;
 
-        docs.forEach(function(doc) {
-            collection.update(doc, doc, {upsert: true}, function (err, created) {
-                firstErr = firstErr || err;
-                totalCreated += created;
-            });
-            sendPushover(doc);
+      docs.forEach(function(doc) {
+        collection.update(doc, doc, {upsert: true}, function (err, created) {
+          firstErr = firstErr || err;
+          if (++totalCreated === numDocs) {
+            fn(firstErr, docs);
+          }
         });
-        fn(firstErr, totalCreated, docs);
+        sendPushover(doc);
       });
+    });
   }
 
   //currently the Android upload will send the last MBG over and over, make sure we get a single notification

--- a/lib/entries.js
+++ b/lib/entries.js
@@ -21,7 +21,7 @@ function storage(name, storage, pushover) {
     with_collection(function (err, collection) {
       // these functions, find, sort, and limit, are used to
       // dynamically configure the request, based on the options we've
-      // been give
+      // been given
 
       // determine find options
       function find ( ) {
@@ -51,13 +51,9 @@ function storage(name, storage, pushover) {
 
       // now just stitch them all together
       limit.call(collection
-        .find(find( ))
-        .sort(sort( )))
-        // .limit(limit( ))
-        .toArray(toArray)
-      ;
-      // limit.call(sort.call(find.call(collection))).toArray(toArray);
-
+          .find(find( ))
+          .sort(sort( ))
+      ).toArray(toArray);
     });
   }
 
@@ -119,56 +115,56 @@ function storage(name, storage, pushover) {
   var lastMBG = 0;
 
   function sendPushover(doc) {
-      if (doc.type && doc.mbg && doc.type == 'mbg' && doc.date && doc.date != lastMBG && pushover) {
-          var offset = new Date().getTime() - doc.date;
-          if (offset > TEN_MINS) {
-              console.info('No MBG Pushover, offset: ' + offset + ' too big, doc.date: ' + doc.date + ', now: ' + new Date().getTime());
-          } else {
-              var msg = {
-                  expire: 14400, // 4 hours
-                  message: '\nMeter BG: ' + doc.mbg,
-                  title: 'Calibration',
-                  sound: 'magic',
-                  timestamp: new Date(doc.date),
-                  priority: 0,
-                  retry: 30
-              };
+    if (doc.type && doc.mbg && doc.type == 'mbg' && doc.date && doc.date != lastMBG && pushover) {
+      var offset = new Date().getTime() - doc.date;
+      if (offset > TEN_MINS) {
+        console.info('No MBG Pushover, offset: ' + offset + ' too big, doc.date: ' + doc.date + ', now: ' + new Date().getTime());
+      } else {
+        var msg = {
+          expire: 14400, // 4 hours
+          message: '\nMeter BG: ' + doc.mbg,
+          title: 'Calibration',
+          sound: 'magic',
+          timestamp: new Date(doc.date),
+          priority: 0,
+          retry: 30
+        };
 
-              pushover.send(msg, function (err, result) {
-                  console.log(result);
-              });
-          }
-          lastMBG = doc.date;
+        pushover.send(msg, function (err, result) {
+          console.log(result);
+        });
       }
+      lastMBG = doc.date;
+    }
   }
 
   function getEntry(fn, id) {
-      console.info("trying to find entry for id: " + id);
-      with_collection(function(err, collection) {
+    console.info("trying to find entry for id: " + id);
+    with_collection(function(err, collection) {
+      if (err)
+        fn(err);
+      else
+        collection.findOne({"_id": ObjectID(id)}, function (err, entry) {
           if (err)
-              fn(err);
+            fn(err);
           else
-              collection.findOne({"_id": ObjectID(id)}, function (err, entry) {
-                  if (err)
-                      fn(err);
-                  else
-                      fn(null, entry);
-              });
-      });
+            fn(null, entry);
+        });
+    });
   }
 
   function getEntries(fn, count) {
-      with_collection(function(err, collection) {
+    with_collection(function(err, collection) {
+      if (err)
+        fn(err);
+      else
+        collection.find({ }).sort({"date": -1}).limit(count).toArray(function (err, entries) {
           if (err)
-              fn(err);
+            fn(err);
           else
-              collection.find({ }).sort({"date": -1}).limit(count).toArray(function (err, entries) {
-                  if (err)
-                      fn(err);
-                  else
-                      fn(null, entries);
-              });
-      });
+            fn(null, entries);
+        });
+    });
   }
 
   // closure to represent the API
@@ -204,4 +200,3 @@ module.exports = {
   storage: storage,
   ensureIndexes: ensureIndexes
 };
-

--- a/tests/api.entries.test.js
+++ b/tests/api.entries.test.js
@@ -1,10 +1,10 @@
-
 var request = require('supertest');
 var should = require('should');
 var load = require('./fixtures/load');
 
 describe('Entries REST api', function ( ) {
   var entries = require('../lib/api/entries/');
+
   before(function (done) {
     var env = require('../env')( );
     this.wares = require('../lib/middleware/')(env);
@@ -18,32 +18,39 @@ describe('Entries REST api', function ( ) {
       self.archive.create(load('json'), done);
     });
   });
+
   after(function (done) {
     this.archive( ).remove({ }, done);
   });
 
   it('should be a module', function ( ) {
     entries.should.be.ok;
-
   });
-  it('/entries.json', function (done) {
+
+  // keep this test pinned at or near the top in order to validate all
+  // entries successfully uploaded. if res.body.length is short of the
+  // expected value, it may indicate a regression in the create
+  // function callback logic in entries.js.
+  it('gets requested number of entries', function (done) {
+    var count = 30;
     request(this.app)
-      .get('/entries.json')
+      .get('/entries.json?count=' + count)
       .expect(200)
-      .end(function (err, res)  {
+      .end(function (err, res) {
         // console.log('body', res.body);
-        res.body.length.should.equal(10);
+        res.body.length.should.equal(count);
         done( );
       });
   });
 
-  it('/entries.json', function (done) {
+  it('gets default number of entries', function (done) {
+    var defaultCount = 10;
     request(this.app)
-      .get('/entries.json?count=30')
+      .get('/entries.json')
       .expect(200)
-      .end(function (err, res)  {
+      .end(function (err, res) {
         // console.log('body', res.body);
-        res.body.length.should.equal(30);
+        res.body.length.should.equal(defaultCount);
         done( );
       });
   });
@@ -52,29 +59,23 @@ describe('Entries REST api', function ( ) {
     request(this.app)
       .get('/entries/current.json')
       .expect(200)
-      .end(function (err, res)  {
+      .end(function (err, res) {
         res.body.length.should.equal(1);
         done( );
         // console.log('err', err, 'res', res);
       });
-
   });
 
   it('/entries/preview', function (done) {
-
-      request(this.app)
-        .post('/entries/preview.json')
-        .send(load('json'))
-        .expect(201)
-        .end(function (err, res)  {
-          // console.log(res.body);
-          res.body.length.should.equal(30);
-          done( );
-          // console.log('err', err, 'res', res);
-        })
-    ;
-
+    request(this.app)
+      .post('/entries/preview.json')
+      .send(load('json'))
+      .expect(201)
+      .end(function (err, res) {
+        // console.log(res.body);
+        res.body.length.should.equal(30);
+        done( );
+        // console.log('err', err, 'res', res);
+      });
   });
-
 });
-

--- a/tests/fixtures/example.json
+++ b/tests/fixtures/example.json
@@ -1,1 +1,212 @@
-[{"sgv":"5","dateString":"07/19/2014 10:49:15 AM","date":1405792155000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:44:15 AM","date":1405791855000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:39:15 AM","date":1405791555000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:34:15 AM","date":1405791255000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:29:15 AM","date":1405790955000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:24:15 AM","date":1405790655000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:19:15 AM","date":1405790355000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:14:15 AM","date":1405790055000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:09:15 AM","date":1405789755000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 10:04:15 AM","date":1405789455000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 09:59:15 AM","date":1405789155000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"5","dateString":"07/19/2014 09:54:15 AM","date":1405788855000,"device":"dexcom","direction":"NOT COMPUTABLE"},{"sgv":"178","dateString":"07/19/2014 03:59:15 AM","date":1405767555000,"device":"dexcom","direction":"Flat"},{"sgv":"179","dateString":"07/19/2014 03:54:15 AM","date":1405767255000,"device":"dexcom","direction":"Flat"},{"sgv":"178","dateString":"07/19/2014 03:49:15 AM","date":1405766955000,"device":"dexcom","direction":"Flat"},{"sgv":"177","dateString":"07/19/2014 03:44:15 AM","date":1405766655000,"device":"dexcom","direction":"Flat"},{"sgv":"176","dateString":"07/19/2014 03:39:15 AM","date":1405766355000,"device":"dexcom","direction":"Flat"},{"sgv":"176","dateString":"07/19/2014 03:34:15 AM","date":1405766055000,"device":"dexcom","direction":"Flat"},{"sgv":"175","dateString":"07/19/2014 03:29:16 AM","date":1405765756000,"device":"dexcom","direction":"Flat"},{"sgv":"174","dateString":"07/19/2014 03:24:15 AM","date":1405765455000,"device":"dexcom","direction":"Flat"},{"sgv":"174","dateString":"07/19/2014 03:19:15 AM","date":1405765155000,"device":"dexcom","direction":"Flat"},{"sgv":"175","dateString":"07/19/2014 03:14:15 AM","date":1405764855000,"device":"dexcom","direction":"Flat"},{"sgv":"176","dateString":"07/19/2014 03:09:15 AM","date":1405764555000,"device":"dexcom","direction":"Flat"},{"sgv":"176","dateString":"07/19/2014 03:04:15 AM","date":1405764255000,"device":"dexcom","direction":"Flat"},{"sgv":"173","dateString":"07/19/2014 02:59:15 AM","date":1405763955000,"device":"dexcom","direction":"Flat"},{"sgv":"171","dateString":"07/19/2014 02:54:15 AM","date":1405763655000,"device":"dexcom","direction":"Flat"},{"sgv":"170","dateString":"07/19/2014 02:49:15 AM","date":1405763355000,"device":"dexcom","direction":"Flat"},{"sgv":"171","dateString":"07/19/2014 02:44:15 AM","date":1405763055000,"device":"dexcom","direction":"Flat"},{"sgv":"169","dateString":"07/19/2014 02:39:15 AM","date":1405762755000,"device":"dexcom","direction":"Flat"},{"sgv":"169","dateString":"07/19/2014 02:34:15 AM","date":1405762455000,"device":"dexcom","direction":"Flat"}]
+[
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:49:15 AM",
+    "date": 1405792155000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:44:15 AM",
+    "date": 1405791855000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:39:15 AM",
+    "date": 1405791555000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:34:15 AM",
+    "date": 1405791255000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:29:15 AM",
+    "date": 1405790955000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:24:15 AM",
+    "date": 1405790655000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:19:15 AM",
+    "date": 1405790355000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:14:15 AM",
+    "date": 1405790055000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:09:15 AM",
+    "date": 1405789755000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 10:04:15 AM",
+    "date": 1405789455000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 09:59:15 AM",
+    "date": 1405789155000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "5",
+    "dateString": "07\/19\/2014 09:54:15 AM",
+    "date": 1405788855000,
+    "device": "dexcom",
+    "direction": "NOT COMPUTABLE"
+  },
+  {
+    "sgv": "178",
+    "dateString": "07\/19\/2014 03:59:15 AM",
+    "date": 1405767555000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "179",
+    "dateString": "07\/19\/2014 03:54:15 AM",
+    "date": 1405767255000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "178",
+    "dateString": "07\/19\/2014 03:49:15 AM",
+    "date": 1405766955000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "177",
+    "dateString": "07\/19\/2014 03:44:15 AM",
+    "date": 1405766655000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "176",
+    "dateString": "07\/19\/2014 03:39:15 AM",
+    "date": 1405766355000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "176",
+    "dateString": "07\/19\/2014 03:34:15 AM",
+    "date": 1405766055000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "175",
+    "dateString": "07\/19\/2014 03:29:16 AM",
+    "date": 1405765756000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "174",
+    "dateString": "07\/19\/2014 03:24:15 AM",
+    "date": 1405765455000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "174",
+    "dateString": "07\/19\/2014 03:19:15 AM",
+    "date": 1405765155000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "175",
+    "dateString": "07\/19\/2014 03:14:15 AM",
+    "date": 1405764855000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "176",
+    "dateString": "07\/19\/2014 03:09:15 AM",
+    "date": 1405764555000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "176",
+    "dateString": "07\/19\/2014 03:04:15 AM",
+    "date": 1405764255000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "173",
+    "dateString": "07\/19\/2014 02:59:15 AM",
+    "date": 1405763955000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "171",
+    "dateString": "07\/19\/2014 02:54:15 AM",
+    "date": 1405763655000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "170",
+    "dateString": "07\/19\/2014 02:49:15 AM",
+    "date": 1405763355000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "171",
+    "dateString": "07\/19\/2014 02:44:15 AM",
+    "date": 1405763055000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "169",
+    "dateString": "07\/19\/2014 02:39:15 AM",
+    "date": 1405762755000,
+    "device": "dexcom",
+    "direction": "Flat"
+  },
+  {
+    "sgv": "169",
+    "dateString": "07\/19\/2014 02:34:15 AM",
+    "date": 1405762455000,
+    "device": "dexcom",
+    "direction": "Flat"
+  }
+]


### PR DESCRIPTION
This resolves an issue where the `create` function in `entries.js` wasn't waiting for the updates to complete before calling back. This would frequently cause Travis failures, when tests would expect entries that had yet to be completed.

resolves #423 
