### PR TITLE
fix environmental variable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Use the [autoconfigure tool][autoconfigure] to sync an uploader to your config.
 Easy to emulate on the commandline:
 
 ```bash
-    echo 'MONGO_CONNECTION="mongodb://sally:sallypass@ds099999.mongolab.com:99999/nightscout"' >> my.env
+    echo 'MONGO_CONNECTION=mongodb://sally:sallypass@ds099999.mongolab.com:99999/nightscout' >> my.env
+    echo 'MONGO_COLLECTION=entries' >> my.env
 ```
 
 From now on you can run using


### PR DESCRIPTION
The values of environmental variables should not be in quotes. This
change also adds MONGO_COLLECTION to the example.