### PR TITLE
simplify boolean assignment

### DIFF
--- a/lib/pebble.js
+++ b/lib/pebble.js
@@ -21,16 +21,8 @@ function directionToTrend (direction) {
 
 function pebble (req, res) {
   var ONE_DAY = 24 * 60 * 60 * 1000;
+  var useMetricBg = (req.query.units === "mmol");
   var uploaderBattery;
-
-  function requestMetric() {
-      var units = req.query.units;
-      if (units == "mmol") {
-        return true;
-      }
-      return false;
-  }
-  var useMetricBg = requestMetric();
 
   function scaleBg(bg) {
       if (useMetricBg) {


### PR DESCRIPTION
The requestMetric function is only called once, and it just does a
simple boolean equality check. It would be cleaner to just inline the
check.