### PR TITLE
allow API to search things better

### DIFF
--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -37,7 +37,7 @@ function configure (app, wares, entries) {
           es.pipeline(output, sgvdata.format( ), res);
         },
         json: function ( ) {
-          es.pipeline(output, sgvdata.lint({strict: false}), es.writeArray(function (err, out) {
+          es.pipeline(output, entries.map( ), es.writeArray(function (err, out) {
             res.json(out);
           }));
         }

--- a/lib/api/treatments/index.js
+++ b/lib/api/treatments/index.js
@@ -17,7 +17,7 @@ function configure (app, wares, treatments) {
 
     // List settings available
     api.get('/treatments/', function(req, res) {
-        treatments.list({}, function (err, profiles) {
+        treatments.list({find: req.params}, function (err, profiles) {
             return res.json(profiles);
         });
     });

--- a/lib/entries.js
+++ b/lib/entries.js
@@ -10,6 +10,18 @@ var TEN_MINS = 10 * 60 * 1000;
  * Encapsulate persistent storage of sgv entries.
 \**********/
 
+function find_sgv_query (opts) {
+  if (opts && opts.find && opts.find.sgv) {
+    Object.keys(opts.find.sgv).forEach(function (key) {
+      var is_keyword = /^\$/g;
+      if (is_keyword.test(key)) {
+        opts.find.sgv[key] = parseInt(opts.find.sgv[key]);
+      }
+    });
+  }
+  return opts;
+}
+
 function storage(name, storage, pushover) {
 
   // TODO: Code is a little redundant.
@@ -25,7 +37,8 @@ function storage(name, storage, pushover) {
 
       // determine find options
       function find ( ) {
-        var q = opts && opts.find ? opts.find : { };
+        var finder = find_sgv_query(opts);
+        var q = finder && finder.find ? finder.find : { };
         return q;
         // return this.find(q);
       }


### PR DESCRIPTION
This allows a query such as this to search for events of hypoglycemia for
example:
```
curl -g localhost:3434 \
     /api/v1/entries   \
     '?find[sgv][$lte]=70&find[sgv][$gte]=20&count=1000
```
It's possible to construct most mongo queries by url encoding the query string.
In this instance, mongo performs poorly when searching for lte/gte for strings.
In order for ranged queries to perform properly, the query parameters must be
set to integer type.  There is a quick and ugly helper to ensure that some sgv
queries will be respected as integer searches.