### PR TITLE
Add DISPLAY_UNITS and Papertrail

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,10 +13,10 @@
       "required": true
     },
     "DISPLAY_UNITS": {
-      "description": "Default null value implies 'mg/dl'.  Seting to 'mmol' forces the server to display BG data in mmol.  This affects the main website and Pebble endpoint.",
+      "description": "Server display units for BG values.  Default null value implies 'mg/dl'.  Set to 'mmol' to change the server to mmol mode.",
       "value": "",
       "required": false
-    }
+    },
     "ENABLE": {
       "description": "Space delimited list of optional features to enable, such as 'careportal'.",
       "value": "",
@@ -59,7 +59,7 @@
     }
   },
   "addons": [
-    "mongolab:sandbox"
+    "mongolab:sandbox",
     "papertrail"
   ]
 }

--- a/app.json
+++ b/app.json
@@ -12,6 +12,11 @@
       "value": "",
       "required": true
     },
+    "DISPLAY_UNITS": {
+      "description": "Default null value implies 'mg/dl'.  Seting to 'mmol' forces the server to display BG data in mmol.  This affects the main website and Pebble endpoint.",
+      "value": "",
+      "required": false
+    }
     "ENABLE": {
       "description": "Space delimited list of optional features to enable, such as 'careportal'.",
       "value": "",
@@ -55,5 +60,6 @@
   },
   "addons": [
     "mongolab:sandbox"
+    "papertrail"
   ]
 }


### PR DESCRIPTION
Giving the DISPLAY_UNITS option will make international deployments easier.  Papertrail is a free logging add-on giving users real-time access to all Heroku router and app related logs via the Heroku Dashboard.