### PR TITLE
querySelectorAll optimization + don't render invisible treatments

### DIFF
--- a/static/js/client.js
+++ b/static/js/client.js
@@ -1,6 +1,46 @@
 //TODO: clean up
 var app = {}, browserSettings = {}, browserStorage = $.localStorage;
 
+/*
+ * query
+ * Abstraction to querySelectorAll for increased 
+ * performance and greater usability
+ * @param {String} selector
+ * @param {Element} context (optional)
+ * @return {Array}
+ */
+
+(function(win){
+    'use strict';
+    
+    console.log("Foo");
+
+    var simpleRe = /^(#?[\w-]+|\.[\w-.]+)$/, 
+    periodRe = /\./g, 
+    slice = [].slice;
+
+    win.query = function(selector, context){
+        context = context || document;
+        // Redirect call to the more performant function 
+        // if it's a simple selector and return an array
+        // for easier usage
+        if(simpleRe.test(selector)){
+            switch(selector[0]){
+                case '#':
+                    return [context.getElementById(selector.substr(1))];
+                case '.':
+                    return slice.call(context.getElementsByClassName(selector.substr(1).replace(periodRe, ' ')));
+                default:
+                    return slice.call(context.getElementsByTagName(selector));
+            }
+        }
+        // If not a simple selector, query the DOM as usual 
+        // and return an array for easier usage
+        return slice.call(context.querySelectorAll(selector));
+    };
+    
+})(this);
+
 (function () {
     'use strict';
 
@@ -1298,6 +1338,9 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
     function drawTreatment(treatment, scale, showValues) {
 
         if (!treatment.carbs && !treatment.insulin) return;
+
+		// don't render the treatment if it's not visible
+		if (Math.abs(xScale(treatment.created_at.getTime())) > window.innerWidth) return;
 
         var CR = treatment.CR || 20;
         var carbs = treatment.carbs || CR;

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -12,8 +12,6 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
 
 (function(win){
     'use strict';
-    
-    console.log("Foo");
 
     var simpleRe = /^(#?[\w-]+|\.[\w-.]+)$/, 
     periodRe = /\./g, 


### PR DESCRIPTION
Optimization for querySelectorAll, which seems to be non-performant and used by D3 a _lot_.

One-liner to disable drawing of treatments not visible on screen.