### PR TITLE
Wip/storage simplification and tests

### DIFF
--- a/lib/devicestatus.js
+++ b/lib/devicestatus.js
@@ -33,7 +33,7 @@ function storage (collection, ctx) {
     }
 
     function api() {
-        return ctx.store.pool.db.collection(collection);
+        return ctx.store.db.collection(collection);
     }
 
 

--- a/lib/entries.js
+++ b/lib/entries.js
@@ -143,7 +143,7 @@ function storage(env, ctx) {
   function api ( ) {
     // obtain handle usable for querying the collection associated
     // with these records
-    return ctx.store.pool.db.collection(env.mongo_collection);
+    return ctx.store.db.collection(env.mongo_collection);
   }
 
   // Expose all the useful functions

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -28,7 +28,7 @@ function storage (collection, ctx) {
   }
 
   function api () {
-    return ctx.store.pool.db.collection(collection);
+    return ctx.store.db.collection(collection);
   }
   
   api.list = list;

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -4,32 +4,49 @@ var mongodb = require('mongodb');
 function init (env, cb) {
   var MongoClient = mongodb.MongoClient;
 
-  var my = { };
-  function maybe_connect (cb) {
+  var mongo = {
+    collection: function get_collection (name) {
+      return mongo.db.collection(name);
+    },
+    with_collection: function with_collection (name) {
+      return function use_collection(fn) {
+        fn(null, mongo.db.collection(name));
+      }
+    },
+    limit: function limit (opts) {
+      if (opts && opts.count) {
+        return this.limit(parseInt(opts.count));
+      }
+      return this;
+    },
+    ensureIndexes: function(collection, fields) {
+      fields.forEach(function (field) {
+        console.info('Ensuring index for: ' + field);
+        collection.ensureIndex(field, function (err) {
+          if (err) {
+            console.error('unable to ensureIndex for: ' + field + ' - ' + err);
+          }
+        });
+      })
+    },
+    db: null // Yet to be assigned
+  };
 
-    if (my.db) {
-      console.log("Reusing MongoDB connection handler");
-      // If there is a valid callback, then return the Mongo-object
-      if (cb && cb.call) { cb(null, mongo); }
-      return;
-    }
-
+  function newConnection (cb) {
     if (!env.mongo) {
-      throw new Error("MongoDB connection string is missing");
+      throw new Error('MongoDB connection string is missing');
     }
 
-    console.log("Setting up new connection to MongoDB");
+    console.log('Setting up new connection to MongoDB');
     MongoClient.connect(env.mongo, function connected (err, db) {
       if (err) {
-        console.log("Error connecting to MongoDB, ERROR: %j", err);
+        console.log('Error connecting to MongoDB, ERROR: %j', err);
         throw err;
       } else {
-        console.log("Successfully established a connected to MongoDB");
+        console.log('Successfully established a connected to MongoDB');
       }
 
-      // FIXME Fokko: I would suggest to just create a private db variable instead of the separate my, pool construction.
-      my.db = db;
-      mongo.pool.db = my.db = db;
+      mongo.db = db;
 
       // If there is a valid callback, then invoke the function to perform the callback
       if (cb && cb.call)
@@ -37,45 +54,19 @@ function init (env, cb) {
     });
   }
 
-  function mongo (cb) {
-    maybe_connect(cb);
-    mongo.pool.db = my.db;
+  return function mongo (cb) {
+    if (mongo.db != null) {
+      console.log('Reusing MongoDB connection handler');
+      // If there is a valid callback, then return the Mongo-object
+      if (cb && cb.call) {
+        cb(null, mongo);
+      }
+    } else {
+      newConnection(cb);
+    }
+
     return mongo;
   }
-
-  mongo.pool = function ( ) {
-    return my;
-  };
-
-  mongo.collection = function get_collection (name) {
-    return mongo.pool( ).db.collection(name);
-  };
-
-  mongo.with_collection = function with_collection (name) {
-    return function use_collection (fn) {
-      fn(null, mongo.pool( ).db.collection(name));
-    };
-  };
-
-  mongo.limit = function limit (opts) {
-    if (opts && opts.count) {
-      return this.limit(parseInt(opts.count));
-    }
-    return this;
-  };
-
-  mongo.ensureIndexes = function(collection, fields) {
-    fields.forEach(function (field) {
-      console.info("ensuring index for: " + field);
-      collection.ensureIndex(field, function (err) {
-        if (err) {
-          console.error("unable to ensureIndex for: " + field + " - " + err);
-        }
-      });
-    });
-  };
-
-  return mongo(cb);
 }
 
 module.exports = init;

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,72 +1,77 @@
 'use strict';
+
 var mongodb = require('mongodb');
 
-function init (env, cb) {
+var connection = null;
+
+function init(env, cb, forceNewConnection) {
   var MongoClient = mongodb.MongoClient;
+  var mongo = {};
 
-  var mongo = {
-    collection: function get_collection (name) {
-      return mongo.db.collection(name);
-    },
-    with_collection: function with_collection (name) {
-      return function use_collection(fn) {
-        fn(null, mongo.db.collection(name));
-      }
-    },
-    limit: function limit (opts) {
-      if (opts && opts.count) {
-        return this.limit(parseInt(opts.count));
-      }
-      return this;
-    },
-    ensureIndexes: function(collection, fields) {
-      fields.forEach(function (field) {
-        console.info('Ensuring index for: ' + field);
-        collection.ensureIndex(field, function (err) {
-          if (err) {
-            console.error('unable to ensureIndex for: ' + field + ' - ' + err);
-          }
-        });
-      })
-    },
-    db: null // Yet to be assigned
-  };
+  function maybe_connect(cb) {
 
-  function newConnection (cb) {
-    if (!env.mongo) {
-      throw new Error('MongoDB connection string is missing');
-    }
-
-    console.log('Setting up new connection to MongoDB');
-    MongoClient.connect(env.mongo, function connected (err, db) {
-      if (err) {
-        console.log('Error connecting to MongoDB, ERROR: %j', err);
-        throw err;
-      } else {
-        console.log('Successfully established a connected to MongoDB');
-      }
-
-      mongo.db = db;
-
-      // If there is a valid callback, then invoke the function to perform the callback
-      if (cb && cb.call)
-          cb(err, mongo);
-    });
-  }
-
-  return function mongo (cb) {
-    if (mongo.db != null) {
+    if (connection != null && !forceNewConnection) {
       console.log('Reusing MongoDB connection handler');
       // If there is a valid callback, then return the Mongo-object
+      mongo.db = connection;
+
       if (cb && cb.call) {
         cb(null, mongo);
       }
     } else {
-      newConnection(cb);
-    }
+      if (!env.mongo) {
+        throw new Error('MongoDB connection string is missing');
+      }
 
-    return mongo;
+      console.log('Setting up new connection to MongoDB');
+      MongoClient.connect(env.mongo, function connected(err, db) {
+        if (err) {
+          console.log('Error connecting to MongoDB, ERROR: %j', err);
+          throw err;
+        } else {
+          console.log('Successfully established a connected to MongoDB');
+        }
+
+        connection = db;
+
+        mongo.db = connection;
+
+        // If there is a valid callback, then invoke the function to perform the callback
+        if (cb && cb.call)
+          cb(err, mongo);
+      });
+    }
   }
+
+  mongo.collection = function get_collection(name) {
+    return connection.collection(name);
+  };
+
+  mongo.with_collection = function with_collection(name) {
+    return function use_collection(fn) {
+      fn(null, connection.collection(name));
+    };
+  };
+
+  mongo.limit = function limit(opts) {
+    if (opts && opts.count) {
+      return this.limit(parseInt(opts.count));
+    }
+    return this;
+  };
+
+  mongo.ensureIndexes = function (collection, fields) {
+    fields.forEach(function (field) {
+      console.info('ensuring index for: ' + field);
+      collection.ensureIndex(field, function (err) {
+        if (err) {
+          console.error('unable to ensureIndex for: ' + field + ' - ' + err);
+        }
+      });
+    });
+  };
+
+  return maybe_connect(cb);
 }
 
 module.exports = init;

--- a/lib/treatments.js
+++ b/lib/treatments.js
@@ -66,7 +66,7 @@ function storage (env, ctx) {
   }
 
   function api ( ) {
-    return ctx.store.pool.db.collection(env.treatments_collection);
+    return ctx.store.db.collection(env.treatments_collection);
   }
 
   api.list = list;

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 var load = require('./fixtures/load');
 
 describe('STORAGE', function () {
-  var env = require('../env')( );
+  var env = require('../env')();
 
   before(function (done) {
     delete env.api_secret;
@@ -25,8 +25,7 @@ describe('STORAGE', function () {
 
       store(env, function (err2, db2) {
         should.not.exist(err2);
-
-        console.log(db1 == db2)
+        assert(db1.db, db2.db, 'Check if the handlers are the same.')
 
         done();
       });
@@ -37,8 +36,8 @@ describe('STORAGE', function () {
     delete env.mongo;
     should.not.exist(env.mongo);
 
-    (function(){
-      return require('../lib/storage')(env);
+    (function () {
+      return require('../lib/storage')(env, false, true);
     }).should.throw('MongoDB connection string is missing');
 
     done();
@@ -47,8 +46,8 @@ describe('STORAGE', function () {
   it('An invalid connection-string should throw an error.', function (done) {
     env.mongo = 'This is not a MongoDB connection-string';
 
-    (function(){
-      return require('../lib/storage')(env);
+    (function () {
+      return require('../lib/storage')(env, false, true);
     }).should.throw('URL must be in the format mongodb://user:pass@host:port/dbname');
 
     done();

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,9 +1,7 @@
 'use strict';
 
-var request = require('supertest');
 var should = require('should');
 var assert = require('assert');
-var load = require('./fixtures/load');
 
 describe('STORAGE', function () {
   var env = require('../env')();
@@ -14,7 +12,7 @@ describe('STORAGE', function () {
   });
 
   it('The storage class should be OK.', function (done) {
-    require('../lib/storage').should.be.ok;
+    should(require('../lib/storage')).be.ok;
     done();
   });
 
@@ -25,7 +23,7 @@ describe('STORAGE', function () {
 
       store(env, function (err2, db2) {
         should.not.exist(err2);
-        assert(db1.db, db2.db, 'Check if the handlers are the same.')
+        assert(db1.db, db2.db, 'Check if the handlers are the same.');
 
         done();
       });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var request = require('supertest');
+var should = require('should');
+var assert = require('assert');
+var load = require('./fixtures/load');
+
+describe('STORAGE', function () {
+  var env = require('../env')( );
+
+  before(function (done) {
+    delete env.api_secret;
+    done();
+  });
+
+  it('The storage class should be OK.', function (done) {
+    require('../lib/storage').should.be.ok;
+    done();
+  });
+
+  it('After initializing the storage class it should re-use the open connection', function (done) {
+    var store = require('../lib/storage');
+    store(env, function (err1, db1) {
+      should.not.exist(err1);
+
+      store(env, function (err2, db2) {
+        should.not.exist(err2);
+
+        console.log(db1 == db2)
+
+        done();
+      });
+    });
+  });
+
+  it('When no connection-string is given the storage-class should throw an error.', function (done) {
+    delete env.mongo;
+    should.not.exist(env.mongo);
+
+    (function(){
+      return require('../lib/storage')(env);
+    }).should.throw('MongoDB connection string is missing');
+
+    done();
+  });
+
+  it('An invalid connection-string should throw an error.', function (done) {
+    env.mongo = 'This is not a MongoDB connection-string';
+
+    (function(){
+      return require('../lib/storage')(env);
+    }).should.throw('URL must be in the format mongodb://user:pass@host:port/dbname');
+
+    done();
+  });
+
+});
+


### PR DESCRIPTION
Written an additional test-script for the `storage` file which hit some lines which were not covered yet. Also the re-use of the connection handler wasn't functional, and it is working now. I removed the `pool()` variable as it did not add any value. 

I decided to keep this PR small and concise. Next stop will be the delayed connection to the MongoDB-server if the connection fails. This is a feature which comes in handy when working with micro-services like Docker etc.