### PR TITLE
Notifications generated by BWP were missing a sbx.scaleBg() around raw values

### DIFF
--- a/lib/plugins/boluswizardpreview.js
+++ b/lib/plugins/boluswizardpreview.js
@@ -88,7 +88,7 @@ function init() {
 
       var rawbgProp = sbx.properties.rawbg;
       if (rawbgProp) {
-        lines.push(['Raw BG:', rawbgProp.value, sbx.unitsLabel, rawbgProp.noiseLabel].join(' '));
+        lines.push(['Raw BG:', sbx.scaleBg(rawbgProp.value), sbx.unitsLabel, rawbgProp.noiseLabel].join(' '));
       }
 
       lines.push(['BWP:', results.bolusEstimateDisplay, 'U'].join(' '));


### PR DESCRIPTION
Added missing sbx.scaleBg() around notifications generated by BWP