### PR TITLE
don't let future data block the current

### DIFF
--- a/lib/plugins/ar2.js
+++ b/lib/plugins/ar2.js
@@ -58,7 +58,7 @@ function init() {
     var rawSGVs;
 
     if (sbx.properties.rawbg && sbx.extendedSettings.useRaw) {
-      var cal = _.last(sbx.data.cals);
+      var cal = sbx.lastEntry(sbx.data.cals);
       if (cal) {
         rawSGVs = _.map(_.takeRight(sgvs, 2), function eachSGV(sgv) {
           var rawResult = rawbg.calc(sgv, cal);

--- a/lib/plugins/direction.js
+++ b/lib/plugins/direction.js
@@ -20,8 +20,7 @@ function init() {
   direction.updateVisualisation = function updateVisualisation (sbx) {
     var prop = sbx.properties.direction;
 
-    var lastSGV = _.last(sbx.data.sgvs);
-    if (lastSGV && lastSGV.y < 39) {
+    if (sbx.lastSGV() < 39) {
       prop.value = 'CGM ERROR';
       prop.label = '✖';
     }

--- a/lib/plugins/errorcodes.js
+++ b/lib/plugins/errorcodes.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
-
 function init() {
 
   var TIME_10_MINS_MS = 10 * 60 * 1000;

--- a/lib/plugins/errorcodes.js
+++ b/lib/plugins/errorcodes.js
@@ -15,7 +15,7 @@ function init() {
 
   errorcodes.checkNotifications = function checkNotifications (sbx) {
     var now = Date.now();
-    var lastSGV = _.last(sbx.data.sgvs);
+    var lastSGV = sbx.lastSGVEntry();
 
     if (lastSGV && now - lastSGV.x < TIME_10_MINS_MS && lastSGV.y < 39) {
 

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
-
 function init() {
 
   function rawbg() {

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -15,9 +15,8 @@ function init() {
   rawbg.setProperties = function setProperties (sbx) {
     sbx.offerProperty('rawbg', function setRawBG ( ) {
       var result = { };
-
-      var currentSGV = _.last(sbx.data.sgvs);
-      var currentCal = _.last(sbx.data.cals);
+      var currentSGV = sbx.lastSGVEntry();
+      var currentCal = sbx.lastEntry(sbx.data.cals);
 
       if (currentSGV && currentCal) {
         result.value = rawbg.calc(currentSGV, currentCal, sbx);

--- a/lib/plugins/simplealarms.js
+++ b/lib/plugins/simplealarms.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
-
 function init() {
 
   function simplealarms() {

--- a/lib/plugins/simplealarms.js
+++ b/lib/plugins/simplealarms.js
@@ -15,7 +15,7 @@ function init() {
 
   simplealarms.checkNotifications = function checkNotifications(sbx) {
     var lastSGV = sbx.lastScaledSGV()
-      , lastSGVEntry = _.last(sbx.data.sgvs)
+      , lastSGVEntry = sbx.lastSGVEntry()
       , trigger = false
       , level = 0
       , title = ''

--- a/lib/plugins/treatmentnotify.js
+++ b/lib/plugins/treatmentnotify.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
-
 function init() {
 
   var TIME_10_MINS_MS = 10 * 60 * 1000;

--- a/lib/plugins/treatmentnotify.js
+++ b/lib/plugins/treatmentnotify.js
@@ -17,12 +17,8 @@ function init() {
 
     var now = Date.now();
 
-    function notInTheFuture (entry) {
-      return entry.x <= now;
-    }
-
-    var lastMBG = _.findLast(sbx.data.mbgs, notInTheFuture);
-    var lastTreatment = _.findLast(sbx.data.treatments, notInTheFuture);
+    var lastMBG = sbx.lastEntry(sbx.data.mbgs);
+    var lastTreatment = sbx.lastEntry(sbx.data.treatments);
 
     //TODO: figure out why date is x here #CleanUpDataModel
     var lastMBGTime = lastMBG ? lastMBG.x : 0;

--- a/lib/plugins/treatmentnotify.js
+++ b/lib/plugins/treatmentnotify.js
@@ -17,15 +17,19 @@ function init() {
 
     var now = Date.now();
 
-    var lastMBG = _.last(sbx.data.mbgs);
-    var lastTreatment = _.last(sbx.data.treatments);
+    function notInTheFuture (entry) {
+      return entry.x <= now;
+    }
+
+    var lastMBG = _.findLast(sbx.data.mbgs, notInTheFuture);
+    var lastTreatment = _.findLast(sbx.data.treatments, notInTheFuture);
 
     //TODO: figure out why date is x here #CleanUpDataModel
     var lastMBGTime = lastMBG ? lastMBG.x : 0;
     var mbgAgo = (lastMBGTime && lastMBGTime <= now) ? now - lastMBGTime : -1;
     var mbgCurrent = mbgAgo !== -1 && mbgAgo < TIME_10_MINS_MS;
 
-    var lastTreatmentTime = lastTreatment ? new Date(lastTreatment.created_at).getTime() : 0;
+    var lastTreatmentTime = lastTreatment ? lastTreatment.x : 0;
     var treatmentAgo = (lastTreatmentTime && lastTreatmentTime <= now) ? now - lastTreatmentTime : -1;
     var treatmentCurrent = treatmentAgo !== -1 && treatmentAgo < TIME_10_MINS_MS;
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -113,13 +113,19 @@ function init ( ) {
     }
   };
 
+  sbx.lastSGVEntry = function lastSGVEntry ( ) {
+    return _.findLast(sbx.data.sgvs, function notInTheFuture (entry) {
+      return entry.x <= sbx.time;
+    });
+  };
+
   sbx.lastSGV = function lastSGV ( ) {
-    var last = _.last(sbx.data.sgvs);
+    var last = sbx.lastSGVEntry();
     return last && last.y;
   };
 
   sbx.lastSGVMills = function lastSGVMills ( ) {
-    var last = _.last(sbx.data.sgvs);
+    var last = sbx.lastSGVEntry();
     return (last && last.x) || (last && last.date && (new Date(last.date)).getTime()) || 0;
   };
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -113,10 +113,14 @@ function init ( ) {
     }
   };
 
-  sbx.lastSGVEntry = function lastSGVEntry ( ) {
-    return _.findLast(sbx.data.sgvs, function notInTheFuture (entry) {
+  sbx.lastEntry = function lastEntry (entries) {
+    return _.findLast(entries, function notInTheFuture (entry) {
       return entry.x <= sbx.time;
     });
+  };
+
+  sbx.lastSGVEntry = function lastSGVEntry ( ) {
+    return sbx.lastEntry(sbx.data.sgvs);
   };
 
   sbx.lastSGV = function lastSGV ( ) {

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -115,7 +115,7 @@ function init ( ) {
 
   sbx.lastEntry = function lastEntry (entries) {
     return _.findLast(entries, function notInTheFuture (entry) {
-      return entryToTime(entry) <= sbx.time;
+      return sbx.entryMills(entry) <= sbx.time;
     });
   };
 
@@ -129,13 +129,13 @@ function init ( ) {
   };
 
   sbx.lastSGVMills = function lastSGVMills ( ) {
-    return entryToTime(sbx.lastSGVEntry());
+    return sbx.entryMills(sbx.lastSGVEntry());
   };
 
-  function entryToTime(entry) {
+  sbx.entryMills = function entryMills(entry) {
     //FIXME: field mismatch between server and client :(
     return (entry && entry.x) || (entry && entry.date && (new Date(entry.date)).getTime()) || 0;
-  }
+  };
 
   sbx.lastScaledSGV = function lastScaledSVG ( ) {
     return sbx.scaleBg(sbx.lastSGV());

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -115,7 +115,7 @@ function init ( ) {
 
   sbx.lastEntry = function lastEntry (entries) {
     return _.findLast(entries, function notInTheFuture (entry) {
-      return entry.x <= sbx.time;
+      return entryToTime(entry) <= sbx.time;
     });
   };
 
@@ -129,9 +129,13 @@ function init ( ) {
   };
 
   sbx.lastSGVMills = function lastSGVMills ( ) {
-    var last = sbx.lastSGVEntry();
-    return (last && last.x) || (last && last.date && (new Date(last.date)).getTime()) || 0;
+    return entryToTime(sbx.lastSGVEntry());
   };
+
+  function entryToTime(entry) {
+    //FIXME: field mismatch between server and client :(
+    return (entry && entry.x) || (entry && entry.date && (new Date(entry.date)).getTime()) || 0;
+  }
 
   sbx.lastScaledSGV = function lastScaledSVG ( ) {
     return sbx.scaleBg(sbx.lastSGV());

--- a/tests/ar2.test.js
+++ b/tests/ar2.test.js
@@ -6,7 +6,6 @@ describe('ar2', function ( ) {
   var delta = require('../lib/plugins/delta')();
 
   var env = require('../env')();
-
   var ctx = {};
   ctx.data = require('../lib/data')(env, ctx);
   ctx.notifications = require('../lib/notifications')(env, ctx);
@@ -120,7 +119,7 @@ describe('ar2', function ( ) {
   it('should include current raw bg and raw bg forecast when predicting w/raw', function (done) {
     ctx.notifications.initRequests();
     ctx.data.sgvs = [{unfiltered: 113680, filtered: 111232, y: 100, x: before, noise: 1}, {unfiltered: 183680, filtered: 111232, y: 100, x: now, noise: 1}];
-    ctx.data.cals = [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918}];
+    ctx.data.cals = [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918, x: now}];
 
     var envRaw = require('../env')();
     envRaw.extendedSettings = {'ar2': {useRaw: true}};
@@ -152,7 +151,7 @@ describe('ar2', function ( ) {
   it('should not trigger an alarm when raw is missing or 0', function (done) {
     ctx.notifications.initRequests();
     ctx.data.sgvs = [{unfiltered: 0, filtered: 0, y: 100, x: before, noise: 1}, {unfiltered: 0, filtered: 0, y: 100, x: now, noise: 1}];
-    ctx.data.cals = [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918}];
+    ctx.data.cals = [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918, x: now}];
 
     var sbx = rawSandbox();
     ar2.checkNotifications(sbx.withExtendedSettings(ar2));
@@ -165,7 +164,7 @@ describe('ar2', function ( ) {
   it('should trigger a warning (no urgent for raw) when raw is falling really fast, but sgv is steady', function (done) {
     ctx.notifications.initRequests();
     ctx.data.sgvs = [{unfiltered: 113680, filtered: 111232, y: 100, x: before, noise: 1}, {unfiltered: 43680, filtered: 111232, y: 100, x: now, noise: 1}];
-    ctx.data.cals = [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918}];
+    ctx.data.cals = [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918, x: now}];
 
     var sbx = rawSandbox();
     sbx.offerProperty('rawbg', function setFakeIOB() {
@@ -183,7 +182,7 @@ describe('ar2', function ( ) {
   it('should trigger a warning (no urgent for raw) when raw is rising really fast, but sgv is steady', function (done) {
     ctx.notifications.initRequests();
     ctx.data.sgvs = [{unfiltered: 113680, filtered: 111232, y: 100, x: before, noise: 1}, {unfiltered: 183680, filtered: 111232, y: 100, x: now, noise: 1}];
-    ctx.data.cals = [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918}];
+    ctx.data.cals = [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918, x: now}];
 
     var sbx = rawSandbox();
     sbx.offerProperty('rawbg', function setFakeIOB() {

--- a/tests/rawbg.test.js
+++ b/tests/rawbg.test.js
@@ -6,10 +6,11 @@ describe('Raw BG', function ( ) {
   var rawbg = require('../lib/plugins/rawbg')();
   var sandbox = require('../lib/sandbox')();
 
+  var now = Date.now();
   var pluginBase = {};
   var data = {
-    sgvs: [{unfiltered: 113680, filtered: 111232, y: 110, noise: 1}]
-    , cals: [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918}]
+    sgvs: [{unfiltered: 113680, filtered: 111232, y: 110, noise: 1, x: now}]
+    , cals: [{scale: 1, intercept: 25717.82377004309, slope: 766.895601715918, x: now}]
   };
   var app = { };
   var clientSettings = {

--- a/tests/sandbox.test.js
+++ b/tests/sandbox.test.js
@@ -3,6 +3,8 @@ var should = require('should');
 describe('sandbox', function ( ) {
   var sandbox = require('../lib/sandbox')();
 
+  var now = Date.now();
+
   it('init on client', function (done) {
     var app = {
       thresholds:{
@@ -18,7 +20,7 @@ describe('sandbox', function ( ) {
     };
 
     var pluginBase = {};
-    var data = {sgvs: [{y: 100}]};
+    var data = {sgvs: [{y: 100, x: now}]};
 
     var sbx = sandbox.clientInit(app, clientSettings, Date.now(), pluginBase, data);
 
@@ -40,7 +42,7 @@ describe('sandbox', function ( ) {
 
   it('init on server', function (done) {
     var sbx = createServerSandbox();
-    sbx.data.sgvs = [{y: 100}];
+    sbx.data.sgvs = [{y: 100, x: now}];
 
     should.exist(sbx.notifications.requestNotify);
     should.not.exist(sbx.notifications.process);
@@ -61,7 +63,7 @@ describe('sandbox', function ( ) {
 
   it('build BG Now line using properties', function ( ) {
     var sbx = createServerSandbox();
-    sbx.data.sgvs = [{y: 99}];
+    sbx.data.sgvs = [{y: 99, x: now}];
     sbx.properties = { delta: {display: '+5' }, direction: {value: 'FortyFiveUp', label: '↗', entity: '&#8599;'} };
 
     sbx.buildBGNowLine().should.equal('BG Now: 99 +5 ↗ mg/dl');
@@ -70,7 +72,7 @@ describe('sandbox', function ( ) {
 
   it('build default message using properties', function ( ) {
     var sbx = createServerSandbox();
-    sbx.data.sgvs = [{y: 99}];
+    sbx.data.sgvs = [{y: 99, x: now}];
     sbx.properties = {
       delta: {display: '+5' }
       , direction: {value: 'FortyFiveUp', label: '↗', entity: '&#8599;'}

--- a/tests/sandbox.test.js
+++ b/tests/sandbox.test.js
@@ -85,4 +85,13 @@ describe('sandbox', function ( ) {
 
   });
 
+  //FIXME: field mismatch between server and client :(, remove this test when we get that cleaned up
+  it('Use the x or date fields to find an entries time in mills', function () {
+    var sbx = createServerSandbox();
+
+    sbx.entryMills({x: now}).should.equal(now);
+    sbx.entryMills({date: now}).should.equal(now);
+  });
+
+
 });

--- a/tests/treatmentnotify.test.js
+++ b/tests/treatmentnotify.test.js
@@ -10,10 +10,12 @@ describe('treatmentnotify', function ( ) {
   ctx.data = require('../lib/data')(env, ctx);
   ctx.notifications = require('../lib/notifications')(env, ctx);
 
+  var now = Date.now();
+
   it('Request a snooze for a recent treatment and request an info notify', function (done) {
     ctx.notifications.initRequests();
-    ctx.data.sgvs = [{sgv: 100}];
-    ctx.data.treatments = [{eventType: 'BG Check', glucose: '100', created_at: (new Date()).toISOString()}];
+    ctx.data.sgvs = [{x: now, y: 100}];
+    ctx.data.treatments = [{eventType: 'BG Check', glucose: '100', x: now}];
 
     var sbx = require('../lib/sandbox')().serverInit(env, ctx);
     treatmentnotify.checkNotifications(sbx);
@@ -27,8 +29,8 @@ describe('treatmentnotify', function ( ) {
 
   it('Not Request a snooze for an older treatment and not request an info notification', function (done) {
     ctx.notifications.initRequests();
-    ctx.data.sgvs = [{sgv: 100}];
-    ctx.data.treatments = [{created_at: (new Date(Date.now() - (15 * 60 * 1000))).toISOString()}];
+    ctx.data.sgvs = [{x: now, y: 100}];
+    ctx.data.treatments = [{x: Date.now() - (15 * 60 * 1000)}];
 
     var sbx = require('../lib/sandbox')().serverInit(env, ctx);
     treatmentnotify.checkNotifications(sbx);
@@ -42,7 +44,7 @@ describe('treatmentnotify', function ( ) {
 
   it('Request a snooze for a recent calibration and request an info notify', function (done) {
     ctx.notifications.initRequests();
-    ctx.data.sgvs = [{sgv: 100}];
+    ctx.data.sgvs = [{x: now, y: 100}];
     ctx.data.mbgs = [{y: '100', x: Date.now()}];
 
     var sbx = require('../lib/sandbox')().serverInit(env, ctx);
@@ -57,7 +59,7 @@ describe('treatmentnotify', function ( ) {
 
   it('Not Request a snooze for an older calibration treatment and not request an info notification', function (done) {
     ctx.notifications.initRequests();
-    ctx.data.sgvs = [{sgv: 100}];
+    ctx.data.sgvs = [{x: now, y: 100}];
     ctx.data.mbgs = [{y: '100', x: Date.now() - (15 * 60 * 1000)}];
 
     var sbx = require('../lib/sandbox')().serverInit(env, ctx);


### PR DESCRIPTION
Noticed a problem where a treatment entered in the future prevented a notification for a current treatment.

Also updated the `sbx.lastSGV*` functions to filter future data also, we wouldn't want BWP or some other plugin doing calculation based on future data that's probably wrong.

@sulkaharo