### PR TITLE
make the current/stale bg states render correctly

### DIFF
--- a/static/js/client.js
+++ b/static/js/client.js
@@ -1391,8 +1391,9 @@ var app = {}, browserSettings = {}, browserStorage = $.localStorage;
       checkTimeAgoAlarm(ago);
     }
 
+    $('#container').toggleClass('alarming-timeago', ago.status !== 'current');
+
     if (alarmingNow() && ago.status === 'current' && isTimeAgoAlarmType(currentAlarmType)) {
-      $('#container').removeClass('alarming-timeago');
       stopAlarm(true, ONE_MIN_IN_MS);
     }
 


### PR DESCRIPTION
simple fix to an annoying bug, where the bg value could have a strikethrough after a stale data alarm auto cleared