### PR TITLE
added language selection to the settings panel

### DIFF
--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -48,6 +48,7 @@ function init (client, plugins, serverSettings, $) {
       $('#theme-default-browser').prop('checked', true);
     }
 
+    $('#language').val(settings.language);
 
     if (settings.timeFormat === 24) {
       $('#24-browser').prop('checked', true);
@@ -110,6 +111,7 @@ function init (client, plugins, serverSettings, $) {
         customTitle: $('input#customTitle').prop('value'),
         theme: $('input:radio[name=theme-browser]:checked').val(),
         timeFormat: $('input:radio[name=timeformat-browser]:checked').val(),
+        language: $('#language').val(),
         showPlugins: checkedPluginNames()
       });
 

--- a/lib/language.js
+++ b/lib/language.js
@@ -19,6 +19,36 @@ function init() {
       ,hr: 'Slušanje na portu'
       }
     // Client
+    ,'Language' : {
+
+    }
+    , 'Bulgarian': {
+
+    }
+    , 'Croatian': {
+
+    }
+    , 'Czech': {
+
+    }
+    , 'English': {
+
+    }
+    , 'French': {
+
+    }
+    , 'German': {
+
+    }
+    , 'Portuguese (Brazil)': {
+
+    }
+    , 'Romanian': {
+
+    }
+    , 'Spanish': {
+
+    }
     ,'Mo' : {
       cs: 'Po'
       ,de: 'Mo'

--- a/static/index.html
+++ b/static/index.html
@@ -96,6 +96,22 @@
                         <dd><input type="radio" name="timeformat-browser" id="12-browser" value="12" checked /><label for="12-browser" class="translate">12 hours</label></dd>
                         <dd><input type="radio" name="timeformat-browser" id="24-browser" value="24" /><label for="24-browser" class="translate">24 hours</label></dd>
                     </dl>
+                    <dl>
+                      <dt class="translate">Language</dt>
+                      <dd>
+                        <select id="language">
+                          <option value="bg" class="translate">Bulgarian</option>
+                          <option value="hr" class="translate">Croatian</option>
+                          <option value="cs" class="translate">Czech</option>
+                          <option value="en" class="translate">English</option>
+                          <option value="fr" class="translate">French</option>
+                          <option value="de" class="translate">German</option>
+                          <option value="pt" class="translate">Portuguese (Brazil)</option>
+                          <option value="ro" class="translate">Romanian</option>
+                          <option value="es" class="translate">Spanish</option>
+                        </select>
+                      </dd>
+                    </dl>
                     <dl class="toggle">
                         <dt><span class="translate">Enable Alarms</span> <a class="tip" original-title="When enabled an alarm may sound."><i class="icon-help-circled"></i></a></dt>
                         <dd><input type="checkbox" id="alarm-urgenthigh-browser" /><label for="alarm-urgenthigh-browser" class="translate">Urgent High Alarm</label></dd>


### PR DESCRIPTION
Will allow for overriding the `LANGUAGE` env var setting and easy translation testing

<img width="296" alt="screen shot 2015-08-15 at 6 32 53 pm" src="https://cloud.githubusercontent.com/assets/751143/9291550/2da4709e-437c-11e5-91a6-8d536e1320fb.png">
