### PR TITLE
delete pushover receipts after they are used

### DIFF
--- a/lib/pushnotify.js
+++ b/lib/pushnotify.js
@@ -58,6 +58,7 @@ function init(env, ctx) {
     console.info('push ack, response: ', response, ', notify: ', notify);
     if (notify) {
       ctx.notifications.ack(notify.level, times.mins(30).msecs, true);
+      receipts.del(response.receipt);
     }
     return !!notify;
   };


### PR DESCRIPTION
this will prevent alarms from being ack'd multiple times