### PR TITLE
tweaks docs, allow previewing/debugging queries

### DIFF
--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -173,6 +173,17 @@ function configure (app, wares, ctx) {
 
     api.get('/entries', query_models, format_entries);
 
+    function echo_query (req, res, next) {
+      var query = req.query;
+      var input = JSON.parse(JSON.stringify(query));
+
+      // If "?count=" is present, use that number to decided how many to return.
+      if (!query.count) {
+        query.count = 10;
+      }
+
+      res.json({ query: ctx.entries.query_for(query), input: input, params: req.params});
+    }
     function query_models (req, res, next) {
       var query = req.query;
 
@@ -214,6 +225,19 @@ function configure (app, wares, ctx) {
         return next( );
       });
     }
+
+    api.param('spec', function (req, res, next, spec) {
+      if (isId(spec)) {
+        prepReqModel(req, req.params.model);
+        req.query = {find: {_id: req.params.spec}};
+      } else {
+        req.params.model = req.params.spec;
+        prepReqModel(req, req.params.model);
+      }
+      next( );
+    });
+    api.get('/echo/:spec', echo_query);
+    api.get('/echo', echo_query);
 
     // Allow previewing your post content, just echos everything you
     // posted back out.

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -181,9 +181,9 @@ function configure (app, wares, ctx) {
       if (!query.count) {
         query.count = 10;
       }
-      var model = req.params.model || 'entries';
+      var storage = req.params.echo || 'entries';
 
-      res.json({ query: ctx[model].query_for(query), input: input, params: req.params, model: model});
+      res.json({ query: ctx[storage].query_for(query), input: input, params: req.params, storage: storage});
     }
     function query_models (req, res, next) {
       var query = req.query;
@@ -236,7 +236,14 @@ function configure (app, wares, ctx) {
       }
       next( );
     });
-    api.get('/echo/:model?/:spec?', echo_query);
+    api.param('echo', function (req, res, next, echo) {
+      console.log('echo', echo);
+      if (!echo) {
+        req.params.echo = 'entries';
+      }
+      next( );
+    });
+    api.get('/echo/:echo/:model?/:spec?', echo_query);
 
     // Allow previewing your post content, just echos everything you
     // posted back out.

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -173,7 +173,7 @@ function configure (app, wares, ctx) {
 
     api.get('/entries', query_models, format_entries);
 
-    function echo_query (req, res, next) {
+    function echo_query (req, res) {
       var query = req.query;
       var input = JSON.parse(JSON.stringify(query));
 

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -181,8 +181,9 @@ function configure (app, wares, ctx) {
       if (!query.count) {
         query.count = 10;
       }
+      var model = req.params.model || 'entries';
 
-      res.json({ query: ctx.entries.query_for(query), input: input, params: req.params});
+      res.json({ query: ctx[model].query_for(query), input: input, params: req.params, model: model});
     }
     function query_models (req, res, next) {
       var query = req.query;
@@ -231,13 +232,11 @@ function configure (app, wares, ctx) {
         prepReqModel(req, req.params.model);
         req.query = {find: {_id: req.params.spec}};
       } else {
-        req.params.model = req.params.spec;
         prepReqModel(req, req.params.model);
       }
       next( );
     });
-    api.get('/echo/:spec', echo_query);
-    api.get('/echo', echo_query);
+    api.get('/echo/:model?/:spec?', echo_query);
 
     // Allow previewing your post content, just echos everything you
     // posted back out.

--- a/lib/entries.js
+++ b/lib/entries.js
@@ -123,6 +123,10 @@ function storage(env, ctx) {
     });
   }
 
+  function query_for (opts) {
+    return find_options(opts, storage.queryOpts);
+  }
+
   // closure to represent the API
   function api ( ) {
     // obtain handle usable for querying the collection associated
@@ -137,6 +141,7 @@ function storage(env, ctx) {
   api.create = create;
   api.remove = remove;
   api.persist = persist;
+  api.query_for = query_for;
   api.getEntry = getEntry;
   api.indexedFields = [ 'date', 'type', 'sgv', 'sysTime', 'dateString' ];
   return api;

--- a/lib/entries.js
+++ b/lib/entries.js
@@ -43,7 +43,7 @@ function storage(env, ctx) {
 
       // now just stitch them all together
       limit.call(collection
-          .find(find_options(opts, storage.queryOpts))
+          .find(query_for(opts))
           .sort(sort( ))
       ).toArray(toArray);
     });
@@ -51,7 +51,7 @@ function storage(env, ctx) {
 
   function remove (opts, fn) {
     with_collection(function (err, collection) {
-      collection.remove(find_options(opts, storage.queryOpts), fn);
+      collection.remove(query_for(opts), fn);
     });
   }
 

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -20,7 +20,7 @@ function init (env, ctx) {
   env.mqtt_shared_topic = shared_topic;
 
   mqtt.client = connect(env);
-  var downloads = downloader();
+  var downloads = mqtt.downloads = downloader();
 
   if (mqtt.client) {
     listenForMessages(ctx);
@@ -309,4 +309,5 @@ function iter_mqtt_record_stream (packet, prop, sync) {
   return stream.pipe(es.map(map));
 }
 
+init.downloadProtobuf = downloadProtobuf;
 module.exports = init;

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -217,8 +217,13 @@ function toTimestamp (proto, receiver_time, download_time) {
   return obj;
 }
 
-function timestamp (item) {
-  return toTimestamp(item, receiver_time, download_time.clone( ));
+function timestampFactory (packet) {
+  var receiver_time = packet.receiver_system_time_sec;
+  var download_time = moment(packet.download_timestamp);
+  function timestamp (item) {
+    return toTimestamp(item, receiver_time, download_time.clone( ));
+  }
+  return timestamp;
 }
 
 function timeSort (a, b) {
@@ -226,9 +231,7 @@ function timeSort (a, b) {
 }
 
 function sgvSensorMerge (packet) {
-  var receiver_time = packet.receiver_system_time_sec;
-  var download_time = moment(packet.download_timestamp);
-
+  var timestamp = timestampFactory(packet);
   var sgvs = (packet['sgv'] || []).map(function(sgv) {
     var timestamped = timestamp(sgv);
     return toSGV(sgv, timestamped);

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -130,8 +130,9 @@ function downloader ( ) {
 function downloadProtobuf (msg, topic, downloads, ctx) {
   var b = new Buffer(msg, 'binary');
   console.log('BINARY', b.length, b.toString('hex'));
+  var packet;
   try {
-    var packet = downloads.parse(b);
+    packet = downloads.parse(b);
     if (!packet.type) {
       packet.type = topic;
 
@@ -216,17 +217,17 @@ function toTimestamp (proto, receiver_time, download_time) {
   return obj;
 }
 
+function timestamp (item) {
+  return toTimestamp(item, receiver_time, download_time.clone( ));
+}
+
+function timeSort (a, b) {
+  return a.date - b.date;
+}
+
 function sgvSensorMerge (packet) {
   var receiver_time = packet.receiver_system_time_sec;
   var download_time = moment(packet.download_timestamp);
-
-  function timestamp (item) {
-    return toTimestamp(item, receiver_time, download_time.clone( ));
-  }
-
-  function timeSort (a, b) {
-    return a.date - b.date;
-  }
 
   var sgvs = (packet['sgv'] || []).map(function(sgv) {
     var timestamped = timestamp(sgv);

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -16,6 +16,7 @@ function init (env, ctx) {
   var username = info.auth.split(':').slice(0, -1).join('');
   var shared_topic = '/downloads/' + username + '/#';
   var alias_topic = '/downloads/' + username + '/protobuf';
+  var notification_topic = '/notifications/' + username + '/json';
   env.mqtt_shared_topic = shared_topic;
 
   mqtt.client = connect(env);
@@ -58,10 +59,12 @@ function init (env, ctx) {
 
   mqtt.emitNotification = function emitNotification(notify) {
     console.info('Publishing notification to mqtt: ', notify);
-    mqtt.client.publish('/notifications/json', JSON.stringify(notify), function mqttCallback (err) {
-      if (err) {
-        console.error('Unable to publish notification to MQTT', err);
-      }
+    [notification_topic, '/notifications/json'].forEach(function iter_notify (topic) {
+      mqtt.client.publish(topic, JSON.stringify(notify), function mqttCallback (err) {
+        if (err) {
+          console.error('Unable to publish notification to MQTT', err);
+        }
+      });
     });
   };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -14,11 +14,13 @@ var TWO_DAYS = 172800000;
   * Options for query.
   * Interpret and return the options to use for building our query.
   *
-  * @returns Object Options for create, below.
+  * @returns {Object} Options for create, below.
+```
   * { deltaAgo: <ms> // ms ago to constrain queries missing any query body
     , dateField: "date" // name of field to ensure there is a valid query body
     , walker: <walker-spec> // a mapping of names to types
     }
+```
   */
 function default_options (opts) {
   opts = opts || { };

--- a/lib/treatments.js
+++ b/lib/treatments.js
@@ -36,10 +36,15 @@ function storage (env, ctx) {
 
   function list (opts, fn) {
     return ctx.store.limit.call(api()
-      .find(find_options(opts, storage.queryOpts))
+      .find(query_for(opts))
       .sort(opts && opts.sort || {created_at: -1}), opts)
       .toArray(fn);
   }
+
+  function query_for (opts) {
+    return find_options(opts, storage.queryOpts);
+  }
+
 
   function api ( ) {
     return ctx.store.db.collection(env.treatments_collection);
@@ -47,6 +52,7 @@ function storage (env, ctx) {
 
   api.list = list;
   api.create = create;
+  api.query_for = query_for;
   api.indexedFields = ['created_at', 'eventType', 'insulin', 'carbs', 'glucose'];
   return api;
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -97,6 +97,26 @@ paths:
           description: Invalid input
         "200":
           description: Rejected list of entries.  Empty list is success.
+    delete:
+      tags:
+        - Entries
+      summary: Delete entries matching query.
+      description: "Remove entries, same search syntax as GET."
+      operationId: remove
+      parameters:
+        - name: find
+          in: query
+          description: The query used to find entries, support nested query syntax, for example `find[dateString][$gte]=2015-08-27`.  All find parameters are interpreted as strings.
+          required: false
+          type: string
+        - name: count
+          in: query
+          description: Number of entries to return.
+          required: false
+          type: number
+      responses:
+        "200":
+          description: Empty list is success.
 
   /treatments:
     get:

--- a/tests/mqtt.test.js
+++ b/tests/mqtt.test.js
@@ -23,7 +23,7 @@ describe('mqtt', function ( ) {
     }
     function written (data, fn) {
       self.results.write(data);
-      fn( );
+      setTimeout(fn, 5);
     }
     self.mqtt = require('../lib/mqtt')(self.env, {entries: { persist: outputs, create: written }, devicestatus: { create: written } });
   });

--- a/tests/mqtt.test.js
+++ b/tests/mqtt.test.js
@@ -21,7 +21,11 @@ describe('mqtt', function ( ) {
         self.results.write(err || results);
       });
     }
-    self.mqtt = require('../lib/mqtt')(self.env, {entries: { persist: outputs, create: self.results.write }, devicestatus: { create: self.results.write } });
+    function written (data, fn) {
+      self.results.write(data);
+      fn( );
+    }
+    self.mqtt = require('../lib/mqtt')(self.env, {entries: { persist: outputs, create: written }, devicestatus: { create: written } });
   });
 
   after(function () {


### PR DESCRIPTION
Adds a simple `echo` interface to debug mongo queries:

```
bewest@hither:~/src/nightscout/cgm-remote-monitor$ curl -s -g 'http://localhost:1337/api/v1/echo?count=1000&find[date][$gte]=1'  | json
{
  "query": {
    "date": {
      "$gte": 1
    }
  },
  "input": {
    "count": "1000",
    "find": {
      "date": {
        "$gte": "1"
      }
    }
  },
  "params": {}
}


```

Also tweak swagger, add `delete`, also tweak jsdocs.