### PR TITLE
make errorcode to level mappings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
   * `direction` (BG Direction) - Displays the trend direction.
   * `upbat` (Uploader Battery) - Displays the most recent battery status from the uploader phone.
   * `errorcodes` (CGM Error Codes) - Generates alarms for CGM codes `9` (hourglass) and `10` (???).
+    * Use [extended settings](#extended-settings) to adjust what errorcodes trigger notifications and alarms:
+      * `ERRORCODES_INFO` (`5`) - By default the needs calibration (blood drop) generates an info level notification, set to a space separate list of number or `off` to disable
+      * `ERRORCODES_WARN` (`off`) - By default there are no warning configured, set to a space separate list of numbers or `off` to disable
+      * `ERRORCODES_URGENT` (`9 10`) - By default the hourglass and ??? generate an urgent alarm, set to a space separate list of numbers or `off` to disable
   * `ar2` ([Forcasting using AR2 algorithm](https://github.com/nightscout/nightscout.github.io/wiki/Forecasting)) - Generates alarms based on forecasted values.
     * Enabled by default if no thresholds are set **OR** `ALARM_TYPES` includes `predict`.
     * Use [extended settings](#extended-settings) to adjust AR2 behavior:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
   * `upbat` (Uploader Battery) - Displays the most recent battery status from the uploader phone.
   * `errorcodes` (CGM Error Codes) - Generates alarms for CGM codes `9` (hourglass) and `10` (???).
     * Use [extended settings](#extended-settings) to adjust what errorcodes trigger notifications and alarms:
-      * `ERRORCODES_INFO` (`5`) - By default the needs calibration (blood drop) generates an info level notification, set to a space separate list of number or `off` to disable
+      * `ERRORCODES_INFO` (`1 2 3 4 5 6 7 8`) - By default the needs calibration (blood drop) and other codes below 9 generate an info level notification, set to a space separate list of number or `off` to disable
       * `ERRORCODES_WARN` (`off`) - By default there are no warning configured, set to a space separate list of numbers or `off` to disable
       * `ERRORCODES_URGENT` (`9 10`) - By default the hourglass and ??? generate an urgent alarm, set to a space separate list of numbers or `off` to disable
   * `ar2` ([Forcasting using AR2 algorithm](https://github.com/nightscout/nightscout.github.io/wiki/Forecasting)) - Generates alarms based on forecasted values.

--- a/lib/plugins/errorcodes.js
+++ b/lib/plugins/errorcodes.js
@@ -42,12 +42,11 @@ function init() {
     var code2Level = buildMappingFromSettings(sbx.extendedSettings);
 
     if (lastSGV && now - lastSGV.mills < times.mins(10).msecs && lastSGV.mgdl < 39) {
-
       var errorDisplay = toDisplay(lastSGV.mgdl);
       var pushoverSound = code2PushoverSound[lastSGV.mgdl] || null;
-      var notifyLevel = code2Level[lastSGV.mgdl] || levels.NONE;
+      var notifyLevel = code2Level[lastSGV.mgdl];
 
-      if (notifyLevel > levels.NONE) {
+      if (notifyLevel !== undefined) {
         sbx.notifications.requestNotify({
           level: notifyLevel
           , title: 'CGM Error Code'
@@ -74,12 +73,12 @@ function init() {
       var rawValues = value && value.split(' ') || [];
       _.each(rawValues, function (num) {
         if (!isNaN(num)) {
-          mapping[Number(num)] = level
+          mapping[Number(num)] = level;
         }
       });
     }
 
-    addValuesToMapping(extendedSettings.info || '5', levels.INFO);
+    addValuesToMapping(extendedSettings.info || '1 2 3 4 5 6 7 8', levels.INFO);
     addValuesToMapping(extendedSettings.warn || 'off', levels.WARN);
     addValuesToMapping(extendedSettings.urgent || '9 10', levels.URGENT);
 

--- a/lib/plugins/errorcodes.js
+++ b/lib/plugins/errorcodes.js
@@ -45,7 +45,7 @@ function init() {
 
       var errorDisplay = toDisplay(lastSGV.mgdl);
       var pushoverSound = code2PushoverSound[lastSGV.mgdl] || null;
-      var notifyLevel = code2Level[lastSGV.mgdl] || levels.LOW;
+      var notifyLevel = code2Level[lastSGV.mgdl] || levels.NONE;
 
       if (notifyLevel > levels.NONE) {
         sbx.notifications.requestNotify({

--- a/lib/plugins/errorcodes.js
+++ b/lib/plugins/errorcodes.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var levels = require('../levels');
 var times = require('../times');
 
@@ -22,13 +23,6 @@ function init() {
     , 12: '?RF' //BAD_RF
   };
 
-  //TODO: move notification levels to constants
-  var code2Level = {
-    5: levels.INFO
-    , 9: levels.URGENT
-    , 10: levels.URGENT
-  };
-
   var code2PushoverSound = {
     5: 'intermission'
     , 9: 'alien'
@@ -44,6 +38,8 @@ function init() {
   errorcodes.checkNotifications = function checkNotifications (sbx) {
     var now = Date.now();
     var lastSGV = sbx.lastSGVEntry();
+
+    var code2Level = buildMappingFromSettings(sbx.extendedSettings);
 
     if (lastSGV && now - lastSGV.mills < times.mins(10).msecs && lastSGV.mgdl < 39) {
 
@@ -66,6 +62,32 @@ function init() {
 
     }
   };
+
+  function buildMappingFromSettings (extendedSettings) {
+    var mapping = {};
+
+    function addValuesToMapping (value, level) {
+      if (!value || !value.split) {
+        return [];
+      }
+
+      var rawValues = value && value.split(' ') || [];
+      _.each(rawValues, function (num) {
+        if (!isNaN(num)) {
+          mapping[Number(num)] = level
+        }
+      });
+    }
+
+    addValuesToMapping(extendedSettings.info || '5', levels.INFO);
+    addValuesToMapping(extendedSettings.warn || 'off', levels.WARN);
+    addValuesToMapping(extendedSettings.urgent || '9 10', levels.URGENT);
+
+    return mapping;
+  }
+
+  //for tests
+  errorcodes.buildMappingFromSettings = buildMappingFromSettings;
 
 
   return errorcodes;

--- a/tests/errorcodes.test.js
+++ b/tests/errorcodes.test.js
@@ -56,7 +56,7 @@ describe('errorcodes', function ( ) {
     errorcodes.checkNotifications(sbx);
     should.not.exist(ctx.notifications.findHighestAlarm());
     var info = _.first(ctx.notifications.findUnSnoozeable());
-    info.level.should.equal(levels.LOW);
+    info.level.should.equal(levels.INFO);
     info.pushoverSound.should.equal('intermission');
 
     done();
@@ -64,7 +64,7 @@ describe('errorcodes', function ( ) {
 
   it('should trigger a low notification when code < 9', function (done) {
 
-    for (var i = 0; i < 9; i++) {
+    for (var i = 1; i < 9; i++) {
       ctx.notifications.initRequests();
       ctx.data.sgvs = [{mgdl: i, mills: now}];
 
@@ -84,10 +84,17 @@ describe('errorcodes', function ( ) {
 
   it('have default code to level mappings', function () {
     var mapping = errorcodes.buildMappingFromSettings({});
+    mapping[1].should.equal(levels.INFO);
+    mapping[2].should.equal(levels.INFO);
+    mapping[3].should.equal(levels.INFO);
+    mapping[4].should.equal(levels.INFO);
     mapping[5].should.equal(levels.INFO);
+    mapping[6].should.equal(levels.INFO);
+    mapping[7].should.equal(levels.INFO);
+    mapping[8].should.equal(levels.INFO);
     mapping[9].should.equal(levels.URGENT);
     mapping[10].should.equal(levels.URGENT);
-    _.keys(mapping).length.should.equal(3);
+    _.keys(mapping).length.should.equal(10);
   });
 
   it('allow config of custom code to level mappings', function () {

--- a/tests/errorcodes.test.js
+++ b/tests/errorcodes.test.js
@@ -82,4 +82,23 @@ describe('errorcodes', function ( ) {
     errorcodes.toDisplay(10).should.equal('???');
   });
 
+  it('have default code to level mappings', function () {
+    var mapping = errorcodes.buildMappingFromSettings({});
+    mapping[5].should.equal(levels.INFO);
+    mapping[9].should.equal(levels.URGENT);
+    mapping[10].should.equal(levels.URGENT);
+    _.keys(mapping).length.should.equal(3);
+  });
+
+  it('allow config of custom code to level mappings', function () {
+    var mapping = errorcodes.buildMappingFromSettings({
+      info: 'off'
+      , warn: '9 10'
+      , urgent: 'off'
+    });
+    mapping[9].should.equal(levels.WARN);
+    mapping[10].should.equal(levels.WARN);
+    _.keys(mapping).length.should.equal(2);
+  });
+
 });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -12,7 +12,7 @@ describe('STORAGE', function () {
   });
 
   it('The storage class should be OK.', function (done) {
-    should(require('../lib/storage')).be.ok;
+    should.exist(require('../lib/storage'));
     done();
   });
 


### PR DESCRIPTION
for @ELUTE and everyone else that doesn't want a notification for code 5 (blood drop) just set the new setting `ERRORCODES_INFO="off"`

Warnings and Urgent Alarms can be configured with `ERRORCODES_WARN` and `ERRORCODES_URGENT`

For example `ERRORCODES_URGENT="9 10"`