### PR TITLE
only check if low/high events are enabled for now

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -220,7 +220,7 @@ function init ( ) {
   function isAlarmEventEnabled (notify) {
     var enabled = false;
 
-    if (!notify.eventName) {
+    if ('high' !== notify.eventName && 'low' !== notify.eventName) {
       enabled = true;
     } else if (notify.eventName === 'high' && notify.level === levels.URGENT && settings.alarmUrgentHigh) {
       enabled = true;


### PR DESCRIPTION
Fixed bug causing BWP alarms not to be pushed to pushover or maker.