### PR TITLE
Make DELETE API more usable

### DIFF
--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -246,10 +246,15 @@ function configure (app, wares, ctx) {
     api.get('/entries/:spec', function(req, res, next) {
       if (isId(req.params.spec)) {
         entries.getEntry(req.params.spec, function(err, entry) {
+          if (err) { return next(err); }
           res.entries = [entry];
           res.entries_err = err;
           req.query.find = req.query.find || {};
-          req.query.find.type = entry.type;
+          if (entry) {
+            req.query.find.type = entry.type;
+          } else {
+            res.entries_err = "No such id: '" + req.params.spec + "'";
+          }
           next();
         });
       } else {
@@ -581,12 +586,15 @@ curl -s -g 'http://localhost:1337/api/v1/times/20{14..15}/T{13..18}:{00..15}'.js
         */
       api.delete('/entries/:spec', wares.verifyAuthorization, function (req, res, next) {
         // if ID, prepare to query for one record
-        if (isId(req.params.id)) {
+        if (isId(req.params.spec)) {
           prepReqModel(req, req.params.model);
           req.query = {find: {_id: req.params.spec}};
         } else {
           req.params.model = req.params.spec;
           prepReqModel(req, req.params.model);
+          if (req.query.find.type == '*') {
+            delete req.query.find.type;
+          }
         }
         next( );
       }, delete_records);

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -592,7 +592,7 @@ curl -s -g 'http://localhost:1337/api/v1/times/20{14..15}/T{13..18}:{00..15}'.js
         } else {
           req.params.model = req.params.spec;
           prepReqModel(req, req.params.model);
-          if (req.query.find.type == '*') {
+          if (req.query.find.type === '*') {
             delete req.query.find.type;
           }
         }


### PR DESCRIPTION
Thanks to @MilosKozak for these suggestions.

* Don't crash if lookup by id does not yield any results
* Report errors, if any
* Allow DELETE by ID
* Allow DELETE by wildcard, `*`, to delete all types.