### PR TITLE
When loading profiles from Mongo, sort by the actual field that tells…

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -295,15 +295,12 @@ function loadTreatments (data, ctx, callback) {
 }
 
 function loadProfile (data, ctx, callback) {
-  ctx.profile.list(function (err, results) {
+  ctx.profile.last(function (err, results) {
     if (!err && results) {
-      // There should be only one document in the profile collection with a DIA.  If there are multiple, use the last one.
       var profiles = [];
       results.forEach(function (element) {
         if (element) {
-          if (element.dia) {
             profiles[0] = element;
-          }
         }
       });
       data.profiles = profiles;

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -22,11 +22,11 @@ function storage (collection, ctx) {
   }
 
   function list (fn) {
-    return api( ).find({ }).sort({validfrom: -1}).toArray(fn);
+    return api( ).find({ }).sort({startDate: -1}).toArray(fn);
   }
 
   function last (fn) {
-    return api().find().sort({validfrom: -1}).limit(1).toArray(fn);
+    return api().find().sort({startDate: -1}).limit(1).toArray(fn);
   }
 
   function api () {

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -37,7 +37,7 @@ function storage (collection, ctx) {
   api.create = create;
   api.save = save;
   api.last = last;
-  api.indexedFields = ['validfrom'];
+  api.indexedFields = ['startDate'];
   return api;
 }
 


### PR DESCRIPTION
… when the profile was created. Load only one profile to speed up the process and consume less resources. Removed old check for dia field existence from iob-cob days.