### PR TITLE
Fix delayed carbs

### DIFF
--- a/lib/plugins/cob.js
+++ b/lib/plugins/cob.js
@@ -30,7 +30,8 @@ function init() {
       return {};
     }
 
-    var liverSensRatio = 1;
+    // Adjusted from 1 to 8 to compensate for half of the effect (in adults; much less in kids) of fixing units on the delayedCarbs term
+    var liverSensRatio = 8;
     var totalCOB = 0;
     var lastCarbs = null;
 
@@ -51,10 +52,16 @@ function init() {
         var cCalc = cob.cobCalc(treatment, profile, lastDecayedBy, time);
         var decaysin_hr = (cCalc.decayedBy - time) / 1000 / 60 / 60;
         if (decaysin_hr > -10) {
+          // units: BG
           var actStart = iob.calcTotal(treatments, profile, lastDecayedBy).activity;
           var actEnd = iob.calcTotal(treatments, profile, cCalc.decayedBy).activity;
           var avgActivity = (actStart + actEnd) / 2;
-          var delayedCarbs = avgActivity * liverSensRatio * profile.getSensitivity(treatment.mills) / profile.getCarbRatio(treatment.mills);
+          // These units were wrong:
+          // units: BG^2/g (?) =   BG      *      scalar    *        BG / U                           /        g / U
+          //var delayedCarbs = avgActivity * liverSensRatio * profile.getSensitivity(treatment.mills) / profile.getCarbRatio(treatment.mills);
+          // This is correct:
+          // units:  g     =     BG      *      scalar    /        BG / U                           *        g / U
+          var delayedCarbs = avgActivity * liverSensRatio / profile.getSensitivity(treatment.mills) * profile.getCarbRatio(treatment.mills);
           var delayMinutes = Math.round(delayedCarbs / profile.getCarbAbsorptionRate(treatment.mills) * 60);
           if (delayMinutes > 0) {
             cCalc.decayedBy.setMinutes(cCalc.decayedBy.getMinutes() + delayMinutes);

--- a/lib/plugins/cob.js
+++ b/lib/plugins/cob.js
@@ -60,8 +60,8 @@ function init() {
           // units: BG^2/g (?) =   BG      *      scalar    *        BG / U                           /        g / U
           //var delayedCarbs = avgActivity * liverSensRatio * profile.getSensitivity(treatment.mills) / profile.getCarbRatio(treatment.mills);
           // This is correct:
-          // units:  g     =     BG      *      scalar    /        BG / U                           *        g / U
-          var delayedCarbs = avgActivity * liverSensRatio / profile.getSensitivity(treatment.mills) * profile.getCarbRatio(treatment.mills);
+          // units:  g     =       BG      *      scalar     /          BG / U                           *     g / U
+          var delayedCarbs = ( avgActivity *  liverSensRatio / profile.getSensitivity(treatment.mills) ) * profile.getCarbRatio(treatment.mills);
           var delayMinutes = Math.round(delayedCarbs / profile.getCarbAbsorptionRate(treatment.mills) * 60);
           if (delayMinutes > 0) {
             cCalc.decayedBy.setMinutes(cCalc.decayedBy.getMinutes() + delayMinutes);

--- a/lib/plugins/cob.js
+++ b/lib/plugins/cob.js
@@ -30,7 +30,7 @@ function init() {
       return {};
     }
 
-    // Adjusted from 1 to 8 to compensate for half of the effect (in adults; much less in kids) of fixing units on the delayedCarbs term
+    // TODO: figure out the liverSensRatio that gives the most accurate purple line predictions
     var liverSensRatio = 8;
     var totalCOB = 0;
     var lastCarbs = null;
@@ -56,10 +56,6 @@ function init() {
           var actStart = iob.calcTotal(treatments, profile, lastDecayedBy).activity;
           var actEnd = iob.calcTotal(treatments, profile, cCalc.decayedBy).activity;
           var avgActivity = (actStart + actEnd) / 2;
-          // These units were wrong:
-          // units: BG^2/g (?) =   BG      *      scalar    *        BG / U                           /        g / U
-          //var delayedCarbs = avgActivity * liverSensRatio * profile.getSensitivity(treatment.mills) / profile.getCarbRatio(treatment.mills);
-          // This is correct:
           // units:  g     =       BG      *      scalar     /          BG / U                           *     g / U
           var delayedCarbs = ( avgActivity *  liverSensRatio / profile.getSensitivity(treatment.mills) ) * profile.getCarbRatio(treatment.mills);
           var delayMinutes = Math.round(delayedCarbs / profile.getCarbAbsorptionRate(treatment.mills) * 60);

--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -38,6 +38,7 @@ function init() {
           lastBolus = treatment;
         }
         if (tIOB && tIOB.iobContrib) { totalIOB += tIOB.iobContrib; }
+        // units: BG (mg/dL or mmol/L)
         if (tIOB && tIOB.activityContrib) { totalActivity += tIOB.activityContrib; }
       }
     });
@@ -76,6 +77,7 @@ function init() {
       if (minAgo < peak) {
         var x1 = minAgo / 5 + 1;
         result.iobContrib = treatment.insulin * (1 - 0.001852 * x1 * x1 + 0.001852 * x1);
+        // units: BG (mg/dL)  = (BG/U) *    U insulin     * scalar
         result.activityContrib = sens * treatment.insulin * (2 / dia / 60 / peak) * minAgo;
 
       } else if (minAgo < 180) {


### PR DESCRIPTION
@cjo20 found a problem with my units that turned out to be a bug in the formula for delayedCarbs, where I was multiplying by ISF and dividing by IC ratio, but should've been doing the reverse.  This may account for the problems @jasoncalabrese and others were seeing on children trying to use wip/iob-cob, as that error results in a much bigger effect (6x as large) in children as it does in adults.  For now I have adjusted liverSensRatio from 1 to 8 to compensate for half the 16x difference seen with adult ratios like 40 and 10.

This will mean that the effect of delayedCarb on displayed COB will be less for everyone, but especially for kids.  COB will decay much closer to the straight carb absorption rate, which should be much more intuitive for people using it, and should also result in less likelihood of bolusing too much for any carbs that COB says are delayed, but may not actually be.