### PR TITLE
Fix directional arrows being converted to emoji

### DIFF
--- a/lib/plugins/direction.js
+++ b/lib/plugins/direction.js
@@ -34,8 +34,8 @@ function init() {
       }
 
       sbx.pluginBase.updatePillText(direction, {
-        label: prop && prop.label
-        , directText: true
+        label: prop && prop.label + '&#xfe0e;'
+        , directHTML: true
       });
     }
   };

--- a/lib/plugins/pluginbase.js
+++ b/lib/plugins/pluginbase.js
@@ -61,16 +61,19 @@ function init (majorPills, minorPills, statusPills, bgStatus, tooltip) {
 
     pill.addClass(options.pillClass);
 
-    if (options.directText) {
-      pill.text(options.label);
+    if (options.directHTML) {
+      pill.html(options.label);
     } else {
-      pill.find('label').attr('class', options.labelClass).text(options.label);
-
-      pill.find('em')
-        .attr('class', options.valueClass)
-        .toggle(options.value != null)
-        .text(options.value)
-      ;
+      if (options.directText) {
+        pill.text(options.label);
+      } else {
+        pill.find('label').attr('class', options.labelClass).text(options.label);
+        pill.find('em')
+          .attr('class', options.valueClass)
+          .toggle(options.value != null)
+          .text(options.value)
+        ;
+      }
     }
 
     if (options.info  && options.info.length) {


### PR DESCRIPTION
Fixes iOS converting the direction arrows to Emoji on _most_ iOS versions. Based on googling, some 8.x iOS versions don't support the Unicode "don't convert this glyph" code but do exhibit the conversion behavior. Sorry for the ugly HTML API hack.

