### PR TITLE
Add trend and more pump status data from MiniMed Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
     * `MMCONNECT_MAX_RETRY_DURATION` (`32`) - Maximum number of total seconds to spend retrying failed requests before giving up.
     * `MMCONNECT_SGV_LIMIT` (`24`) - Maximum number of recent sensor glucose values to send to Nightscout on each request.
     * `MMCONNECT_VERBOSE` - Set this to any truthy value to log CareLink request information to the console.
+    * `MMCONNECT_STORE_RAW_DATA` - Set this to any truthy value to store raw data returned from CareLink as `type: "carelink_raw"` database entries (useful for development).
   
  Also see [Pushover](#pushover) and [IFTTT Maker](#ifttt-maker).
  

--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
     * `MMCONNECT_INTERVAL` (`60000` *1 minute*) - Number of milliseconds to wait between requests to the CareLink server.
     * `MMCONNECT_MAX_RETRY_DURATION` (`32`) - Maximum number of total seconds to spend retrying failed requests before giving up.
     * `MMCONNECT_SGV_LIMIT` (`24`) - Maximum number of recent sensor glucose values to send to Nightscout on each request.
-    * `MMCONNECT_VERBOSE` - Set this to any truthy value to log CareLink request information to the console.
-    * `MMCONNECT_STORE_RAW_DATA` - Set this to any truthy value to store raw data returned from CareLink as `type: "carelink_raw"` database entries (useful for development).
+    * `MMCONNECT_VERBOSE` - Set this to "true" to log CareLink request information to the console.
+    * `MMCONNECT_STORE_RAW_DATA` - Set this to "true" to store raw data returned from CareLink as `type: "carelink_raw"` database entries (useful for development).
   
  Also see [Pushover](#pushover) and [IFTTT Maker](#ifttt-maker).
  

--- a/lib/plugins/mmconnect.js
+++ b/lib/plugins/mmconnect.js
@@ -19,7 +19,7 @@ function makeRunner_ (env, entries) {
   var client = connect.carelink.Client(options);
   connect.logger.setVerbose(options.verbose);
 
-  var handleData = makeHandler_(entries, makeRecentSgvFilter_(), options.storeRawData);
+  var handleData = makeHandler_(entries, options.sgvLimit, makeRecentSgvFilter_(), options.storeRawData);
 
   return function run () {
     setInterval(function() {
@@ -40,12 +40,12 @@ function getOptions_ (env) {
   };
 }
 
-function makeHandler_ (entries, filter, storeRawData) {
+function makeHandler_ (entries, sgvLimit, filter, storeRawData) {
   return function handleCarelinkData (err, data) {
     if (err) {
       console.error('MiniMed Connect error: ' + err);
     } else {
-      var transformed = connect.transform(data);
+      var transformed = connect.transform(data, sgvLimit);
 
       if (storeRawData && transformed.length) {
         transformed.push(rawDataEntry_(data));

--- a/lib/plugins/mmconnect.js
+++ b/lib/plugins/mmconnect.js
@@ -19,7 +19,7 @@ function makeRunner_ (env, entries) {
   var client = connect.carelink.Client(options);
   connect.logger.setVerbose(options.verbose);
 
-  var handleData = makeHandler_(entries, options.storeRawData);
+  var handleData = makeHandler_(entries, makeRecentSgvFilter_(), options.storeRawData);
 
   return function run () {
     setInterval(function() {
@@ -40,7 +40,7 @@ function getOptions_ (env) {
   };
 }
 
-function makeHandler_ (entries, storeRawData) {
+function makeHandler_ (entries, filter, storeRawData) {
   return function handleCarelinkData (err, data) {
     if (err) {
       console.error('MiniMed Connect error: ' + err);
@@ -51,12 +51,38 @@ function makeHandler_ (entries, storeRawData) {
         transformed.push(rawDataEntry_(data));
       }
 
-      entries.create(transformed, function afterCreate (err) {
+      // If we blindly upsert the SGV entries, we will lose trend data for
+      // entries we've already stored, since all SGVs from CareLink except
+      // the most recent are missing trend data.
+      var filtered = filter(transformed);
+
+      entries.create(filtered, function afterCreate (err) {
         if (err) {
           console.error('MiniMed Connect storage error: ' + err);
         }
       });
     }
+  };
+}
+
+function makeRecentSgvFilter_ () {
+  var lastSgvDate = 0;
+
+  return function filter (entries) {
+    var out = [];
+
+    entries.forEach(function(entry) {
+      if (entry['type'] !== 'sgv' || entry['date'] > lastSgvDate) {
+        out.push(entry);
+      }
+    });
+
+    out.filter(function(e) { return e['type'] === 'sgv'; })
+      .forEach(function(e) {
+        lastSgvDate = Math.max(lastSgvDate, e['date']);
+      });
+
+    return out;
   };
 }
 
@@ -83,8 +109,7 @@ function rawDataEntry_ (data) {
 module.exports = {
   init: init
   // exposed for testing
-  , makeRunner_: makeRunner_
   , getOptions_: getOptions_
-  , makeHandler_: makeHandler_
+  , makeRecentSgvFilter_: makeRecentSgvFilter_
   , rawDataEntry_: rawDataEntry_
 };

--- a/lib/plugins/mmconnect.js
+++ b/lib/plugins/mmconnect.js
@@ -1,7 +1,8 @@
 /* jshint node: true */
 'use strict';
 
-var connect = require('minimed-connect-to-nightscout');
+var _ = require('lodash'),
+  connect = require('minimed-connect-to-nightscout');
 
 function init (env, entries) {
   if (env.extendedSettings.mmconnect && env.extendedSettings.mmconnect.userName && env.extendedSettings.mmconnect.password) {
@@ -35,10 +36,6 @@ function getOptions_ (env) {
     , interval: parseInt(env.extendedSettings.mmconnect.interval || 60*1000, 10)
     , maxRetryDuration: parseInt(env.extendedSettings.mmconnect.maxRetryDuration || 32, 10)
     , verbose: !!env.extendedSettings.mmconnect.verbose
-
-    // TODO(@mddub|2015-10-15): remove
-    // This is a temporary config variable to enable beta testers to store raw
-    // CareLink JSON in Mongo so we can learn what values it can contain.
     , storeRawData: !!env.extendedSettings.mmconnect.storeRawData
   };
 }
@@ -50,22 +47,8 @@ function makeHandler_ (entries, storeRawData) {
     } else {
       var transformed = connect.transform(data);
 
-      // TODO(@mddub|2015-10-15): remove
       if (storeRawData && transformed.length) {
-
-        // redact PII
-        data['firstName'] = data['lastName'] = data['medicalDeviceSerialNumber'] = '<redacted>';
-
-        // trim the default 288 sgvs returned by carelink
-        if (data['sgs'] && data['sgs'] instanceof Array) {
-          data['sgs'] = data['sgs'].slice(Math.max(0, data['sgs'].length - 6));
-        }
-
-        transformed.push({
-          'date': transformed[0]['date']
-          , 'type': 'carelink_raw'
-          , 'data': data
-        });
+        transformed.push(rawDataEntry_(data));
       }
 
       entries.create(transformed, function afterCreate (err) {
@@ -77,10 +60,31 @@ function makeHandler_ (entries, storeRawData) {
   };
 }
 
+function rawDataEntry_ (data) {
+  var cleansed = _.cloneDeep(data);
+
+  // redact PII
+  cleansed['firstName'] = cleansed['lastName'] = cleansed['medicalDeviceSerialNumber'] = '<redacted>';
+
+  // trim the default 288 sgvs returned by carelink
+  if (cleansed['sgs'] && cleansed['sgs'] instanceof Array) {
+    cleansed['sgs'] = cleansed['sgs'].slice(Math.max(0, cleansed['sgs'].length - 6));
+  }
+
+  var timestamp = data['lastMedicalDeviceDataUpdateServerTime'];
+  return {
+    'date': timestamp
+    , 'dateString': new Date(timestamp).toISOString()
+    , 'type': 'carelink_raw'
+    , 'data': cleansed
+  };
+}
+
 module.exports = {
   init: init
   // exposed for testing
   , makeRunner_: makeRunner_
   , getOptions_: getOptions_
   , makeHandler_: makeHandler_
+  , rawDataEntry_: rawDataEntry_
 };

--- a/lib/plugins/mmconnect.js
+++ b/lib/plugins/mmconnect.js
@@ -6,20 +6,20 @@ var _ = require('lodash'),
 
 function init (env, entries) {
   if (env.extendedSettings.mmconnect && env.extendedSettings.mmconnect.userName && env.extendedSettings.mmconnect.password) {
-    return {run: makeRunner_(env, entries)};
+    return {run: makeRunner(env, entries)};
   } else {
     console.info('MiniMed Connect not enabled');
     return null;
   }
 }
 
-function makeRunner_ (env, entries) {
-  var options = getOptions_(env);
+function makeRunner (env, entries) {
+  var options = getOptions(env);
 
   var client = connect.carelink.Client(options);
   connect.logger.setVerbose(options.verbose);
 
-  var handleData = makeHandler_(entries, options.sgvLimit, makeRecentSgvFilter_(), options.storeRawData);
+  var handleData = makeHandler_(entries, options.sgvLimit, makeRecentSgvFilter(), options.storeRawData);
 
   return function run () {
     setInterval(function() {
@@ -28,7 +28,7 @@ function makeRunner_ (env, entries) {
   };
 }
 
-function getOptions_ (env) {
+function getOptions (env) {
   return {
     username: env.extendedSettings.mmconnect.userName
     , password: env.extendedSettings.mmconnect.password
@@ -48,7 +48,7 @@ function makeHandler_ (entries, sgvLimit, filter, storeRawData) {
       var transformed = connect.transform(data, sgvLimit);
 
       if (storeRawData && transformed.length) {
-        transformed.push(rawDataEntry_(data));
+        transformed.push(rawDataEntry(data));
       }
 
       // If we blindly upsert the SGV entries, we will lose trend data for
@@ -65,7 +65,7 @@ function makeHandler_ (entries, sgvLimit, filter, storeRawData) {
   };
 }
 
-function makeRecentSgvFilter_ () {
+function makeRecentSgvFilter () {
   var lastSgvDate = 0;
 
   return function filter (entries) {
@@ -86,7 +86,7 @@ function makeRecentSgvFilter_ () {
   };
 }
 
-function rawDataEntry_ (data) {
+function rawDataEntry (data) {
   var cleansed = _.cloneDeep(data);
 
   // redact PII
@@ -109,7 +109,7 @@ function rawDataEntry_ (data) {
 module.exports = {
   init: init
   // exposed for testing
-  , getOptions_: getOptions_
-  , makeRecentSgvFilter_: makeRecentSgvFilter_
-  , rawDataEntry_: rawDataEntry_
+  , getOptions: getOptions
+  , makeRecentSgvFilter: makeRecentSgvFilter
+  , rawDataEntry: rawDataEntry
 };

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jquery": "^2.1.4",
     "lodash": "^3.9.1",
     "long": "~2.2.3",
-    "minimed-connect-to-nightscout": "git://github.com/mddub/minimed-connect-to-nightscout#v0.2.2",
+    "minimed-connect-to-nightscout": "git://github.com/mddub/minimed-connect-to-nightscout#v0.2.4",
     "moment": "2.10.6",
     "moment-timezone": "^0.4.0",
     "mongodb": "^2.0.42",

--- a/tests/mmconnect.test.js
+++ b/tests/mmconnect.test.js
@@ -57,6 +57,44 @@ describe('mmconnect', function () {
 
   });
 
+  describe('makeRecentSgvFilter_()', function () {
+    function sgv(date) {
+      return {type: 'sgv', date: date};
+    }
+    function pumpStatus(date) {
+      return {type: 'pump_status', date: date};
+    }
+
+    it('should return a stateful filter which discards sgvs older than the most recent one seen', function() {
+      var filter = mmconnect.makeRecentSgvFilter_();
+
+      filter([2, 3, 4].map(sgv)).length.should.equal(3);
+
+      filter([2, 3, 4].map(sgv)).length.should.equal(0);
+
+      var filtered = filter([1, 2, 3, 4, 5, 6].map(sgv));
+      filtered.length.should.equal(2);
+      _.pluck(filtered, 'date').should.containEql(5);
+      _.pluck(filtered, 'date').should.containEql(6);
+    });
+
+    it('should return a stateful filter which allows non-sgv entries to be old', function() {
+      var filter = mmconnect.makeRecentSgvFilter_();
+
+      filter([2, 3, 4].map(sgv)).length.should.equal(3);
+
+      filter([1, 2, 3, 4, 5].map(pumpStatus)).length.should.equal(5);
+
+      var filtered = filter(
+        [1, 2, 3, 4, 5].map(pumpStatus).concat(
+          [3, 4, 5, 6, 7].map(sgv)
+        )
+      );
+      _.filter(filtered, {type: 'pump_status'}).length.should.equal(5);
+      _.filter(filtered, {type: 'sgv'}).length.should.equal(3);
+    });
+  });
+
   describe('rawDataEntry_()', function () {
     it('should generate a "carelink_raw" entry with sgs truncated and PII redacted', function () {
       var data = {

--- a/tests/mmconnect.test.js
+++ b/tests/mmconnect.test.js
@@ -43,9 +43,9 @@ describe('mmconnect', function () {
   });
 
 
-  describe('getOptions_()', function () {
+  describe('getOptions()', function () {
     it('should set the carelink client config from env', function () {
-      mmconnect.getOptions_(env).should.have.properties({
+      mmconnect.getOptions(env).should.have.properties({
         username: 'nightscout'
         , password: 'wearenotwaiting'
         , sgvLimit: 99
@@ -57,7 +57,7 @@ describe('mmconnect', function () {
 
   });
 
-  describe('makeRecentSgvFilter_()', function () {
+  describe('makeRecentSgvFilter()', function () {
     function sgv(date) {
       return {type: 'sgv', date: date};
     }
@@ -66,7 +66,7 @@ describe('mmconnect', function () {
     }
 
     it('should return a stateful filter which discards sgvs older than the most recent one seen', function() {
-      var filter = mmconnect.makeRecentSgvFilter_();
+      var filter = mmconnect.makeRecentSgvFilter();
 
       filter([2, 3, 4].map(sgv)).length.should.equal(3);
 
@@ -79,7 +79,7 @@ describe('mmconnect', function () {
     });
 
     it('should return a stateful filter which allows non-sgv entries to be old', function() {
-      var filter = mmconnect.makeRecentSgvFilter_();
+      var filter = mmconnect.makeRecentSgvFilter();
 
       filter([2, 3, 4].map(sgv)).length.should.equal(3);
 
@@ -95,7 +95,7 @@ describe('mmconnect', function () {
     });
   });
 
-  describe('rawDataEntry_()', function () {
+  describe('rawDataEntry()', function () {
     it('should generate a "carelink_raw" entry with sgs truncated and PII redacted', function () {
       var data = {
         'lastMedicalDeviceDataUpdateServerTime': 1445471797479
@@ -104,7 +104,7 @@ describe('mmconnect', function () {
         , 'lastName': 'sensitive'
         , 'medicalDeviceSerialNumber': 'sensitive'
       };
-      var entry = mmconnect.rawDataEntry_(data);
+      var entry = mmconnect.rawDataEntry(data);
       entry.should.have.properties({
         'date': 1445471797479
         , 'type': 'carelink_raw'


### PR DESCRIPTION
Confirmed working with two beta testers.

Changes:
* Add new keys `trend` and `direction` to sgv entries.
* Add new keys `calibStatus`, `conduitSensorInRange`, `sensorDurationHours`, `sensorState`, `timeToNextCalibHours` to pump_status entries.
* Make `MMCONNECT_STORE_RAW_DATA` a permanent extended setting since it will be necessary for future work and debugging (in particular, supporting mmol/L and including `lastAlarm`).
* Add code to filter Connect data so that we don't overwrite already-submitted sgvs and lose trend data for past sgv entries (CareLink includes a trend only for the last sgv).

Notes:
* Most of the changes are in [minimed-connect-to-nightscout](https://github.com/mddub/minimed-connect-to-nightscout/commits/master).
* My understanding of the data is based on [this basic analysis](https://gist.github.com/mddub/5e4a585508c93249eb51) of ~3000 `carelink_raw` entries from a tester's NS data. Here's [an example carelink_raw entry](https://gist.github.com/mddub/9342305b89e67fe7d96e).

Nightscout entries:
```json
[
   {
      "type" : "pump_status",
      "device" : "connect://paradigm",
      "date" : 1445536512677,
      "dateString" : "2015-10-22T17:55:12.677Z",
      "activeInsulin" : 1.75,
      "calibStatus" : "LESS_THAN_NINE_HRS",
      "conduitBatteryLevel" : 46,
      "conduitInRange" : true,
      "conduitMedicalDeviceInRange" : true,
      "conduitSensorInRange" : true,
      "medicalDeviceBatteryLevelPercent" : 50,
      "reservoirAmount" : 49,
      "reservoirLevelPercent" : 50,
      "sensorDurationHours" : 114,
      "sensorState" : "NORMAL",
      "timeToNextCalibHours" : 6
   },
   {
      "type" : "sgv",
      "device" : "connect://paradigm",
      "date" : 1445536260000,
      "dateString" : "2015-10-22T17:51:00.000Z",
      "direction" : "SingleDown",
      "sgv" : 121,
      "trend" : 6
   }
]
```