### PR TITLE
add mongodb connect retries

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -27,23 +27,28 @@ function init (env, cb, forceNewConnection) {
       var timeout =  30 * 1000;
       var options = { replset: { socketOptions: { connectTimeoutMS : timeout, socketTimeoutMS : timeout }}};
 
-      MongoClient.connect(env.mongo, options, function connected(err, db) {
-        if (err) {
-          console.log('Error connecting to MongoDB, ERROR: %j', err);
-          throw err;
-        } else {
-          console.log('Successfully established a connected to MongoDB');
-        }
+      var connect_with_retry = function(i) {
+        return MongoClient.connect(env.mongo, options, function connected(err, db) {
+          if (err) {
+            if (i>20) {
+              // Abort after retrying for more than 10 minutes
+              throw 'Error connecting to MongoDB, stopping the retry loop and aborting...';
+            }
+            console.log('Error connecting to MongoDB: %j - retrying in ' + i*3 + ' sec', err);
+            setTimeout(connect_with_retry, i*3000, i+1);
+          } else {
+            console.log('Successfully established a connected to MongoDB');
+            connection = db;
+            mongo.db = connection;
+            // If there is a valid callback, then invoke the function to perform the callback
 
-        connection = db;
-
-        mongo.db = connection;
-
-        // If there is a valid callback, then invoke the function to perform the callback
-        if (cb && cb.call) {
-          cb(err, mongo);
-        }
-      });
+            if (cb && cb.call) {
+              cb(err, mongo);
+            }
+          }
+        });
+      };
+      connect_with_retry(1);
     }
   }
 


### PR DESCRIPTION
This PR adds linear backoff retries for the MongoDB connections. It fixes https://github.com/nightscout/nightscout-docker/issues/2 and other deployments where the NightScout code tried to connect to the database before this is ready to accept connections.

Without this, the majority of the `docker-compose up` tries lead to errors like:

```bash
nightscout_1 | Setting up new connection to MongoDB
nightscout_1 | GIT HEAD 24b674e
nightscout_1 | Error connecting to MongoDB, ERROR: {"name":"MongoError","message":"auth failed","ok":0,"errmsg":"auth failed","code":18}
nightscout_1 | 
nightscout_1 | /home/node/app/node_modules/mongodb/lib/mongo_client.js:447
```

or

```bash
nightscout_1 | Setting up new connection to MongoDB
nightscout_1 | GIT HEAD 24b674e
nightscout_1 | Error connecting to MongoDB, ERROR: {"name":"MongoError","message":"connect ECONNREFUSED"}
nightscout_1 | 
nightscout_1 | /home/node/app/node_modules/mongodb/lib/server.js:235
```