### PR TITLE
Fix logic that determines npm version to use

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -78,7 +78,7 @@ selectNodeVersion () {
       exitWithMessageOnError "getting node version failed"
     fi
     
-    if [[ -e "$DEPLOYMENT_TEMP/.tmp" ]]; then
+    if [[ -e "$DEPLOYMENT_TEMP/__npmVersion.tmp" ]]; then
       NPM_JS_PATH=`cat "$DEPLOYMENT_TEMP/__npmVersion.tmp"`
       exitWithMessageOnError "getting npm version failed"
     fi


### PR DESCRIPTION
This was caused by a bug in an older version of kuduscript (see https://github.com/projectkudu/KuduScript/issues/35). The bug has been fixed for a while, but once you generate your custom deploy.sh with the bug in it, you have to hand fix it, which is what this patch does.