### PR TITLE
Fix temp basal rendering for Firefox

### DIFF
--- a/lib/client/chart.js
+++ b/lib/client/chart.js
@@ -161,7 +161,6 @@ function init (client, d3, $) {
     .attr('class', 'chartContainer');
 
   chart.basals = chart.charts.append('g').attr('class', 'chart-basals');
-  chart.basals.attr('display','none');
 
   chart.focus = chart.charts.append('g').attr('class', 'chart-focus');
   chart.drag = chart.focus.append('g').attr('class', 'drag-area');


### PR DESCRIPTION
On Firefox, if there are any temp basals in the last 3 hours, even if "Render Basal" is "None", then the whole chart (SGVs, etc.) fails to render.

If the basal element starts as `display: none`, then attempting to call getBBox on its child elements ([to hide basal text when it doesn't fit][1]) will fail on Firefox due to a long-standing implementation issue which does not allow computing the bounding box of an unrendered SVG element:

https://bugzilla.mozilla.org/show_bug.cgi?id=612118

[1]: https://github.com/nightscout/cgm-remote-monitor/blob/49432c9/lib/client/renderer.js#L709