### PR TITLE
Split to three packets

### DIFF
--- a/lib/data/ddata.js
+++ b/lib/data/ddata.js
@@ -32,6 +32,7 @@ function init( ) {
     var result = {
       first: { }
       , rest: { }
+      , last: { }
     };
     
     function recent (item) {
@@ -42,7 +43,7 @@ function init( ) {
       return item.mills >= time - max;
     }
       
-    function partition (field, filter) {
+    function partition (field, filter, last) {
       var data;
       if (filter) {
         data = ddata[field].filter(filterMax);
@@ -52,17 +53,26 @@ function init( ) {
       
       var parts = _.partition(data, recent);
       result.first[field] = parts[0];
-      result.rest[field] = parts[1];
+      
+      if (last) {
+         result.last[field] = parts[1];
+      } else {      
+        result.rest[field] = parts[1];
+     }
     }
 
-    partition('treatments', false);
-    partition('devicestatus', true);
+    partition('treatments', false, false);
+    partition('devicestatus', true, true);
 
     result.first.sgvs = ddata.sgvs.filter(filterMax);
     result.first.cals = ddata.cals;
     result.first.profiles = ddata.profiles;
 
     result.rest.mbgs = ddata.mbgs.filter(filterMax);
+
+     console.log('results.first size', JSON.stringify(result.first).length,'bytes');
+     console.log('results.rest size', JSON.stringify(result.rest).length,'bytes');
+     console.log('results.last size', JSON.stringify(result.last).length,'bytes');
 
     return result;
   };

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -372,6 +372,12 @@ function init (env, ctx, server) {
               split.rest.delta = true;
               socket.emit('dataUpdate', split.rest);
             }, 500);
+
+            setTimeout(function sendTheLast() {
+              split.last.delta = true;
+              socket.emit('dataUpdate', split.last);
+            }, 10000);
+
           }
         }
         console.log(LOG_WS + 'Authetication ID: ',socket.client.id, ' client: ', clientType, ' history: ' + history);


### PR DESCRIPTION
Further improves performance at least on iOS, as this allows the client to fully render the first view before the huge status update packet is sent