### PR TITLE
Show IOB from devicestatus when available (OpenAPS or MM Connect)

### DIFF
--- a/lib/client/boluscalc.js
+++ b/lib/client/boluscalc.js
@@ -390,14 +390,14 @@ function init(client, $, plugins) {
     // Load IOB
     record.iob = 0;
     if ($('#bc_useiob').is(':checked')) {
-      record.iob = roundTo(iob.calcTotal(client.sbx.data.treatments, client.sbx.data.profile, record.eventTime, record.profile).iob, 0.01);
+      record.iob = roundTo(iob.calcTotal(client.sbx.data.treatments, client.sbx.data.devicestatus, client.sbx.data.profile, record.eventTime, record.profile).iob, 0.01);
     }
 
     // Load COB
     record.cob = 0;
     record.insulincob = 0;
     if ($('#bc_usecob').is(':checked')) {
-      record.cob = roundTo(cob.cobTotal(client.sbx.data.treatments, client.sbx.data.profile, record.eventTime, record.profile).cob, 0.01);
+      record.cob = roundTo(cob.cobTotal(client.sbx.data.treatments, client.sbx.data.devicestatus, client.sbx.data.profile, record.eventTime, record.profile).cob, 0.01);
       record.insulincob = roundTo(record.cob / ic, 0.01);
     }
     

--- a/lib/pebble.js
+++ b/lib/pebble.js
@@ -94,7 +94,7 @@ function addExtraData (first, req, sbx) {
 
   function addIOB() {
     if (req.iob) {
-      var iobResult = iob.calcTotal(data.treatments, data.profile, Date.now());
+      var iobResult = iob.calcTotal(data.treatments, data.devicestatus, data.profile, Date.now());
       if (iobResult) {
         first.iob = iobResult.display;
       }

--- a/lib/pebble.js
+++ b/lib/pebble.js
@@ -96,7 +96,7 @@ function addExtraData (first, req, sbx) {
     if (req.iob) {
       var iobResult = iob.calcTotal(data.treatments, data.devicestatus, data.profile, Date.now());
       if (iobResult) {
-        first.iob = iobResult.display;
+        first.iob = iobResult.display || 0;
       }
       
       sbx.properties.iob = iobResult;

--- a/lib/plugins/boluswizardpreview.js
+++ b/lib/plugins/boluswizardpreview.js
@@ -119,7 +119,7 @@ function init() {
     }
 
     var profile = sbx.data.profile;
-    var iob = results.iob = sbx.properties.iob.iob;
+    var iob = results.iob = sbx.properties.iob.iob || 0;
 
     results.effect = iob * profile.getSensitivity(sbx.time);
     results.outcome = scaled - results.effect;

--- a/lib/plugins/cob.js
+++ b/lib/plugins/cob.js
@@ -14,11 +14,11 @@ function init() {
 
   cob.setProperties = function setProperties(sbx) {
     sbx.offerProperty('cob', function setCOB ( ) {
-      return cob.cobTotal(sbx.data.treatments, sbx.data.profile, sbx.time);
+      return cob.cobTotal(sbx.data.treatments, sbx.data.devicestatus, sbx.data.profile, sbx.time);
     });
   };
 
-  cob.cobTotal = function cobTotal(treatments, profile, time, spec_profile) {
+  cob.cobTotal = function cobTotal(treatments, devicestatus, profile, time, spec_profile) {
 
     if (!profile || !profile.hasData()) {
       console.warn('For the COB plugin to function you need a treatment profile');
@@ -26,7 +26,7 @@ function init() {
     }
 
     if (!profile.getSensitivity(time, spec_profile) || !profile.getCarbRatio(time, spec_profile)) {
-      console.warn('For the CPB plugin to function your treatment profile must have both sens and carbratio fields');
+      console.warn('For the COB plugin to function your treatment profile must have both sens and carbratio fields');
       return {};
     }
 
@@ -53,8 +53,8 @@ function init() {
         var decaysin_hr = (cCalc.decayedBy - time) / 1000 / 60 / 60;
         if (decaysin_hr > -10) {
           // units: BG
-          var actStart = iob.calcTotal(treatments, profile, lastDecayedBy, spec_profile).activity;
-          var actEnd = iob.calcTotal(treatments, profile, cCalc.decayedBy, spec_profile).activity;
+          var actStart = iob.calcTotal(treatments, devicestatus, profile, lastDecayedBy, spec_profile).activity;
+          var actEnd = iob.calcTotal(treatments, devicestatus, profile, cCalc.decayedBy, spec_profile).activity;
           var avgActivity = (actStart + actEnd) / 2;
           // units:  g     =       BG      *      scalar     /          BG / U                           *     g / U
           var delayedCarbs = ( avgActivity *  liverSensRatio / profile.getSensitivity(treatment.mills, spec_profile) ) * profile.getCarbRatio(treatment.mills, spec_profile);

--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -160,8 +160,10 @@ function init() {
       info.push({ label: 'Device', value: prop.device });
     }
 
+    var value = (prop.display !== undefined ? sbx.roundInsulinForDisplayFormat(prop.display) : '---') + 'U';
+
     sbx.pluginBase.updatePillText(iob, {
-      value: sbx.roundInsulinForDisplayFormat(prop.display) + 'U'
+      value: value
       , label: 'IOB'
       , info: info
     });

--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -14,12 +14,11 @@ function init() {
 
   iob.setProperties = function setProperties(sbx) {
     sbx.offerProperty('iob', function setIOB ( ) {
-      return iob.calcTotal(sbx.data.treatments, sbx.data.profile, sbx.time);
+      return iob.calcTotal(sbx.data.treatments, sbx.data.devicestatus, sbx.data.profile, sbx.time);
     });
   };
 
-  iob.calcTotal = function calcTotal(treatments, profile, time, spec_profile) {
-
+  iob.calcTotal = function calcTotal(treatments, devicestatus, profile, time, spec_profile) {
     var totalIOB = 0
       , totalActivity = 0;
 
@@ -82,7 +81,7 @@ function init() {
 
       } else if (minAgo < 180) {
         var x2 = (minAgo - 75) / 5;
-        result.iobContrib = treatment.insulin * (0.001323 * x2 * x2 - .054233 * x2 + .55556);
+        result.iobContrib = treatment.insulin * (0.001323 * x2 * x2 - 0.054233 * x2 + 0.55556);
         result.activityContrib = sens * treatment.insulin * (2 / dia / 60 - (minAgo - peak) * 2 / dia / 60 / (60 * dia - peak));
       }
 

--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -12,6 +12,8 @@ function init() {
     , pluginType: 'pill-major'
   };
 
+  iob.RECENCY_THRESHOLD = 30 * 60 * 1000;
+
   iob.setProperties = function setProperties(sbx) {
     sbx.offerProperty('iob', function setIOB ( ) {
       return iob.calcTotal(sbx.data.treatments, sbx.data.devicestatus, sbx.data.profile, sbx.time);
@@ -19,14 +21,63 @@ function init() {
   };
 
   iob.calcTotal = function calcTotal(treatments, devicestatus, profile, time, spec_profile) {
-    var totalIOB = 0
-      , totalActivity = 0;
-
-    if (!treatments) { return {}; }
-
     if (time === undefined) {
       time = Date.now();
     }
+
+    var lastDevicestatus;
+    if (devicestatus && devicestatus.length) {
+      devicestatus.forEach(function(devicestatusEntry) {
+        if (devicestatusEntry.mills <= time && (!lastDevicestatus || devicestatusEntry.mills > lastDevicestatus.mills)) {
+          lastDevicestatus = devicestatusEntry;
+        }
+      });
+    }
+
+    var result = {};
+    if (lastDevicestatus !== undefined && time - lastDevicestatus.mills <= iob.RECENCY_THRESHOLD) {
+      result = iob.fromDeviceStatus(lastDevicestatus);
+    }
+    if (_.isEmpty(result) && treatments !== undefined && treatments.length) {
+      result = iob.fromTreatments(treatments, profile, time, spec_profile);
+    }
+    return addDisplay(result);
+  };
+
+  function addDisplay(iob) {
+    if (_.isEmpty(iob)) {
+      return {};
+    }
+    var display = utils.toFixed(iob.iob);
+    return _.merge(iob, {
+      display: display
+      , displayLine: 'IOB: ' + display + 'U'
+    });
+  }
+
+  iob.fromDeviceStatus = function fromDeviceStatus(devicestatusEntry) {
+    if (_.get(devicestatusEntry, 'openaps.iob.iob') !== undefined) {
+      return {
+        iob: devicestatusEntry.openaps.iob.iob
+        , basaliob: devicestatusEntry.openaps.iob.basaliob
+        , activity: devicestatusEntry.openaps.iob.activity
+        , source: 'OpenAPS'
+        , device: devicestatusEntry.device
+      };
+    } else if (_.get(devicestatusEntry, 'pump.iob') !== undefined) {
+      return {
+        iob: devicestatusEntry.pump.iob
+        , source: devicestatusEntry.connect !== undefined ? 'MM Connect' : undefined
+        , device: devicestatusEntry.device
+      };
+    } else {
+      return {};
+    }
+  };
+
+  iob.fromTreatments = function fromTreatments(treatments, profile, time, spec_profile) {
+    var totalIOB = 0
+      , totalActivity = 0;
 
     var lastBolus = null;
 
@@ -42,13 +93,11 @@ function init() {
       }
     });
 
-    var display = utils.toFixed(totalIOB);
     return {
       iob: totalIOB
-      , display: display
-      , displayLine: 'IOB: ' + display + 'U'
       , activity: totalActivity
       , lastBolus: lastBolus
+      , source: 'Care Portal'
     };
   };
 
@@ -92,14 +141,23 @@ function init() {
   };
 
   iob.updateVisualisation = function updateVisualisation(sbx) {
-    var info = null;
+    var info = [];
 
     var prop = sbx.properties.iob;
 
-    if (prop && prop.lastBolus) {
+    if (prop.lastBolus) {
       var when = moment(prop.lastBolus.mills).format('lll');
       var amount = sbx.roundInsulinForDisplayFormat(Number(prop.lastBolus.insulin)) + 'U';
-      info = [{label: 'Last Bolus', value: amount + ' @ ' + when }];
+      info.push({ label: 'Last Bolus', value: amount + ' @ ' + when });
+    }
+    if (prop.basaliob !== undefined) {
+      info.push({ label: 'Basal IOB', value: prop.basaliob.toFixed(2) });
+    }
+    if (prop.source !== undefined) {
+      info.push({ label: 'Source', value: prop.source });
+    }
+    if (prop.device !== undefined) {
+      info.push({ label: 'Device', value: prop.device });
     }
 
     sbx.pluginBase.updatePillText(iob, {

--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -45,7 +45,7 @@ function init() {
   };
 
   function addDisplay(iob) {
-    if (_.isEmpty(iob)) {
+    if (_.isEmpty(iob) || iob.iob === undefined) {
       return {};
     }
     var display = utils.toFixed(iob.iob);
@@ -65,8 +65,10 @@ function init() {
         , device: devicestatusEntry.device
       };
     } else if (_.get(devicestatusEntry, 'pump.iob') !== undefined) {
+      var iob = devicestatusEntry.pump.iob.iob;
+      iob = iob !== undefined ? iob : devicestatusEntry.pump.iob.bolusiob;
       return {
-        iob: devicestatusEntry.pump.iob
+        iob: iob
         , source: devicestatusEntry.connect !== undefined ? 'MM Connect' : undefined
         , device: devicestatusEntry.device
       };

--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -283,14 +283,14 @@ daytoday.report = function report_daytoday(datastorage,sorteddaystoshow,options)
     cobpolyline += (xScale2(moment(from)) + padding.left) + ',' + (yCarbsScale(0) + padding.top) + ' ';
     for (var dt=moment(from); dt < to; dt.add(5, 'minutes')) {
       if (options.iob) {
-        var iob = Nightscout.plugins('iob').calcTotal(datastorage.treatments,profile,dt.toDate()).iob;
+        var iob = Nightscout.plugins('iob').calcTotal(datastorage.treatments,datastorage.devicestatus,profile,dt.toDate()).iob;
         if (!dt.isSame(from)) {
           iobpolyline += ', ';
         }
         iobpolyline += (xScale2(dt) + padding.left) + ',' + (yInsulinScale(iob) + padding.top) + ' ';
       }
       if (options.cob) {
-        var cob = Nightscout.plugins('cob').cobTotal(datastorage.treatments,profile,dt.toDate()).cob;
+        var cob = Nightscout.plugins('cob').cobTotal(datastorage.treatments,datastorage.devicestatus,profile,dt.toDate()).cob;
         if (!dt.isSame(from)) {
           cobpolyline += ', ';
         }

--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -143,8 +143,9 @@ daytoday.report = function report_daytoday(datastorage,sorteddaystoshow,options)
         .domain([client.utils.scaleMgdl(36), client.utils.scaleMgdl(420)]);
     }
 
+    // allow insulin to be negative (when plotting negative IOB)
     yInsulinScale = d3.scale.linear()
-      .domain([0, options.maxInsulinValue*2]);
+      .domain([-2 * options.maxInsulinValue, 2 * options.maxInsulinValue]);
 
     yCarbsScale = d3.scale.linear()
       .domain([0, options.maxCarbsValue*1.25]);
@@ -177,7 +178,7 @@ daytoday.report = function report_daytoday(datastorage,sorteddaystoshow,options)
     // ranges are based on the width and height available so reset
     xScale2.range([0, chartWidth]);
     yScale2.range([chartHeight,0]);
-    yInsulinScale.range([chartHeight,0]);
+    yInsulinScale.range([chartHeight * 2, 0]);
     yCarbsScale.range([chartHeight,0]);
     yScaleBasals.range([chartHeight * 3 / 4, chartHeight]);
 
@@ -275,6 +276,8 @@ daytoday.report = function report_daytoday(datastorage,sorteddaystoshow,options)
     var tempbasalareadata = [];
     var comboareadata = [];
     var lastbasal = 0;
+    var lastDt = from;
+    var lastIOB;
     var basals = context.append('g');
 
     profile.updateTreatments([], datastorage.tempbasalTreatments, datastorage.combobolusTreatments);
@@ -284,10 +287,18 @@ daytoday.report = function report_daytoday(datastorage,sorteddaystoshow,options)
     for (var dt=moment(from); dt < to; dt.add(5, 'minutes')) {
       if (options.iob) {
         var iob = Nightscout.plugins('iob').calcTotal(datastorage.treatments,datastorage.devicestatus,profile,dt.toDate()).iob;
-        if (!dt.isSame(from)) {
-          iobpolyline += ', ';
+        // make the graph discontinuous when data is missing
+        if (iob === undefined) {
+          iobpolyline += ', ' + (xScale2(lastDt) + padding.left) + ',' + (yInsulinScale(0) + padding.top);
+          iobpolyline += ', ' + (xScale2(dt) + padding.left) + ',' + (yInsulinScale(0) + padding.top);
+        } else {
+          if (lastIOB === undefined) {
+            iobpolyline += ', ' + (xScale2(dt) + padding.left) + ',' + (yInsulinScale(0) + padding.top);
+          }
+          iobpolyline += ', '+ (xScale2(dt) + padding.left) + ',' + (yInsulinScale(iob) + padding.top);
         }
-        iobpolyline += (xScale2(dt) + padding.left) + ',' + (yInsulinScale(iob) + padding.top) + ' ';
+        lastDt = dt.clone();
+        lastIOB = iob;
       }
       if (options.cob) {
         var cob = Nightscout.plugins('cob').cobTotal(datastorage.treatments,datastorage.devicestatus,profile,dt.toDate()).cob;
@@ -319,8 +330,8 @@ daytoday.report = function report_daytoday(datastorage,sorteddaystoshow,options)
         lastbasal = basalvalue;
       }
     }
-    iobpolyline += (xScale2(to) + padding.left) + ',' + (yInsulinScale(0) + padding.top) + ' ';
-    cobpolyline += (xScale2(to) + padding.left) + ',' + (yCarbsScale(0) + padding.top) + ' ';
+    iobpolyline += ', ' + (xScale2(to) + padding.left) + ',' + (yInsulinScale(0) + padding.top);
+    cobpolyline += ', ' + (xScale2(to) + padding.left) + ',' + (yCarbsScale(0) + padding.top);
 
     if (options.iob) {
       context.append('polyline')

--- a/tests/boluswizardpreview.test.js
+++ b/tests/boluswizardpreview.test.js
@@ -137,10 +137,11 @@ describe('boluswizardpreview', function ( ) {
     };
     var data = {sgvs: [{mills: before, mgdl: 100}, {mills: now, mgdl: 100}]};
     data.treatments = [{mills: now, insulin: '1.0'}];
+    data.devicestatus = [];
     data.profile = require('../lib/profilefunctions')([profileData]);
     var sbx = sandbox.clientInit(ctx, Date.now(), data);
     var iob = require('../lib/plugins/iob')();
-    sbx.properties.iob = iob.calcTotal(data.treatments, data.profile, now);
+    sbx.properties.iob = iob.calcTotal(data.treatments, data.devicestatus, data.profile, now);
 
     var results = boluswizardpreview.calc(sbx);
     
@@ -177,10 +178,11 @@ describe('boluswizardpreview', function ( ) {
     };
     var data = {sgvs: [{mills: before, mgdl: 175}, {mills: now, mgdl: 153}]};
     data.treatments = [{mills: now, insulin: '0.45'}];
+    data.devicestatus = [];
     data.profile = require('../lib/profilefunctions')([profileData]);
     var sbx = sandbox.clientInit(ctx, Date.now(), data);
     var iob = require('../lib/plugins/iob')();
-    sbx.properties.iob = iob.calcTotal(data.treatments, data.profile, now);
+    sbx.properties.iob = iob.calcTotal(data.treatments, data.devicestatus, data.profile, now);
 
     var results = boluswizardpreview.calc(sbx);
     
@@ -282,6 +284,7 @@ describe('boluswizardpreview', function ( ) {
     var data = {
       sgvs: [{mills: before, mgdl: 295}, {mills: now, mgdl: 300}]
       , treatments: [{mills: before, insulin: '1.5'}]
+      , devicestatus: []
       , profile: loadedProfile
     };
 

--- a/tests/boluswizardpreview.test.js
+++ b/tests/boluswizardpreview.test.js
@@ -223,7 +223,7 @@ describe('boluswizardpreview', function ( ) {
     var highest = ctx.notifications.findHighestAlarm();
     highest.level.should.equal(levels.WARN);
     highest.title.should.equal('Warning, Check BG, time to bolus?');
-    highest.message.should.equal('BG Now: 180 +5 ↗ mg/dl\nBG 15m: 187 mg/dl\nBWP: 0.66U\nIOB: 0U');
+    highest.message.should.equal('BG Now: 180 +5 ↗ mg/dl\nBG 15m: 187 mg/dl\nBWP: 0.66U');
     done();
   });
 

--- a/tests/cob.test.js
+++ b/tests/cob.test.js
@@ -26,9 +26,11 @@ describe('COB', function ( ) {
       }
     ];
 
-    var after100 = cob.cobTotal(treatments, profile, new Date('2015-05-29T02:03:49.827Z').getTime());
-    var before10 = cob.cobTotal(treatments, profile, new Date('2015-05-29T03:45:10.670Z').getTime());
-    var after10 = cob.cobTotal(treatments, profile, new Date('2015-05-29T03:45:11.670Z').getTime());
+    var devicestatus = [];
+
+    var after100 = cob.cobTotal(treatments, devicestatus, profile, new Date('2015-05-29T02:03:49.827Z').getTime());
+    var before10 = cob.cobTotal(treatments, devicestatus, profile, new Date('2015-05-29T03:45:10.670Z').getTime());
+    var after10 = cob.cobTotal(treatments, devicestatus, profile, new Date('2015-05-29T03:45:11.670Z').getTime());
 
     after100.cob.should.equal(100);
     Math.round(before10.cob).should.equal(59);
@@ -44,17 +46,19 @@ describe('COB', function ( ) {
       }
     ];
 
+    var devicestatus = [];
+
     var rightAfterCorrection = new Date('2015-05-29T04:41:40.174Z').getTime();
     var later1 = new Date('2015-05-29T05:04:40.174Z').getTime();
     var later2 = new Date('2015-05-29T05:20:00.174Z').getTime();
     var later3 = new Date('2015-05-29T05:50:00.174Z').getTime();
     var later4 = new Date('2015-05-29T06:50:00.174Z').getTime();
 
-    var result1 = cob.cobTotal(treatments, profile, rightAfterCorrection);
-    var result2 = cob.cobTotal(treatments, profile, later1);
-    var result3 = cob.cobTotal(treatments, profile, later2);
-    var result4 = cob.cobTotal(treatments, profile, later3);
-    var result5 = cob.cobTotal(treatments, profile, later4);
+    var result1 = cob.cobTotal(treatments, devicestatus, profile, rightAfterCorrection);
+    var result2 = cob.cobTotal(treatments, devicestatus, profile, later1);
+    var result3 = cob.cobTotal(treatments, devicestatus, profile, later2);
+    var result4 = cob.cobTotal(treatments, devicestatus, profile, later3);
+    var result5 = cob.cobTotal(treatments, devicestatus, profile, later4);
 
     result1.cob.should.equal(8);
     result2.cob.should.equal(6);

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -165,7 +165,7 @@ describe('IOB', function() {
       var devicestatus = [{
         device: 'connect://paradigm',
         mills: time - 1,
-        pump: { iob: 0.87 },
+        pump: { iob: { bolusiob: 0.87 } },
         connect: { sensorState: 'copacetic' },
       }];
       iob.calcTotal(treatments, devicestatus, profile, time).should.containEql({

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -1,104 +1,180 @@
 'use strict';
 
 require('should');
+var _ = require('lodash');
 
-describe('IOB', function ( ) {
+describe('IOB', function() {
+
   var iob = require('../lib/plugins/iob')();
 
+  describe('from treatments', function ( ) {
 
-  it('should calculate IOB', function() {
+    it('should calculate IOB', function() {
 
-    var time = Date.now()
-      , treatments = [ {
+      var time = Date.now()
+        , treatments = [ {
+            mills: time - 1,
+            insulin: '1.00'
+          }
+        ];
+      
+ 
+    var profileData = {
+      dia: 3,
+      sens: 0};
+
+     var profile = require('../lib/profilefunctions')([profileData]);
+
+      var rightAfterBolus = iob.calcTotal(treatments, [], profile, time);
+
+      rightAfterBolus.display.should.equal('1.00');
+
+      var afterSomeTime = iob.calcTotal(treatments, [], profile, time + (60 * 60 * 1000));
+
+      afterSomeTime.iob.should.be.lessThan(1);
+      afterSomeTime.iob.should.be.greaterThan(0);
+
+      var afterDIA = iob.calcTotal(treatments, [], profile, time + (3 * 60 * 60 * 1000));
+
+      afterDIA.iob.should.equal(0);
+
+    });
+
+    it('should calculate IOB using defaults', function() {
+
+      var treatments = [{
+        mills: Date.now() - 1,
+        insulin: '1.00'
+      }];
+
+      var rightAfterBolus = iob.calcTotal(treatments, []);
+
+      rightAfterBolus.display.should.equal('1.00');
+
+    });
+
+    it('should not show a negative IOB when approaching 0', function() {
+
+      var time = Date.now() - 1;
+
+      var treatments = [{
+        mills: time,
+        insulin: '5.00'
+      }];
+
+      var whenApproaching0 = iob.calcTotal(treatments, [], undefined, time + (3 * 60 * 60 * 1000) - (90 * 1000));
+
+      //before fix we got this: AssertionError: expected '-0.00' to be '0.00'
+      whenApproaching0.display.should.equal('0.00');
+
+    });
+
+    it('should calculate IOB using a 4 hour duration', function() {
+
+      var time = Date.now()
+        , treatments = [ {
           mills: time - 1,
           insulin: '1.00'
-        }
-      ];
-    
-    
-  var profileData = {
-    dia: 3,
-    sens: 0};
+        } ];
+         
+    var profileData = {
+      dia: 4,
+      sens: 0};
 
-   var profile = require('../lib/profilefunctions')([profileData]);
+     var profile = require('../lib/profilefunctions')([profileData]);
 
-    var rightAfterBolus = iob.calcTotal(treatments, profile, time);
 
-    rightAfterBolus.display.should.equal('1.00');
+      var rightAfterBolus = iob.calcTotal(treatments, [], profile, time);
 
-    var afterSomeTime = iob.calcTotal(treatments, profile, time + (60 * 60 * 1000));
+      rightAfterBolus.display.should.equal('1.00');
 
-    afterSomeTime.iob.should.be.lessThan(1);
-    afterSomeTime.iob.should.be.greaterThan(0);
+      var afterSomeTime = iob.calcTotal(treatments, [], profile, time + (60 * 60 * 1000));
 
-    var afterDIA = iob.calcTotal(treatments, profile, time + (3 * 60 * 60 * 1000));
+      afterSomeTime.iob.should.be.lessThan(1);
+      afterSomeTime.iob.should.be.greaterThan(0);
 
-    afterDIA.iob.should.equal(0);
+      var after3hDIA = iob.calcTotal(treatments, [], profile, time + (3 * 60 * 60 * 1000));
+
+      after3hDIA.iob.should.greaterThan(0);
+
+      var after4hDIA = iob.calcTotal(treatments, [], profile, time + (4 * 60 * 60 * 1000));
+
+      after4hDIA.iob.should.equal(0);
+
+    });
+
 
   });
 
-  it('should calculate IOB using defaults', function() {
-
+  describe('from devicestatus', function () {
+    var time = Date.now();
+    var profile = require('../lib/profilefunctions')([{ dia: 3, sens: 0 }]);
     var treatments = [{
-      mills: Date.now() - 1,
-      insulin: '1.00'
+      mills: time - 1,
+      insulin: '3.00',
     }];
+    var treatmentIOB = iob.fromTreatments(treatments, profile, time).iob;
 
-    var rightAfterBolus = iob.calcTotal(treatments);
+    var OPENAPS_DEVICESTATUS = {
+      device: 'openaps://pi1',
+      openaps: {
+        iob: {
+           iob: 0.047,
+           basaliob: -0.298,
+           activity: 0.0147,
+         },
+      },
+    };
 
-    rightAfterBolus.display.should.equal('1.00');
+    it('should fall back to treatment data if no devicestatus data', function() {
+      iob.calcTotal(treatments, [], profile, time).should.containEql({
+        source: 'Care Portal',
+        iob: treatmentIOB,
+      });
+    });
 
-  });
-
-  it('should not show a negative IOB when approaching 0', function() {
-
-    var time = Date.now() - 1;
-
-    var treatments = [{
-      mills: time,
-      insulin: '5.00'
-    }];
-
-    var whenApproaching0 = iob.calcTotal(treatments, undefined, time + (3 * 60 * 60 * 1000) - (90 * 1000));
-
-    //before fix we got this: AssertionError: expected '-0.00' to be '0.00'
-    whenApproaching0.display.should.equal('0.00');
-
-  });
-
-  it('should calculate IOB using a 4 hour duration', function() {
-
-    var time = Date.now()
-      , treatments = [ {
+    it('should fall back to treatments if openaps devicestatus is present but empty', function() {
+      var devicestatus = [{
+        device: 'openaps://pi1',
         mills: time - 1,
-        insulin: '1.00'
-      } ];
-       
-  var profileData = {
-    dia: 4,
-    sens: 0};
+        openaps: {},
+      }];
+      iob.calcTotal(treatments, devicestatus, profile, time).iob.should.equal(treatmentIOB);
+    });
 
-   var profile = require('../lib/profilefunctions')([profileData]);
+    it('should fall back to treatments if openaps devicestatus is present but too stale', function() {
+      var devicestatus = [_.merge(OPENAPS_DEVICESTATUS, { mills: time - iob.RECENCY_THRESHOLD - 1 })];
+      iob.calcTotal(treatments, devicestatus, profile, time).should.containEql({
+        source: 'Care Portal',
+        iob: treatmentIOB,
+      });
+    });
 
-    
-    var rightAfterBolus = iob.calcTotal(treatments, profile, time);
+    it('should return IOB data from openaps', function () {
+      var devicestatus = [_.merge(OPENAPS_DEVICESTATUS, { mills: time - 1 })];
+      iob.calcTotal(treatments, devicestatus, profile, time).should.containEql({
+        iob: 0.047,
+        basaliob: -0.298,
+        activity: 0.0147,
+        source: 'OpenAPS',
+        device: 'openaps://pi1',
+      });
+    });
 
-    rightAfterBolus.display.should.equal('1.00');
-
-    var afterSomeTime = iob.calcTotal(treatments, profile, time + (60 * 60 * 1000));
-
-    afterSomeTime.iob.should.be.lessThan(1);
-    afterSomeTime.iob.should.be.greaterThan(0);
-
-    var after3hDIA = iob.calcTotal(treatments, profile, time + (3 * 60 * 60 * 1000));
-
-    after3hDIA.iob.should.greaterThan(0);
-
-    var after4hDIA = iob.calcTotal(treatments, profile, time + (4 * 60 * 60 * 1000));
-
-    after4hDIA.iob.should.equal(0);
+    it('should return IOB data from MiniMed Connect', function () {
+      var devicestatus = [{
+        device: 'connect://paradigm',
+        mills: time - 1,
+        pump: { iob: 0.87 },
+        connect: { sensorState: 'copacetic' },
+      }];
+      iob.calcTotal(treatments, devicestatus, profile, time).should.containEql({
+        iob: 0.87,
+        source: 'MM Connect',
+        device: 'connect://paradigm',
+      });
+    });
 
   });
-
 
 });

--- a/tests/pebble.test.js
+++ b/tests/pebble.test.js
@@ -215,7 +215,6 @@ describe('Pebble Endpoint', function ( ) {
 describe('Pebble Endpoint with Raw and IOB', function ( ) {
   var pebbleRaw = require('../lib/pebble');
   before(function (done) {
-    ctx.ddata.devicestatus = [{uploader: {battery: 100}}];
     var envRaw = require('../env')( );
     envRaw.settings.enable = ['rawbg', 'iob'];
     this.appRaw = require('express')( );
@@ -225,6 +224,7 @@ describe('Pebble Endpoint with Raw and IOB', function ( ) {
   });
 
   it('/pebble', function (done) {
+    ctx.ddata.devicestatus = [{uploader: {battery: 100}}];
     request(this.appRaw)
       .get('/pebble?count=2')
       .expect(200)
@@ -241,6 +241,7 @@ describe('Pebble Endpoint with Raw and IOB', function ( ) {
         bg.unfiltered.should.equal(111920);
         bg.noise.should.equal(1);
         bg.battery.should.equal('100');
+        bg.iob.should.equal('1.50');
 
         res.body.cals.length.should.equal(1);
         var cal = res.body.cals[0];
@@ -248,6 +249,35 @@ describe('Pebble Endpoint with Raw and IOB', function ( ) {
         cal.intercept.toFixed(3).should.equal('34281.069');
         cal.scale.should.equal(1);
         done( );
+      });
+  });
+
+  it('/pebble with no treatments', function (done) {
+    ctx.ddata.treatments = [];
+    request(this.appRaw)
+      .get('/pebble')
+      .expect(200)
+      .end(function (err, res)  {
+        var bgs = res.body.bgs;
+        bgs.length.should.equal(1);
+        var bg = bgs[0];
+        bg.iob.should.equal(0);
+        done();
+      });
+  });
+
+  it('/pebble with IOB from devicestatus', function (done) {
+    ctx.ddata.treatments = [];
+    ctx.ddata.devicestatus = updateMills([{pump: {iob: {bolusiob: 2.3}}}]);
+    request(this.appRaw)
+      .get('/pebble')
+      .expect(200)
+      .end(function (err, res)  {
+        var bgs = res.body.bgs;
+        bgs.length.should.equal(1);
+        var bg = bgs[0];
+        bg.iob.should.equal('2.30');
+        done();
       });
   });
 

--- a/tests/reports.test.js
+++ b/tests/reports.test.js
@@ -185,26 +185,11 @@ describe('reports', function ( ) {
       //var logfile = filesys.createWriteStream('out.txt', { flags: 'a'} )
       
       self.$.ajax = function mockAjax (url, opts) {
-        //logfile.write(url+'\n');
-        return {
-          done: function mockDone (fn) {
-            if (opts && opts.success && opts.success.call) {
-              if (someData[url]) {
-                //console.log('+++++Data for ' + url + ' sent');
-                opts.success(someData[url]);
-              } else {
-                //console.log('-----Data for ' + url + ' missing');
-                opts.success([]);
-              }
-            }
-            fn();
-            return self.$.ajax();
-          },
-          fail: function mockFail (fn) {
-            fn({status: 400});
-            return self.$.ajax();
-          }
-        };
+        var returnVal = someData[url] || [];
+        if (opts && typeof opts.success === 'function') {
+          opts.success(returnVal);
+        }
+        return self.$.Deferred().resolveWith(returnVal);
       };
 
       self.$.plot = function mockPlot () {


### PR DESCRIPTION
* Pass `devicestatus` to `iob.calcTotal` and `cob.cobTotal`
* Let IOB be undefined sometimes (No treatments and no devicestatus in sandbox == haven't heard from device in a while == undefined IOB, displayed as "---U". Assuming/showing "0U" in this case would be misleading.)
* ...but always return a number on /pebble for backwards compatibility with the clients in the wild