### PR TITLE
Use 24-hour time format for minute marks in chart

### DIFF
--- a/lib/client/chart.js
+++ b/lib/client/chart.js
@@ -110,7 +110,7 @@ function init (client, d3, $) {
   var tickFormat = localeFormatter.timeFormat.multi(  [
     ['.%L', function(d) { return d.getMilliseconds(); }],
     [':%S', function(d) { return d.getSeconds(); }],
-    ['%I:%M', function(d) { return d.getMinutes(); }],
+    [client.settings.timeFormat === 24 ? '%H:%M' : '%I:%M', function(d) { return d.getMinutes(); }],
     [client.settings.timeFormat === 24 ? '%H:%M' : '%-I %p', function(d) { return d.getHours(); }],
     ['%a %d', function(d) { return d.getDay() && d.getDate() !== 1; }],
     ['%b %d', function(d) { return d.getDate() !== 1; }],


### PR DESCRIPTION
The tick marks in the bottom chart were displayed using 12-hour format for the non-whole-hour ticks, even if 24-hour format was selected in the client settings. (This only applies in the first few hours of using Nightscout, after that the bottom chart has enough time in it so there is no need to display non-whole-hour ticks anymore)

This PR fixes that by using the client settings for time format for those tick marks as well. I've verified by running Nightscout locally that they look correct now and that they are unchanged with 12-hour format. Please let me know if there is any additional testing you would like me to do.

Thank you and everyone else working on the Nightscout project for this awesome tool. #WeAreNotWaiting!