### PR TITLE
Wip/reportsperformance

### DIFF
--- a/lib/data/ddata.js
+++ b/lib/data/ddata.js
@@ -145,11 +145,8 @@ function init( ) {
       return t.eventType && t.eventType.indexOf('Temp Basal') > -1;
     });
     
-    console.log("dedupe before " + tempbasalTreatments.length);
-    
+	// dedupe the data
 	tempbasalTreatments = _.uniqBy(tempbasalTreatments, 'mills');
-
-    console.log("dedupe after " + tempbasalTreatments.length);
 
     // store prepared temp basal treatments
     ddata.tempbasalTreatments = ddata.processTempBasals(tempbasalTreatments);

--- a/lib/data/ddata.js
+++ b/lib/data/ddata.js
@@ -145,6 +145,12 @@ function init( ) {
       return t.eventType && t.eventType.indexOf('Temp Basal') > -1;
     });
     
+    console.log("dedupe before " + tempbasalTreatments.length);
+    
+	tempbasalTreatments = _.uniqBy(tempbasalTreatments, 'mills');
+
+    console.log("dedupe after " + tempbasalTreatments.length);
+
     // store prepared temp basal treatments
     ddata.tempbasalTreatments = ddata.processTempBasals(tempbasalTreatments);
   };

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -161,14 +161,10 @@ function init(profileData) {
 
   profile.updateTreatments = function updateTreatments (profiletreatments, tempbasaltreatments, combobolustreatments) {
   
-    console.log("Loading temp events", this);
-  	if (profile.profiletreatments) { console.log("size before: " + profile.profiletreatments.length + " size after " + tempbasaltreatments.length); }
-  	  else { console.log("No previous data");}
-  	
-  
     profile.profiletreatments = profiletreatments || [];
     profile.tempbasaltreatments = tempbasaltreatments || [];
-    
+
+	// dedupe temp basal events    
     profile.tempbasaltreatments = _.uniqBy(profile.tempbasaltreatments, 'mills');
     
     _.each(profile.tempbasaltreatments, function addDuration(t) {
@@ -222,8 +218,7 @@ function init(profileData) {
 
   profile.tempBasalTreatment = function tempBasalTreatment(time) {
 
-   // console.log("Searching treatment at " + time);
-
+	// Most queries for the data in reporting will match the latest found value, caching that hugely improves performance
  	if (prevBasalTreatment && time >= prevBasalTreatment.mills && time <= prevBasalTreatment.endmills) {
  		return prevBasalTreatment;
  	}
@@ -234,32 +229,18 @@ function init(profileData) {
     while (first <= last) {
         var i = first + Math.floor((last - first) / 2);
         var t = profile.tempbasaltreatments[i];
-       // console.log(first + " " + last + " pos" + i + " mills" + t.mills);
         if (time >= t.mills && time <= t.endmills) {
-            // console.log("mills found " + t.mills + " to " + t.endmills);
              prevBasalTreatment = t;
         	return t;
         	}
         if (time < t.mills) {
             last = i - 1;
-        } else { // time > t.endmills
+        } else {
             first = i + 1;
         }
     }
     
     return null;
-    /*
-    // returns undefined
-
-  
-    var treatment = null;
-    profile.tempbasaltreatments.forEach( function eachTreatment (t) {
-        //var duration = times.mins(t.duration || 0).msecs;
-        if (time <= t.endmills && time >= t.mills) {
-          return t; //treatment = t;
-        }
-    });
-    return treatment;*/
   };
 
   profile.comboBolusTreatment = function comboBolusTreatment(time) {

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -6,6 +6,8 @@ var NodeCache = require('node-cache');
 var times = require('./times');
 var crypto = require('crypto');
 
+var prevBasalTreatment = null;
+
 function init(profileData) {
 
   var profile = { };
@@ -158,8 +160,25 @@ function init(profileData) {
   };
 
   profile.updateTreatments = function updateTreatments (profiletreatments, tempbasaltreatments, combobolustreatments) {
+  
+    console.log("Loading temp events", this);
+  	if (profile.profiletreatments) { console.log("size before: " + profile.profiletreatments.length + " size after " + tempbasaltreatments.length); }
+  	  else { console.log("No previous data");}
+  	
+  
     profile.profiletreatments = profiletreatments || [];
     profile.tempbasaltreatments = tempbasaltreatments || [];
+    
+    profile.tempbasaltreatments = _.uniqBy(profile.tempbasaltreatments, 'mills');
+    
+    _.each(profile.tempbasaltreatments, function addDuration(t) {
+       t.endmills = t.mills + times.mins(t.duration || 0).msecs;
+    });
+    
+    profile.tempbasaltreatments.sort(function (a, b) { 
+   	 return a.mills - b.mills;
+	});
+
     profile.combobolustreatments = combobolustreatments || [];
     profile.profiletreatments_hash = crypto.createHash('sha1').update(JSON.stringify(profile.profiletreatments)).digest('hex');
     profile.tempbasaltreatments_hash = crypto.createHash('sha1').update(JSON.stringify(profile.tempbasaltreatments)).digest('hex');
@@ -202,14 +221,45 @@ function init(profileData) {
   };
 
   profile.tempBasalTreatment = function tempBasalTreatment(time) {
+
+   // console.log("Searching treatment at " + time);
+
+ 	if (prevBasalTreatment && time >= prevBasalTreatment.mills && time <= prevBasalTreatment.endmills) {
+ 		return prevBasalTreatment;
+ 	}
+  
+    // Binary search for events for O(log n) performance
+    var first = 0, last = profile.tempbasaltreatments.length - 1;
+    
+    while (first <= last) {
+        var i = first + Math.floor((last - first) / 2);
+        var t = profile.tempbasaltreatments[i];
+       // console.log(first + " " + last + " pos" + i + " mills" + t.mills);
+        if (time >= t.mills && time <= t.endmills) {
+            // console.log("mills found " + t.mills + " to " + t.endmills);
+             prevBasalTreatment = t;
+        	return t;
+        	}
+        if (time < t.mills) {
+            last = i - 1;
+        } else { // time > t.endmills
+            first = i + 1;
+        }
+    }
+    
+    return null;
+    /*
+    // returns undefined
+
+  
     var treatment = null;
     profile.tempbasaltreatments.forEach( function eachTreatment (t) {
-        var duration = times.mins(t.duration || 0).msecs;
-        if (time < t.mills + duration && time > t.mills) {
-          treatment = t;
+        //var duration = times.mins(t.duration || 0).msecs;
+        if (time <= t.endmills && time >= t.mills) {
+          return t; //treatment = t;
         }
     });
-    return treatment;
+    return treatment;*/
   };
 
   profile.comboBolusTreatment = function comboBolusTreatment(time) {

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -8,13 +8,13 @@ var crypto = require('crypto');
 
 var prevBasalTreatment = null;
 
-function init(profileData) {
+function init (profileData) {
 
   var profile = { };
 
   profile.timeValueCache = new NodeCache({ stdTTL: 600, checkperiod: 600 });
   
-  profile.loadData = function loadData(profileData) {
+  profile.loadData = function loadData (profileData) {
     if (profileData && profileData.length) {
       profile.data =  profile.convertToProfileStore(profileData);
       _.each(profile.data, function eachProfileRecord (record) {
@@ -48,13 +48,13 @@ function init(profileData) {
     return convertedProfiles;
   };
 
-  profile.timeStringToSeconds = function timeStringToSeconds(time) {
+  profile.timeStringToSeconds = function timeStringToSeconds (time) {
     var split = time.split(':');
     return parseInt(split[0])*3600 + parseInt(split[1])*60;
   };
 
   // preprocess the timestamps to seconds for a couple orders of magnitude faster operation
-  profile.preprocessProfileOnLoad = function preprocessProfileOnLoad(container) {
+  profile.preprocessProfileOnLoad = function preprocessProfileOnLoad (container) {
     _.each(container, function eachValue (value) {
       if( Object.prototype.toString.call(value) === '[object Array]' ) {
         profile.preprocessProfileOnLoad(value);
@@ -112,50 +112,50 @@ function init(profileData) {
     return returnValue;
   };
 
-  profile.getCurrentProfile = function getCurrentProfile(time, spec_profile) {
+  profile.getCurrentProfile = function getCurrentProfile (time, spec_profile) {
     time = time || new Date().getTime();
     var data = profile.hasData() ? profile.data[0] : null;
     var timeprofile = spec_profile || profile.activeProfileToTime(time);
     return data && data.store[timeprofile] ? data.store[timeprofile] : {};
   };
 
-  profile.getUnits = function getUnits(spec_profile) {
+  profile.getUnits = function getUnits (spec_profile) {
     return profile.getCurrentProfile(null, spec_profile)['units'];
   };
 
-  profile.getTimezone = function getTimezone(spec_profile) {
+  profile.getTimezone = function getTimezone (spec_profile) {
     return profile.getCurrentProfile(null, spec_profile)['timezone'];
   };
 
-  profile.hasData = function hasData() {
+  profile.hasData = function hasData () {
     return profile.data ? true : false;
   };
 
-  profile.getDIA = function getDIA(time, spec_profile) {
+  profile.getDIA = function getDIA (time, spec_profile) {
     return profile.getValueByTime(time, 'dia', spec_profile);
   };
 
-  profile.getSensitivity = function getSensitivity(time, spec_profile) {
+  profile.getSensitivity = function getSensitivity (time, spec_profile) {
     return profile.getValueByTime(time, 'sens', spec_profile);
   };
 
-  profile.getCarbRatio = function getCarbRatio(time, spec_profile) {
+  profile.getCarbRatio = function getCarbRatio (time, spec_profile) {
     return profile.getValueByTime(time, 'carbratio', spec_profile);
   };
 
-  profile.getCarbAbsorptionRate = function getCarbAbsorptionRate(time, spec_profile) {
+  profile.getCarbAbsorptionRate = function getCarbAbsorptionRate (time, spec_profile) {
     return profile.getValueByTime(time, 'carbs_hr', spec_profile);
   };
 
-  profile.getLowBGTarget = function getLowBGTarget(time, spec_profile) {
+  profile.getLowBGTarget = function getLowBGTarget (time, spec_profile) {
     return profile.getValueByTime(time, 'target_low', spec_profile);
   };
 
-  profile.getHighBGTarget = function getHighBGTarget(time, spec_profile) {
+  profile.getHighBGTarget = function getHighBGTarget (time, spec_profile) {
     return profile.getValueByTime(time, 'target_high', spec_profile);
   };
 
-  profile.getBasal = function getBasal(time, spec_profile) {
+  profile.getBasal = function getBasal (time, spec_profile) {
     return profile.getValueByTime(time, 'basal', spec_profile);
   };
 
@@ -167,11 +167,11 @@ function init(profileData) {
 	// dedupe temp basal events    
     profile.tempbasaltreatments = _.uniqBy(profile.tempbasaltreatments, 'mills');
     
-    _.each(profile.tempbasaltreatments, function addDuration(t) {
+    _.each(profile.tempbasaltreatments, function addDuration (t) {
        t.endmills = t.mills + times.mins(t.duration || 0).msecs;
     });
     
-    profile.tempbasaltreatments.sort(function (a, b) { 
+    profile.tempbasaltreatments.sort (function compareTreatmentMills (a, b) { 
    	 return a.mills - b.mills;
 	});
 
@@ -194,7 +194,7 @@ function init(profileData) {
     return null;
   };
   
-  profile.activeProfileTreatmentToTime = function activeProfileTreatmentToTime(time) {
+  profile.activeProfileTreatmentToTime = function activeProfileTreatmentToTime (time) {
     var cacheKey = 'profile' + time + profile.profiletreatments_hash;
     var returnValue = profile.timeValueCache[cacheKey];
 
@@ -216,7 +216,7 @@ function init(profileData) {
     return returnValue;
   };
 
-  profile.tempBasalTreatment = function tempBasalTreatment(time) {
+  profile.tempBasalTreatment = function tempBasalTreatment (time) {
 
 	// Most queries for the data in reporting will match the latest found value, caching that hugely improves performance
  	if (prevBasalTreatment && time >= prevBasalTreatment.mills && time <= prevBasalTreatment.endmills) {
@@ -243,7 +243,7 @@ function init(profileData) {
     return null;
   };
 
-  profile.comboBolusTreatment = function comboBolusTreatment(time) {
+  profile.comboBolusTreatment = function comboBolusTreatment (time) {
     var treatment = null;
     profile.combobolustreatments.forEach( function eachTreatment (t) {
         var duration = times.mins(t.duration || 0).msecs;
@@ -254,7 +254,7 @@ function init(profileData) {
     return treatment;
   };
 
-  profile.getTempBasal = function getTempBasal(time, spec_profile) {
+  profile.getTempBasal = function getTempBasal (time, spec_profile) {
 
     var cacheKey = 'basal' + time + profile.tempbasaltreatments_hash + profile.combobolustreatments_hash + profile.profiletreatments_hash + spec_profile;
     var returnValue = profile.timeValueCache[cacheKey];

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "forever": "~0.13.0",
     "git-rev": "git://github.com/bewest/git-rev.git",
     "jquery": "^2.1.4",
-    "lodash": "^3.9.1",
+    "lodash": "^4.0.0",
     "long": "~2.2.3",
     "minimed-connect-to-nightscout": "git://github.com/mddub/minimed-connect-to-nightscout#v1.0.0",
     "moment": "2.10.6",

--- a/static/report/js/report.js
+++ b/static/report/js/report.js
@@ -618,7 +618,7 @@
 
   function loadTempBasals(from, callback) {
     $('#info > b').html('<b>'+translate('Loading temp basal data') + ' ...</b>');
-    var tquery = '?find[created_at][$gte]='+moment(from).subtract(32, 'days').toISOString()+'&find[eventType][$eq]=Temp Basal';
+    var tquery = '?find[created_at][$gte]='+moment(from).subtract(1, 'days').toISOString()+'&find[eventType][$eq]=Temp Basal';
     $.ajax('/api/v1/treatments.json'+tquery, {
       success: function (xhr) {
         var treatmentData = xhr.map(function (treatment) {


### PR DESCRIPTION
Rendering two weeks of graphs on my laptop drops from over a minute to around 9 seconds with these. Using binary search for temps, deduping data, caching latest temp result for huge gain in reporting speed & loading less temp basal data. Note the new loadash version.