### PR TITLE
Add colorblind-friendly color theme

### DIFF
--- a/app.json
+++ b/app.json
@@ -73,7 +73,7 @@
       "required": false
     },
     "THEME": {
-      "description": "Possible values default or colors",
+      "description": "Possible values default, colors or colorblindfriendly",
       "value": "",
       "required": false
     },

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -65,7 +65,8 @@
         "type": "string",
 		 "allowedValues": [
                 "default",
-                "colors"
+                "colors",
+                "colorblindfriendly"
             ],
 	    "defaultValue": "colors",
         },

--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -49,6 +49,8 @@ function init (client, plugins, serverSettings, $) {
 
     if (settings.theme === 'colors') {
       $('#theme-colors-browser').prop('checked', true);
+    } else if (settings.theme === 'colorblindfriendly') {
+      $('#theme-colorblindfriendly-browser').prop('checked', true);
     } else {
       $('#theme-default-browser').prop('checked', true);
     }

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -387,13 +387,13 @@ client.init = function init(serverSettings, plugins) {
   function sgvToColor(sgv) {
     var color = 'grey';
 
-    if (client.settings.theme === 'colors' || client.settings.theme === 'colorblindfriendly') {
+    if (client.settings.theme !== 'default') {
       if (sgv > client.settings.thresholds.bgHigh) {
         color = 'red';
       } else if (sgv > client.settings.thresholds.bgTargetTop) {
         color = 'yellow';
-      } else if (sgv >= client.settings.thresholds.bgTargetBottom && sgv <= client.settings.thresholds.bgTargetTop) {
-        color = client.settings.theme === 'colorblindfriendly' ? 'deepskyblue' : '#4cff00';
+      } else if (sgv >= client.settings.thresholds.bgTargetBottom && sgv <= client.settings.thresholds.bgTargetTop && client.settings.theme === 'colors') {
+        color = '#4cff00';
       } else if (sgv < client.settings.thresholds.bgLow) {
         color = 'red';
       } else if (sgv < client.settings.thresholds.bgTargetBottom) {
@@ -407,13 +407,13 @@ client.init = function init(serverSettings, plugins) {
   function sgvToColoredRange(sgv) {
     var range = '';
 
-    if (client.settings.theme === 'colors' || client.settings.theme === 'colorblindfriendly') {
+    if (client.settings.theme !== 'default') {
       if (sgv > client.settings.thresholds.bgHigh) {
         range = 'urgent';
       } else if (sgv > client.settings.thresholds.bgTargetTop) {
         range = 'warning';
-      } else if (sgv >= client.settings.thresholds.bgTargetBottom && sgv <= client.settings.thresholds.bgTargetTop) {
-        range = client.settings.theme === 'colorblindfriendly' ? 'inrange-colorblindfriendly' : 'inrange';
+      } else if (sgv >= client.settings.thresholds.bgTargetBottom && sgv <= client.settings.thresholds.bgTargetTop && client.settings.theme === 'colors') {
+        range = 'inrange';
       } else if (sgv < client.settings.thresholds.bgLow) {
         range = 'urgent';
       } else if (sgv < client.settings.thresholds.bgTargetBottom) {

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -387,13 +387,13 @@ client.init = function init(serverSettings, plugins) {
   function sgvToColor(sgv) {
     var color = 'grey';
 
-    if (client.settings.theme === 'colors') {
+    if (client.settings.theme === 'colors' || client.settings.theme === 'colorblindfriendly') {
       if (sgv > client.settings.thresholds.bgHigh) {
         color = 'red';
       } else if (sgv > client.settings.thresholds.bgTargetTop) {
         color = 'yellow';
       } else if (sgv >= client.settings.thresholds.bgTargetBottom && sgv <= client.settings.thresholds.bgTargetTop) {
-        color = '#4cff00';
+        color = client.settings.theme === 'colorblindfriendly' ? 'deepskyblue' : '#4cff00';
       } else if (sgv < client.settings.thresholds.bgLow) {
         color = 'red';
       } else if (sgv < client.settings.thresholds.bgTargetBottom) {
@@ -407,13 +407,13 @@ client.init = function init(serverSettings, plugins) {
   function sgvToColoredRange(sgv) {
     var range = '';
 
-    if (client.settings.theme === 'colors') {
+    if (client.settings.theme === 'colors' || client.settings.theme === 'colorblindfriendly') {
       if (sgv > client.settings.thresholds.bgHigh) {
         range = 'urgent';
       } else if (sgv > client.settings.thresholds.bgTargetTop) {
         range = 'warning';
       } else if (sgv >= client.settings.thresholds.bgTargetBottom && sgv <= client.settings.thresholds.bgTargetTop) {
-        range = 'inrange';
+        range = client.settings.theme === 'colorblindfriendly' ? 'inrange-colorblindfriendly' : 'inrange';
       } else if (sgv < client.settings.thresholds.bgLow) {
         range = 'urgent';
       } else if (sgv < client.settings.thresholds.bgTargetBottom) {

--- a/lib/language.js
+++ b/lib/language.js
@@ -4263,6 +4263,8 @@ function init() {
       ,nb: 'Farger'
       ,pl: 'Kolorowy'
       }
+    ,'Colorblind-friendly colors' : {
+      }
     ,'Reset, and use defaults' : {
       cs: 'Vymaž a nastav výchozí hodnoty'
       ,de: 'Zurücksetzen und Voreinstellungen verwenden'

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -60,10 +60,6 @@ body {
   color: #4cff00;
 }
 
-.inrange-colorblindfriendly .bgButton {
-  color: deepskyblue;
-}
-
 .bgStatus .currentBG {
   font-size: 120px;
   line-height: 100px;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -60,6 +60,10 @@ body {
   color: #4cff00;
 }
 
+.inrange-colorblindfriendly .bgButton {
+  color: deepskyblue;
+}
+
 .bgStatus .currentBG {
   font-size: 120px;
   line-height: 100px;

--- a/static/index.html
+++ b/static/index.html
@@ -164,6 +164,7 @@
                         <dt class="translate">Theme</dt>
                         <dd><input type="radio" name="theme-browser" id="theme-default-browser" value="default" checked /><label for="theme-default-browser" class="translate">Default</label></dd>
                         <dd><input type="radio" name="theme-browser" id="theme-colors-browser" value="colors" /><label for="theme-colors-browser" class="translate">Colors</label></dd>
+                        <dd><input type="radio" name="theme-browser" id="theme-colorblindfriendly-browser" value="colorblindfriendly" /><label for="theme-colorblindfriendly-browser" class="translate">Colorblind-friendly colors</label></dd>
                     </dl>
                     <dl id="show-plugins" class="toggle">
                         <dt class="translate">Show Plugins</dt>

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -553,7 +553,7 @@ definitions:
         description: Should Night mode be enabled by default?
       theme:
         type: string
-        description: Default theme to be displayed system wide, `default` or `colors`.
+        description: Default theme to be displayed system wide, `default`, `colors`, `colorblindfriendly`.
       language:
         type: string
         description: Default language code to be used system wide


### PR DESCRIPTION
The color theme uses light green and yellow which to some colorblind
people may be too close to distinguish easily. This adds a
"colorblind-friendly colors" theme which uses light blue instead of
light green for the "in-range" color.