### PR TITLE
Fix/crash iob null

### DIFF
--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -75,7 +75,7 @@ function init() {
       iobObj = _.isArray(devicestatusEntry.openaps.iob) ? devicestatusEntry.openaps.iob[0] : devicestatusEntry.openaps.iob;
 
       // array could still be empty, handle as null
-      if (iobObj === undefined) {
+      if (iobObj === undefined || iobObj == null) {
         return {};
       }
 


### PR DESCRIPTION
Somehow iob was null in the database, causing web server to crash.

Stacktrace:

```
TypeError: Cannot read property 'time' of null
    at fromDeviceStatus (/www/cgm-remote-monitor/lib/plugins/iob.js:82:17)
    at arrayMap (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:607:23)
    at Function.map (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:9059:14)
    at interceptor (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:16477:35)
    at thru (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:8296:14)
    at /www/cgm-remote-monitor/node_modules/lodash/lodash.js:4063:28
    at arrayReduce (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:651:21)
    at baseWrapperValue (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:4062:14)
    at LazyWrapper.lazyValue [as value] (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:1709:16)
    at baseWrapperValue (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:4060:25)
    at LodashWrapper.wrapperValue (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:8552:14)
    at Object.lastIOBDeviceStatus (/www/cgm-remote-monitor/lib/plugins/iob.js:67:8)
    at Object.calcTotal (/www/cgm-remote-monitor/lib/plugins/iob.js:29:22)
    at setIOB (/www/cgm-remote-monitor/lib/plugins/iob.js:20:18)
    at Object.offerProperty (/www/cgm-remote-monitor/lib/sandbox.js:111:19)
    at Object.setProperties (/www/cgm-remote-monitor/lib/plugins/iob.js:19:9)
    at eachPlugin (/www/cgm-remote-monitor/lib/plugins/index.js:123:16)
    at arrayEach (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:484:11)
    at Function.forEach (/www/cgm-remote-monitor/node_modules/lodash/lodash.js:8843:14)
    at Function.eachEnabledPlugin (/www/cgm-remote-monitor/lib/plugins/index.js:98:7)
    at Function.setProperties (/www/cgm-remote-monitor/lib/plugins/index.js:121:13)
    at Stream.updatePlugins (/www/cgm-remote-monitor/lib/bootevent.js:106:19)
    at emitNone (events.js:67:13)
    at Stream.emit (events.js:166:7)
    at dataUpdated (/www/cgm-remote-monitor/lib/bootevent.js:90:17)
    at loadComplete (/www/cgm-remote-monitor/lib/data/dataloader.js:45:7)
    at /www/cgm-remote-monitor/node_modules/async/lib/async.js:251:17
    at done (/www/cgm-remote-monitor/node_modules/async/lib/async.js:132:19)
    at /www/cgm-remote-monitor/node_modules/async/lib/async.js:32:16
    at /www/cgm-remote-monitor/node_modules/async/lib/async.js:248:21
    at /www/cgm-remote-monitor/node_modules/async/lib/async.js:572:34
    at /www/cgm-remote-monitor/lib/data/dataloader.js:102:5
    at toArray (/www/cgm-remote-monitor/lib/entries.js:41:9)
    at handleCallback (/www/cgm-remote-monitor/node_modules/mongodb/lib/utils.js:96:12)
    at /www/cgm-remote-monitor/node_modules/mongodb/lib/cursor.js:839:16
    at handleCallback (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/cursor.js:159:5)
    at setCursorDeadAndNotified (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/cursor.js:501:3)
    at nextFunction (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/cursor.js:652:7)
    at Cursor.next [as _next] (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/cursor.js:693:3)
    at fetchDocs (/www/cgm-remote-monitor/node_modules/mongodb/lib/cursor.js:835:10)
    at /www/cgm-remote-monitor/node_modules/mongodb/lib/cursor.js:858:7
    at handleCallback (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/cursor.js:159:5)
    at nextFunction (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/cursor.js:683:5)
    at /www/cgm-remote-monitor/node_modules/mongodb-core/lib/cursor.js:641:9
    at queryCallback (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/wireprotocol/3_2_support.js:195:5)
    at Callbacks.emit (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/topologies/server.js:119:3)
    at null.messageHandler (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/topologies/server.js:358:23)
    at Socket.<anonymous> (/www/cgm-remote-monitor/node_modules/mongodb-core/lib/connection/connection.js:211:18)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:146:16)
    at Socket.Readable.push (_stream_readable.js:110:10)
    at TCP.onread (net.js:523:20)
```
