### PR TITLE
Fix API for broken insulin data; treatments data processing when IOB …

### DIFF
--- a/lib/api/treatments/index.js
+++ b/lib/api/treatments/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var consts = require('../../constants');
 
 function configure (app, wares, ctx) {
@@ -22,6 +23,7 @@ function configure (app, wares, ctx) {
   // List treatments available
   api.get('/treatments', function(req, res) {
     ctx.treatments.list(req.query, function (err, results) {
+      _.forEach(results, function clean(t) { t.carbs = Number(t.carbs); t.insulin = Number(t.insulin); });
       return res.json(results);
     });
   });

--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -75,7 +75,7 @@ function init() {
       iobObj = _.isArray(devicestatusEntry.openaps.iob) ? devicestatusEntry.openaps.iob[0] : devicestatusEntry.openaps.iob;
 
       // array could still be empty, handle as null
-      if (iobObj === undefined) {
+      if (_.isEmpty(iobObj)) {
         return {};
       }
 


### PR DESCRIPTION
…is missing but expected.

Fixes #1901 in a bit more generic manner, as well as API issue with installations that backdate to when Nightscout stored insulin information in treatments as Strings. Tested to not impact performance (the conversion for a month of data takes less than a millisecond on a somewhat slow computer).