### PR TITLE
Show last predicted, even if lastLoop doesn't have a prediction

### DIFF
--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -87,6 +87,7 @@ function init() {
     var result = {
       lastLoop: null
       , lastEnacted: null
+      , lastPredicted: null
       , lastOkMoment: null
     };
 
@@ -97,6 +98,12 @@ function init() {
         if (!result.lastEnacted || enacted.moment.isAfter(result.lastEnacted.moment)) {
           result.lastEnacted = enacted;
         }
+      }
+    }
+
+    function assignLastPredicted (loopStatus) {
+      if (loopStatus.predicted && loopStatus.predicted.startDate) {
+        result.lastPredicted = loopStatus.predicted;
       }
     }
 
@@ -118,6 +125,7 @@ function init() {
         loopStatus.moment = moment(loopStatus.timestamp);
         assignLastEnacted(loopStatus);
         assignLastLoop(loopStatus);
+        assignLastPredicted(loopStatus);
         assignLastOkMoment(loopStatus);
       }
     });
@@ -244,8 +252,8 @@ function init() {
         };
       }
 
-      if (prop.lastLoop && prop.lastLoop.predicted && prop.lastLoop.predicted.startDate) {
-        var predicted = prop.lastLoop.predicted;
+      if (prop.lastPredicted) {
+        var predicted = prop.lastPredicted;
         var startTime = moment(predicted.startDate);
         if (predicted.values) {
           points = points.concat(_.map(predicted.values, toPoints(startTime, 0)));


### PR DESCRIPTION
If we have Loop errors to report, but no updated prediction, the graph was redrawing to drop the forecast area. In other cases (like if Loop was offline) it would keep drawing the old forecast as new BG points came in.  This updates the loop plugin to keep the old forecast onscreen until we have an updated one. 