### PR TITLE
Add right padding to button bar to fix scrollbar issue

### DIFF
--- a/static/css/drawer.css
+++ b/static/css/drawer.css
@@ -227,7 +227,7 @@ h1, legend,
   overflow: hidden;
 }
 #buttonbar {
-  padding-right: 10px;
+  padding-right: 15px;
   height: 44px;
   opacity: 0.75;
   vertical-align: middle;

--- a/static/index.html
+++ b/static/index.html
@@ -35,7 +35,7 @@
     <body>
         <div class="container loading" id="container">
             <div id="toolbar">
-                <div id="buttonbar">
+                <div id="buttonbar" style="padding-right:15px">
                     <a id="editbutton" class="tip" original-title="Edit Mode" href="#" style="display:none;"><i class="icon-edit"></i></a>
                     <a id="testAlarms" class="tip" original-title="Alarm Test / Smartphone Enable" href="#"><i class="icon-volume"></i></a>
                     <a id="drawerToggle" class="tip" original-title="Settings" href="#"><i class="icon-menu"></i></a>

--- a/static/index.html
+++ b/static/index.html
@@ -35,7 +35,7 @@
     <body>
         <div class="container loading" id="container">
             <div id="toolbar">
-                <div id="buttonbar" style="padding-right:15px">
+                <div id="buttonbar">
                     <a id="editbutton" class="tip" original-title="Edit Mode" href="#" style="display:none;"><i class="icon-edit"></i></a>
                     <a id="testAlarms" class="tip" original-title="Alarm Test / Smartphone Enable" href="#"><i class="icon-volume"></i></a>
                     <a id="drawerToggle" class="tip" original-title="Settings" href="#"><i class="icon-menu"></i></a>


### PR DESCRIPTION
Windows users may experience scollbars being displayed when hovering
over the right most icon on the button bar. This adds right padding to
kick the buttons over to the left more.

This is for issue #1788 