### PR TITLE
minify bundle.js

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -8,7 +8,7 @@ function bundle() {
     watch: __dirname + '/../lib/',
     mount: '/public/js/bundle.js',
     verbose: true,
-    //minify: true,
+    minify: true,
     bundle_opts: { debug: true }, // enable inline sourcemap on js files
     write_file: __dirname + '/bundle.out.js'
   });


### PR DESCRIPTION
Minify bundle.js to improve page load latency.

According to Pingdom speed test, this reduces download size by about 800kB, and improves page load latency by about 500ms.