### PR TITLE
Shortened dutch translations 

### DIFF
--- a/lib/language.js
+++ b/lib/language.js
@@ -3912,7 +3912,7 @@ function init() {
       ,pt: 'Insulina ativa'
       ,ru: 'Активный инсулин'
       ,sk: 'Aktívny inzulín (IOB)'
-      ,nl: 'Actieve nnsuline (IOB)'
+      ,nl: 'Actieve insuline (IOB)'
       ,ko: 'IOB'
       }
     ,'Carbs-on-Board' : {
@@ -3946,7 +3946,7 @@ function init() {
       ,pt: 'Ajuda de bolus'
       ,ru: 'Предпросмотр мастера болюса'
       ,sk: 'Bolus Wizard'
-      ,nl: 'Bolus wizzard'
+      ,nl: 'Bolus Wizard Preview (BWP)'
       ,ko: 'Bolus 마법사 미리보기'
       }
     ,'Value Loaded' : {
@@ -3979,7 +3979,7 @@ function init() {
       ,pt: 'Idade da Cânula (ICAT)'
       ,ru: 'Возраст сенсора'
       ,sk: 'Zavedenie kanyly (CAGE)'
-      ,nl: 'Canule leeftijd'
+      ,nl: 'Canule leeftijd (CAGE)'
       ,ko: '캐뉼라 사용기간'
       }
     ,'Basal Profile' : {
@@ -7720,7 +7720,7 @@ function init() {
       ,bg: 'Възраст на инсулина (ВИ)'
       ,ro: 'Vechimea insulinei'
       ,ru: 'Возраст инсулина'
-      ,nl: 'Insuline leeftijd'
+      ,nl: 'Insuline leeftijd (IAGE)'
       ,ko: '인슐린 사용 기간'
       ,fi: 'Insuliinin ikä'
       ,pt: 'Idade da insulina'
@@ -8641,7 +8641,7 @@ function init() {
       ,bg: 'БП'
       ,ko: 'BWP'
       ,it: 'BWP'
-      ,nl: 'Bolus Wizzard preview' 
+      ,nl: 'BWP' 
     }
     ,'Urgent' : {
       cs:'Urgentní'
@@ -9093,7 +9093,7 @@ function init() {
       ,pt: 'COB'
       ,sk: 'SACH'
       ,it: 'COB'
-      ,nl: 'Koolhydraten on board' 
+      ,nl: 'COB' 
     }
    ,'Last Carbs' : {
       cs:'Poslední sacharidy'


### PR DESCRIPTION
@martijnmcb  changed some of the dutch translations, but because of the length, some translations caused layout problems. this patch fixes these and fix a typo in 'nnsuline' instead of 'insuline'.