### PR TITLE
Show correct mmol/l value in treatment tooltip

### DIFF
--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -174,7 +174,7 @@ function init (client, d3) {
       return '<strong>'+translate('Time')+':</strong> ' + client.formatTime(new Date(d.mills)) + '<br/>' +
         (d.eventType ? '<strong>'+translate('Treatment type')+':</strong> ' + translate(client.careportal.resolveEventName(d.eventType)) + '<br/>' : '') +
         (d.reason ? '<strong>'+translate('Reason')+':</strong> ' + translate(d.reason) + '<br/>' : '') +
-        (d.glucose ? '<strong>'+translate('BG')+':</strong> ' + utils.scaleMgdl(d.glucose) + (d.glucoseType ? ' (' + translate(d.glucoseType) + ')': '') + '<br/>' : '') +
+        (d.glucose ? '<strong>'+translate('BG')+':</strong> ' + d.glucose + (d.glucoseType ? ' (' + translate(d.glucoseType) + ')': '') + '<br/>' : '') +
         (d.enteredBy ? '<strong>'+translate('Entered By')+':</strong> ' + d.enteredBy + '<br/>' : '') +
         (d.targetTop ? '<strong>'+translate('Target Top')+':</strong> ' + d.targetTop + '<br/>' : '') +
         (d.targetBottom ? '<strong>'+translate('Target Bottom')+':</strong> ' + d.targetBottom + '<br/>' : '') +
@@ -493,7 +493,7 @@ function init (client, d3) {
         (treatment.carbs ? '<strong>' + translate('Carbs') + ':</strong> ' + treatment.carbs + '<br/>' : '') +
         (treatment.insulin ? '<strong>' + translate('Insulin') + ':</strong> ' + treatment.insulin + '<br/>' : '') +
         (treatment.enteredinsulin ? '<strong>' + translate('Combo Bolus') + ':</strong> ' + treatment.enteredinsulin + 'U, ' + treatment.splitNow + '% : ' + treatment.splitExt + '%, ' + translate('Duration') + ': ' + treatment.duration + '<br/>' : '') +
-        (treatment.glucose ? '<strong>' + translate('BG') + ':</strong> ' + utils.scaleMgdl(treatment.glucose) + (treatment.glucoseType ? ' (' + translate(treatment.glucoseType) + ')' : '') + '<br/>' : '') +
+        (treatment.glucose ? '<strong>' + translate('BG') + ':</strong> ' + treatment.glucose + (treatment.glucoseType ? ' (' + translate(treatment.glucoseType) + ')' : '') + '<br/>' : '') +
         (treatment.enteredBy ? '<strong>' + translate('Entered By') + ':</strong> ' + treatment.enteredBy + '<br/>' : '') +
         (treatment.notes ? '<strong>' + translate('Notes') + ':</strong> ' + treatment.notes : '') +
         boluscalcTooltip(treatment)


### PR DESCRIPTION
It seems that by the time that treatment glucose values reach `lib/client/renderer.js`, they have already been converted to mmol/L where appropriate. The code was doing a double conversion from mg/dL to mmol/L, leading to a BG of 5.4mmol/L displaying as 0.3 in the treatment tooltip.