### PR TITLE
display oref1 UAM purple line

### DIFF
--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -355,6 +355,9 @@ function init(ctx) {
         if (prop.lastPredBGs.COB) {
           points = points.concat(_.map(prop.lastPredBGs.COB, toPoints(7000)));
         }
+        if (prop.lastPredBGs.UAM) {
+          points = points.concat(_.map(prop.lastPredBGs.UAM, toPoints(9000)));
+        }
       }
 
       return points;


### PR DESCRIPTION
Per https://github.com/openaps/oref0/pull/424, the "oref1" features of openaps/oref0 now support unannounced meal predictions and dosing.  This PR displays those predictions in Nightscout (alongside the other three OpenAPS purple line predictions) if a rig is generating them.