### PR TITLE
Update example start command to allow spaces in vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Easy to emulate on the commandline:
 
 From now on you can run using
 ```bash
-    $ env $(cat my.env) PORT=1337 node server.js
+    $ (eval $(cat my.env | sed 's/^/export /') && PORT=1337 node server.js)
 ```
 
 Your hosting provider probably has a way to set these through their GUI.


### PR DESCRIPTION
When running the server with environment variables like the following set in your .env file:

```
ENABLE=cob iob careportal
```

Then NS will start with ENABLE actually set to 'cob'. 

This update allows environment variables with spaces in them to be used.