### PR TITLE
SVG dimension fix

### DIFF
--- a/static/images/NONE.svg
+++ b/static/images/NONE.svg
@@ -1,3 +1,9 @@
-<svg width="244px" height="110px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g style="">  <rect x="8.000000" y="23.000000" width="228.000000" height="64.000000" style="fill: rgba(255, 255, 255, 1.000000); " fill="#feffff" stroke="none"  />
-</g></svg>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="67.7 -12.1 823.8 592" style="enable-background:new 67.7 -12.1 823.8 592;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<polygon class="st0" points="761.3,200.5 761.3,370.8 169.3,370.8 169.3,200.5"/>
+</svg>


### PR DESCRIPTION
Somehow the NONE.svg ended up with an incorrect rectangle shape; fixed
to match the aspect ratio of the other symbols.