### PR TITLE
Remove pattern regex from basal change field

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -339,7 +339,7 @@
                     </label>
                     <label id="percentLabel" for="percent" class="left-column short-label">
                         <span class="translate">Percent</span>
-                        <input type="number" step="10" id="percent" placeholder="Basal change in %" class="titletranslate" pattern="\d*" />
+                        <input type="number" step="10" id="percent" placeholder="Basal change in %" class="titletranslate" />
                     </label>
                     <label id="profileLabel" for="profile" class="left-column short-label">
                         <span class="translate">Profile</span>


### PR DESCRIPTION
Having the regex require integers means that only the numeric keypad will pop on iOS. This prevents the entry of negative values, which is pretty critical for temp basals.

I'm not sure whether there's adequate sanitizing of the entry on the other side of this; that should be double-checked.