### PR TITLE
Adding some test coverage for /lib/client/renderer.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 
 bundle/bundle.out.js
 
+.vscode/
 .idea/
 *.iml
 my.env

--- a/tests/client.renderer.test.js
+++ b/tests/client.renderer.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('should');
+let _ = require('lodash');
+
+let renderer = require('../lib/client/renderer');
+const MAX_DELTA = 0.0001;
+const PREV_CHART_WIDTHS = [
+  { width: 400, expectedScale: 3.5 }
+  , { width: 500, expectedScale: 2.625 }
+  , { width: 900, expectedScale: 1.75 }
+];
+
+describe('renderer', () => {
+  describe('bubbleScale', () => {
+    _.forEach(PREV_CHART_WIDTHS, (prev) => {
+      describe(`prevChartWidth < ${prev.width}`, () => {
+        let mockClient = {
+          utils: true
+          , chart: { prevChartWidth: prev.width }
+          , foucusRangeMS: true
+        };
+        it('scales correctly', () => {
+          renderer(mockClient, {}).bubbleScale().should.be.approximately(prev.expectedScale, MAX_DELTA);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
I noticed the coverage report showed a pretty large gap in coverage for /lib/client/renderer.js. This is just an incremental step towards getting that 70% coverage mark up to a healthier number... only adds a test and a small change to .gitignore for VS Code.