### PR TITLE
deviceInfo.recent null check

### DIFF
--- a/lib/plugins/bgnow.js
+++ b/lib/plugins/bgnow.js
@@ -209,7 +209,7 @@ function init (ctx) {
       _.forEach(delta.previous.sgvs, function deviceAndValue(entry) {
         var device = utils.deviceName(entry.device);
         var deviceInfo = deviceInfos[device];
-        if (deviceInfo) {
+        if (deviceInfo && deviceInfo.recent) {
           var deviceDelta = bgnow.calcDelta(
             { mills: deviceInfo.recent.mills , mean: deviceInfo.recent.mgdl}
             , { mills: entry.mills, mean: entry.mgdl}


### PR DESCRIPTION
I saw a case this morning where some sort of apparently truncated upload from one of my rigs resulted in a deviceInfo variable that did not contain deviceInfo.recent, resulting in an inability to load NS.

This PR adds a check to make sure that deviceInfo.recent exists before trying to reference deviceInfo.recent.mills.