### PR TITLE
Retro at specific time

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -358,7 +358,8 @@ client.load = function load(serverSettings, callback) {
 
   client.showRetroAtTime = function showRetroAtTime(time) {
     client.now = time.getTime();
-    client.chart.brush.extent([new Date(time.getTime() - client.focusRangeMS), time]);
+    client.chart.brush.extent([new Date(time.getTime() - client.focusRangeMS),
+                               new Date(time.getTime() + client.forecastTime)]);
     client.chart.brush(d3.select(".brush").transition());
     client.chart.brush.event(d3.select(".brush").transition().delay(1000))
   }

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -36,6 +36,7 @@ client.headers = function headers ( ) {
   }
 };
 
+
 client.init = function init(callback) {
 
   client.browserUtils = require('./browser-utils')($);
@@ -355,6 +356,12 @@ client.load = function load(serverSettings, callback) {
     $(document).attr('title', windowTitle || generateTitle());
   }
 
+  client.showRetroAtTime = function showRetroAtTime(time) {
+    client.now = time.getTime();
+    client.chart.brush.extent([new Date(time.getTime() - client.focusRangeMS), time]);
+    client.chart.brush(d3.select(".brush").transition());
+    client.chart.brush.event(d3.select(".brush").transition().delay(1000))
+  }
 // clears the current user brush and resets to the current real time data
   function updateBrushToNow(skipBrushing) {
 
@@ -1130,6 +1137,29 @@ client.load = function load(serverSettings, callback) {
     }
 
   }
+
+$(document).on("click", "#currentTime", function() {
+  var original_text = $(this).text();
+  var new_input = $("<input id=\"currentTime_editor\"/>");
+  new_input.val(new Date(client.now).toString());
+  $(this).replaceWith(new_input);
+  new_input.focus();
+});
+
+$(document).on("blur", "#currentTime_editor", function() {
+  var new_input = $(this).val();
+  var updated_text = $("<div id=\"currentTime\" />");
+  var newDate = new Date(new_input);
+  if (isNaN( newDate.getTime())) {
+   newDate = new Date(Date.now()); 
+  }
+  updated_text.text(formatTime(newDate, true));
+  $(this).replaceWith(updated_text);
+  client.showRetroAtTime(newDate);
+});
+
+
+
 
 };
 

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -130,6 +130,12 @@ function init (client, d3) {
       return sel;
     }
 
+    function focusCircleDoubleClick (d) {
+      if (d && d.mills) {
+        client.showRetroAtTime(new Date(d.mills));
+      }
+    }
+
     function focusCircleTooltip (d) {
       if (d.type !== 'sgv' && d.type !== 'mbg' && d.type !== 'forecast') {
         return;
@@ -165,7 +171,8 @@ function init (client, d3) {
     // if new circle then just display
     prepareFocusCircles(focusCircles.enter().append('circle'))
       .on('mouseover', focusCircleTooltip)
-      .on('mouseout', hideTooltip);
+      .on('mouseout', hideTooltip)
+      .on('dblclick', focusCircleDoubleClick);
 
     focusCircles.exit().remove();
   };


### PR DESCRIPTION
Very early preview, still WIP. 

Allow jumping to the retro view at a specific time. This is very useful for reviewing openaps decisions.

 - Double clicking on a point on the chart will move the retro view at the time of that point. 
 - Clicking on the current time also allows to enter a time and move the retro view at that time. 

This is very crude right now. TODO:
 -  I want to make the time selection better. It's just a javascript time string at the moment. Maybe some kind of date picker widget?? Looking for suggestions, please.
 - I also want to add +5min and -5 min buttons. 

I'm just raising the pr for discussion on whether this is a good feature and the approach is okay.

