### PR TITLE
Autotune first day consumed to establish conditions

### DIFF
--- a/lib/report_plugins/autotune.js
+++ b/lib/report_plugins/autotune.js
@@ -184,6 +184,11 @@ autotune.report = function report_autotune(datastorage, sorteddaystoshow, option
     return;
   }
 
+  if (sorteddaystoshow.length < 2) {
+    $('<div class="error">' + "Error: At least 2 days must be selected. The first day is consumed to establish conditions going into the second day." + "</div>").appendTo(report);
+    return;
+  }
+
   var table = $('<table class="centeraligned autotune-report">');
   report.append(table);
 
@@ -197,21 +202,22 @@ autotune.report = function report_autotune(datastorage, sorteddaystoshow, option
   var profile = profileRecords[foundActiveProfile.activeIndex];
   var store = profile.store[profile.defaultProfile];
 
-  const re = /\d{4}-\d{2}-\d{2}/g;
-  var keys = _.filter(Object.keys(datastorage), function (key) { return key.match(re)});
-
-  keys = _.filter(keys, function (key) { return sorteddaystoshow.includes(key); });
+  var keys = _.cloneDeep(sorteddaystoshow);
 
   var convertedProfile = autotune.convertProfile(profile);
   var opts = {
         profile: convertedProfile //inputs.profile
       // TODO: figure out how to use only the relevant treatments so it's not so slow on >1d of data
       , history: _.flatMap(keys, function(key){return datastorage[key].treatments;}) //inputs.history
-      , glucose: _.flatMap(keys, function(key){return datastorage[key].sgv;})//inputs.glucose
       , prepped_glucose: undefined// inputs.prepped_glucose
       , basalprofile: convertedProfile.basalprofile
       , carbs: []
   };
+
+  // Remove the first day from the glucose data so Autotune starts
+  // knowing current conditions.
+  var glucoseKeys = sorteddaystoshow.slice(1);
+  opts.glucose = _.flatMap(glucoseKeys, function(key){return datastorage[key].sgv;})//inputs.glucose
 
   if (Nightscout.client.settings.units == 'mmol') {
    var g = _.cloneDeep(opts.glucose);

--- a/lib/report_plugins/autotune.js
+++ b/lib/report_plugins/autotune.js
@@ -32,7 +32,6 @@ autotune.html = function html(client) {
     + '<p><b>NOTE</b>: The “current” basal rate, ISF, and carb ratio is based on what you manually input into the Nightscout profile. If you have updated your pump or use other tools (i.e. one of the DIY closed loops), this may not be up to date with your settings there.</p>'
     + '<p><b>NOTE</b>: Autotune requires insulin delivery and carb intake information prior to the beginning of the time period being tuned. To faciliate this, the first day in the From / To range will be consumed to establish current conditions going into the second day.</p>'
     + '<p><i>More details about autotune and documentation around interpreting autotune can be found <a href="http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html">here</a>.</i></p>'
-    + '<p><i>More details about autotune and documentation around interpreting autotune can be found <a href="http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html">here</a>.</i></p>'
     + '<p><input type="checkbox" id="compute_autotune">Compute autotune</p>'
     + '<div id="autotune-report"></div>'
     ;

--- a/lib/report_plugins/autotune.js
+++ b/lib/report_plugins/autotune.js
@@ -30,7 +30,7 @@ autotune.html = function html(client) {
     '<h2>' + translate('Autotune') + '</h2>'
     + '<p><b>WARNING</b>: Autotune is a DIY tool for recommending potential changes to (a single) ISF, basal rate, and (a single) carb ratio. If you have questions or concerns about your personal settings, you should talk with your healthcare provider about them.</p>'
     + '<p><b>NOTE</b>: The “current” basal rate, ISF, and carb ratio is based on what you manually input into the Nightscout profile. If you have updated your pump or use other tools (i.e. one of the DIY closed loops), this may not be up to date with your settings there.</p>'
-    + '<p><b>NOTE</b>: Autotune requires insulin delivery and carb intake information prior to the beginning of the time period being tuned. To faciliate this, the first day in the From / To range will be consumed to establish current conditions going into the second day.</p>"
+    + '<p><b>NOTE</b>: Autotune requires insulin delivery and carb intake information prior to the beginning of the time period being tuned. To faciliate this, the first day in the From / To range will be consumed to establish current conditions going into the second day.</p>'
     + '<p><i>More details about autotune and documentation around interpreting autotune can be found <a href="http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html">here</a>.</i></p>'
     + '<p><i>More details about autotune and documentation around interpreting autotune can be found <a href="http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html">here</a>.</i></p>'
     + '<p><input type="checkbox" id="compute_autotune">Compute autotune</p>'

--- a/lib/report_plugins/autotune.js
+++ b/lib/report_plugins/autotune.js
@@ -30,6 +30,8 @@ autotune.html = function html(client) {
     '<h2>' + translate('Autotune') + '</h2>'
     + '<p><b>WARNING</b>: Autotune is a DIY tool for recommending potential changes to (a single) ISF, basal rate, and (a single) carb ratio. If you have questions or concerns about your personal settings, you should talk with your healthcare provider about them.</p>'
     + '<p><b>NOTE</b>: The “current” basal rate, ISF, and carb ratio is based on what you manually input into the Nightscout profile. If you have updated your pump or use other tools (i.e. one of the DIY closed loops), this may not be up to date with your settings there.</p>'
+    + '<p><b>NOTE</b>: Autotune requires insulin delivery and carb intake information prior to the beginning of the time period being tuned. To faciliate this, the first day in the From / To range will be consumed to establish current conditions going into the second day.</p>"
+    + '<p><i>More details about autotune and documentation around interpreting autotune can be found <a href="http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html">here</a>.</i></p>'
     + '<p><i>More details about autotune and documentation around interpreting autotune can be found <a href="http://openaps.readthedocs.io/en/latest/docs/Customize-Iterate/autotune.html">here</a>.</i></p>'
     + '<p><input type="checkbox" id="compute_autotune">Compute autotune</p>'
     + '<div id="autotune-report"></div>'
@@ -197,6 +199,8 @@ autotune.report = function report_autotune(datastorage, sorteddaystoshow, option
 
   const re = /\d{4}-\d{2}-\d{2}/g;
   var keys = _.filter(Object.keys(datastorage), function (key) { return key.match(re)});
+
+  keys = _.filter(keys, function (key) { return sorteddaystoshow.includes(key); });
 
   var convertedProfile = autotune.convertProfile(profile);
   var opts = {


### PR DESCRIPTION
The standalone Autotune algorithms pull data from before the time period being tuned so the IOB and COB are accurately reflected at the beginning of the tuning period.

This change accomplishes the same thing by consuming the first day in the From / To fields to set the conditions going into the second day and onward that are to be tuned.