### PR TITLE
Fix rawbg calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
   An option plugin to enable adding foods from database in Bolus Wizard and enable .
 
 ##### `rawbg` (Raw BG)
-  Calculates BG using sensor and calibration records from and displays an alternate BG values and noise levels.
+  Calculates BG using sensor and calibration records from and displays an alternate BG values and noise levels. Defaults that can be adjusted with [extended setting](#extended-settings)
+  * `SMOOTH` (`false`) - If `SMOOTH` is false, rawbg will be calculated such that it exagerates direction changes to provide early visible indication of glucose trend changes.
 
 ##### `iob` (Insulin-on-Board)
   Adds the IOB pill visualization in the client and calculates values that used by other plugins.  Uses treatments with insulin doses and the `dia` and `sens` fields from the [treatment profile](#treatment-profile).

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
 ##### `rawbg` (Raw BG)
   Calculates BG using sensor and calibration records from and displays an alternate BG values and noise levels. Defaults that can be adjusted with [extended setting](#extended-settings)
   * `SMOOTH` (`false`) - If `SMOOTH` is false, rawbg will be calculated such that it exagerates direction changes to provide early visible indication of glucose trend changes.
+  * `UNFILTERED` (`false`) - If `UNFILTERED` is false, rawbg will be calculated using the raw filtered value. If `UNFILTERED` is true, rawbg will be calculated using the raw unfiltered value.
 
 ##### `iob` (Insulin-on-Board)
   Adds the IOB pill visualization in the client and calculates values that used by other plugins.  Uses treatments with insulin doses and the `dia` and `sens` fields from the [treatment profile](#treatment-profile).

--- a/README.md
+++ b/README.md
@@ -319,8 +319,10 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
 
 ##### `rawbg` (Raw BG)
   Calculates BG using sensor and calibration records from and displays an alternate BG values and noise levels. Defaults that can be adjusted with [extended setting](#extended-settings)
-  * `SMOOTH` (`false`) - If `SMOOTH` is false, rawbg will be calculated such that it exagerates direction changes to provide early visible indication of glucose trend changes.
-  * `UNFILTERED` (`false`) - If `UNFILTERED` is false, rawbg will be calculated using the raw filtered value. If `UNFILTERED` is true, rawbg will be calculated using the raw unfiltered value.
+  * `DISPLAY` (`unsmoothed`) - Allows the user to control which algorithm is used to calculate the displayed raw BG values using the most recent calibration record.
+    * `unfiltered` - Raw BG is calculated by applying the calibration to the glucose record's unfiltered value.
+    * `filtered` - Raw BG is calculated by applying the calibration to the glucose record's filtered value. The glucose record's filtered values are generally produced by the CGM by a running average of the unfiltered values to produce a smoothed value when the sensor noise is high.
+    * `unsmoothed` - Raw BG is calculated by first finding the ratio of the calculated filtered value (the same value calculated by the `filtered` setting) to the reported glucose value. The displayed raw BG value is calculated by dividing the calculated unfiltered value (the same value calculated by the `unfiltered` setting) by the ratio.  The effect is to exagerate changes in trend direction so the trend changes are more noticeable to the user. This is the legacy raw BG calculation algorithm.
 
 ##### `iob` (Insulin-on-Board)
   Adds the IOB pill visualization in the client and calculates values that used by other plugins.  Uses treatments with insulin doses and the `dia` and `sens` fields from the [treatment profile](#treatment-profile).

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1052,9 +1052,11 @@ client.load = function load(serverSettings, callback) {
   function prepareEntries ( ) {
     // Post processing after data is in
     var temp1 = [ ];
-    if (client.ddata.cal && client.rawbg.isEnabled(client.sbx)) {
+    var sbx = client.sbx.withExtendedSettings(client.rawbg);
+
+    if (client.ddata.cal && client.rawbg.isEnabled(sbx)) {
       temp1 = client.ddata.sgvs.map(function (entry) {
-        var rawbgValue = client.rawbg.showRawBGs(entry.mgdl, entry.noise, client.ddata.cal, client.sbx) ? client.rawbg.calc(entry, client.ddata.cal, client.sbx) : 0;
+        var rawbgValue = client.rawbg.showRawBGs(entry.mgdl, entry.noise, client.ddata.cal, sbx) ? client.rawbg.calc(entry, client.ddata.cal, sbx) : 0;
         if (rawbgValue > 0) {
           return { mills: entry.mills - 2000, mgdl: rawbgValue, color: 'white', type: 'rawbg' };
         } else {

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -137,10 +137,11 @@ function init (client, d3) {
 
       function getRawbgInfo ( ) {
         var info = { };
+        var sbx = client.sbx.withExtendedSettings(client.rawbg);
         if (d.type === 'sgv') {
           info.noise = client.rawbg.noiseCodeToDisplay(d.mgdl, d.noise);
-          if (client.rawbg.showRawBGs(d.mgdl, d.noise, client.ddata.cal, client.sbx)) {
-            info.value = utils.scaleMgdl(client.rawbg.calc(d, client.ddata.cal, client.sbx));
+          if (client.rawbg.showRawBGs(d.mgdl, d.noise, client.ddata.cal, sbx)) {
+            info.value = utils.scaleMgdl(client.rawbg.calc(d, client.ddata.cal, sbx));
           }
         }
         return info;

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -15,7 +15,7 @@ function init (ctx) {
 
   rawbg.getPrefs = function getPrefs (sbx) {
     return {
-      smooth: (sbx && sbx.extendedSettings.smooth) ? (sbx.extendedSettings.smooth.toLowerCase() == "true")  : false
+      smooth: (sbx && sbx.extendedSettings.smooth) ? sbx.extendedSettings.smooth  : false
     };
   };
 

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -16,7 +16,7 @@ function init (ctx) {
   rawbg.getPrefs = function getPrefs (sbx) {
     return {
       smooth: (sbx && sbx.extendedSettings.smooth) ? sbx.extendedSettings.smooth  : false
-      unfiltered: (sbx && sbx.extendedSettings.unfiltered) ? sbx.extendedSettings.unfiltered  : false
+      , unfiltered: (sbx && sbx.extendedSettings.unfiltered) ? sbx.extendedSettings.unfiltered  : false
     };
   };
 

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -15,7 +15,7 @@ function init (ctx) {
 
   rawbg.getPrefs = function getPrefs (sbx) {
     return {
-      smooth: sbx.extendedSettings.smooth ? (sbx.extendedSettings.smooth.toLowerCase() == "true")  : false
+      smooth: (sbx && sbx.extendedSettings.smooth) ? (sbx.extendedSettings.smooth.toLowerCase() == "true")  : false
     };
   };
 

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -13,6 +13,12 @@ function init (ctx) {
     , pillFlip: true
   };
 
+  rawbg.getPrefs = function getPrefs (sbx) {
+    return {
+      smooth: sbx.extendedSettings.smooth ? (sbx.extendedSettings.smooth.toLowerCase() == "true")  : false
+    };
+  };
+
   rawbg.setProperties = function setProperties (sbx) {
     sbx.offerProperty('rawbg', function setRawBG ( ) {
       var result = { };
@@ -49,16 +55,21 @@ function init (ctx) {
     sbx.pluginBase.updatePillText(rawbg, options);
   };
 
-  rawbg.calc = function calc(sgv, cal) {
+  rawbg.calc = function calc(sgv, cal, sbx) {
     var raw = 0;
     var cleaned = cleanValues(sgv, cal);
 
+    var prefs = rawbg.getPrefs(sbx);
+
     if (cleaned.slope === 0 || cleaned.unfiltered === 0 || cleaned.scale === 0) {
       raw = 0;
-    } else if (parseInt(sgv.noise) < 2 || sgv.mgdl < 40) {
+    } else if (cleaned.filtered === 0 || sgv.mgdl < 40) {
       raw = cleaned.scale * (cleaned.unfiltered - cleaned.intercept) / cleaned.slope;
-    } else {
+    } else if (prefs.smooth) {
       raw = cleaned.scale * (cleaned.filtered - cleaned.intercept) / cleaned.slope;
+    } else {
+      var ratio = cleaned.scale * (cleaned.filtered - cleaned.intercept) / cleaned.slope / sgv.mgdl;
+      raw = cleaned.scale * (cleaned.unfiltered - cleaned.intercept) / cleaned.slope / ratio;
     }
 
     return Math.round(raw);

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -16,6 +16,7 @@ function init (ctx) {
   rawbg.getPrefs = function getPrefs (sbx) {
     return {
       smooth: (sbx && sbx.extendedSettings.smooth) ? sbx.extendedSettings.smooth  : false
+      unfiltered: (sbx && sbx.extendedSettings.unfiltered) ? sbx.extendedSettings.unfiltered  : false
     };
   };
 
@@ -63,7 +64,7 @@ function init (ctx) {
 
     if (cleaned.slope === 0 || cleaned.unfiltered === 0 || cleaned.scale === 0) {
       raw = 0;
-    } else if (cleaned.filtered === 0 || sgv.mgdl < 40) {
+    } else if (cleaned.filtered === 0 || sgv.mgdl < 40 || prefs.unfiltered) {
       raw = cleaned.scale * (cleaned.unfiltered - cleaned.intercept) / cleaned.slope;
     } else if (prefs.smooth) {
       raw = cleaned.scale * (cleaned.filtered - cleaned.intercept) / cleaned.slope;

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -15,8 +15,7 @@ function init (ctx) {
 
   rawbg.getPrefs = function getPrefs (sbx) {
     return {
-      smooth: (sbx && sbx.extendedSettings.smooth) ? sbx.extendedSettings.smooth  : false
-      , unfiltered: (sbx && sbx.extendedSettings.unfiltered) ? sbx.extendedSettings.unfiltered  : false
+      display: (sbx && sbx.extendedSettings.display) ? sbx.extendedSettings.display  : 'unsmoothed'
     };
   };
 
@@ -64,9 +63,9 @@ function init (ctx) {
 
     if (cleaned.slope === 0 || cleaned.unfiltered === 0 || cleaned.scale === 0) {
       raw = 0;
-    } else if (cleaned.filtered === 0 || sgv.mgdl < 40 || prefs.unfiltered) {
+    } else if (cleaned.filtered === 0 || sgv.mgdl < 40 || prefs.display === 'unfiltered') {
       raw = cleaned.scale * (cleaned.unfiltered - cleaned.intercept) / cleaned.slope;
-    } else if (prefs.smooth) {
+    } else if (prefs.display === 'filtered') {
       raw = cleaned.scale * (cleaned.filtered - cleaned.intercept) / cleaned.slope;
     } else {
       var ratio = cleaned.scale * (cleaned.filtered - cleaned.intercept) / cleaned.slope / sgv.mgdl;

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -55,11 +55,10 @@ function init (ctx) {
 
     if (cleaned.slope === 0 || cleaned.unfiltered === 0 || cleaned.scale === 0) {
       raw = 0;
-    } else if (cleaned.filtered === 0 || sgv.mgdl < 40) {
+    } else if (parseInt(sgv.noise) < 2 || sgv.mgdl < 40) {
       raw = cleaned.scale * (cleaned.unfiltered - cleaned.intercept) / cleaned.slope;
     } else {
-      var ratio = cleaned.scale * (cleaned.filtered - cleaned.intercept) / cleaned.slope / sgv.mgdl;
-      raw = cleaned.scale * (cleaned.unfiltered - cleaned.intercept) / cleaned.slope / ratio;
+      raw = cleaned.scale * (cleaned.filtered - cleaned.intercept) / cleaned.slope;
     }
 
     return Math.round(raw);

--- a/tests/rawbg.test.js
+++ b/tests/rawbg.test.js
@@ -27,7 +27,7 @@ describe('Raw BG', function ( ) {
     sbx.offerProperty = function mockedOfferProperty (name, setter) {
       name.should.equal('rawbg');
       var result = setter();
-      result.mgdl.should.equal(115);
+      result.mgdl.should.equal(113);
       result.noiseLabel.should.equal('Clean');
       done();
     };
@@ -47,7 +47,7 @@ describe('Raw BG', function ( ) {
 
     rawbg.alexa.intentHandlers[0].intentHandler(function next(title, response) {
       title.should.equal('Current Raw BG');
-      response.should.equal('Your raw bg is 115');
+      response.should.equal('Your raw bg is 113');
 
       done();
     }, [], sbx);

--- a/tests/rawbg.test.js
+++ b/tests/rawbg.test.js
@@ -27,7 +27,7 @@ describe('Raw BG', function ( ) {
     sbx.offerProperty = function mockedOfferProperty (name, setter) {
       name.should.equal('rawbg');
       var result = setter();
-      result.mgdl.should.equal(113);
+      result.mgdl.should.equal(115);
       result.noiseLabel.should.equal('Clean');
       done();
     };
@@ -47,7 +47,7 @@ describe('Raw BG', function ( ) {
 
     rawbg.alexa.intentHandlers[0].intentHandler(function next(title, response) {
       title.should.equal('Current Raw BG');
-      response.should.equal('Your raw bg is 113');
+      response.should.equal('Your raw bg is 115');
 
       done();
     }, [], sbx);


### PR DESCRIPTION
Change the rawbg calculations to simply use the noise value to determine whether to use the calibrated filtered value vs the calibrated unfiltered value to display. It was creating a ratio that had the effect of exaggerating acceleration when BG was changing.