### PR TITLE
adding Loop as automated uploader

### DIFF
--- a/lib/plugins/treatmentnotify.js
+++ b/lib/plugins/treatmentnotify.js
@@ -15,13 +15,13 @@ function init() {
     , pluginType: 'notification'
   };
 
-  //automated treatments from OpenAPS shouldn't trigger notifications or snooze alarms
+  //automated treatments from OpenAPS or Loop shouldn't trigger notifications or snooze alarms
   function filterTreatments (sbx) {
     var treatments = sbx.data.treatments;
 
     treatments = _.filter(treatments, function notOpenAPS (treatment) {
       var ok = true;
-      if (treatment.enteredBy && treatment.enteredBy.indexOf('openaps://') === 0) {
+      if (treatment.enteredBy && treatment.enteredBy.indexOf('openaps://' || 'loop://') === 0) {
         ok = _.indexOf(OPENAPS_WHITELIST, treatment.eventType) >= 0;
       }
       return ok;


### PR DESCRIPTION
Loop is also an automated uploader of treatments.  Had an issue where temp basals set by Loop and uploaded to treatments were auto-snoozing BG alarms.  This PR resolves the error shown below.

<img width="1047" alt="screen-shot-2018-02-28-at-10 12 34-am" src="https://user-images.githubusercontent.com/12402160/36831951-86917cd6-1cde-11e8-8f63-e405f3b7d53b.png">


