### PR TITLE
Fix a memory leak in Nightscout chart

### DIFF
--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -881,6 +881,7 @@ function init (client, d3) {
   renderer.drawTreatments = function drawTreatments(client) {
   
     var treatmentCount = 0;
+    chart().focus.selectAll('.draggable-treatment').remove();
     
     _.forEach(client.ddata.treatments, function eachTreatment (d) {
     	if (Number(d.insulin) > 0 || Number(d.carbs) > 0) { treatmentCount += 1; };


### PR DESCRIPTION
The chart would create SVG objects for treatment event records, then later recreate them without deleting the old ones. This resulted in a huge number of duplicates accumulating, which (in my setup) would cause a crash due to excessive memory usage and DOM size in about a day.

Tested by deploying to my personal install and poking around. This corresponds to issue #3499. 