### PR TITLE
Fix Temp Targets so mgdl will always be used 

### DIFF
--- a/lib/data/ddata.js
+++ b/lib/data/ddata.js
@@ -36,7 +36,7 @@ function init( ) {
       first: { }
       , rest: { }
     };
-    
+
     function recent (item) {
       return item.mills >= time - cutoff;
     }
@@ -44,7 +44,7 @@ function init( ) {
     function filterMax(item) {
       return item.mills >= time - max;
     }
-      
+
     function partition (field, filter) {
       var data;
       if (filter) {
@@ -52,7 +52,7 @@ function init( ) {
       } else {
         data = ddata[field];
       }
-      
+
       var parts = _.partition(data, recent);
       result.first[field] = parts[0];
       result.rest[field] = parts[1];
@@ -64,7 +64,7 @@ function init( ) {
 
     result.first.sgvs = ddata.sgvs.filter(filterMax);
     result.first.cals = ddata.cals;
-    
+
     var profiles = _.cloneDeep(ddata.profiles);
     if (profiles && profiles[0])
       for (var k in profiles[0].store) {
@@ -127,7 +127,7 @@ function init( ) {
       .value();
 
   };
-  
+
   ddata.processDurations = function processDurations (treatments, keepzeroduration) {
 
     treatments = _.uniqBy(treatments, 'mills');
@@ -215,6 +215,17 @@ function init( ) {
 
     // filter temp target
     var tempTargetTreatments = ddata.treatments.filter( function filterTargets (t) {
+      //check for a units being sent
+      if (t.units){
+        if (t.units == 'mmol'){
+          //convert to mgdl
+          t.targetTop = t.targetTop * 18;
+          t.targetBottom = t.targetBottom * 18;
+        }
+      }
+      //if we have a temp target thats below 20, assume its mmol and convert to mgdl for safety.
+      if ( t.targetTop < 20 ) { t.targetTop = t.targetTop * 18; }
+      if ( t.targetBottom < 20 ) { t.targetBottom = t.targetBottom * 18; }
       return t.eventType && t.eventType.indexOf('Temporary Target') > -1;
     });
     if (preserveOrignalTreatments)


### PR DESCRIPTION
After the revelation that Temp Targets treat mmol units as mgdl values and set a much lower temp target than expected.
This enforces the use of mgdl so any mmol enabled temp targets will be automatically converted to mgdl.

This PR is very important for people looping on mmol units, if a looping client using mmol units doesnt use a saftey cut off for temp targets.