### PR TITLE
Change regular expression to make Autotune work in Firefox

### DIFF
--- a/lib/report_plugins/autotune/iob/history.js
+++ b/lib/report_plugins/autotune/iob/history.js
@@ -85,7 +85,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
     var tempHistory = [];
     var tempBoluses = [];
     var now = new Date();
-    var timeZone = now.toString().match(/([-\+][0-9]+)\s/)[1];
+    var timeZone = now.toString().match(/([-\+][0-9]+)/)[1];
 
     // Pick relevant events for processing and clean the data
 


### PR DESCRIPTION
This change in the regular expression searching for the timezone offset was required to make Autotune work in Firefox at all.
Firefox reports `now` as `Tue May 08 2018 20:31:03 GMT+0200` while Chrome reports it as `Tue May 08 2018 20:18:25 GMT+0200 (Mitteleuropäische Sommerzeit)` including the name of the time zone, which causes an error using the old regular expression.
On a side note, I could not find where the result of this gets used at all, and since moment-timezone provides much more elegant ways to perform conversions between time zones, it may be possilble to remove these lines entirely.