### PR TITLE
Change min_5m_carbimpact from 3 to 8

### DIFF
--- a/lib/report_plugins/autotune.js
+++ b/lib/report_plugins/autotune.js
@@ -297,7 +297,7 @@ autotune.convertProfile = function convertProfile(profile)
 	
     var autotuneProfile =
     {
-      "min_5m_carbimpact": 3,
+      "min_5m_carbimpact": 8,
       "dia": Number(p.dia),
       "basalprofile": _.map(p.basal, autotune.convertBasal),
       "isfProfile": {


### PR DESCRIPTION
For some reason the autotune branch used a `min_5m-carbimpact` of 3 instead of 8 as oref0 does, leading to unrealistic carb absorption results and thus wrong autotune results. Changing `min_5m-carbimpact` from 3 to 8 leads to Nightscout autotune providing results very similar to autotune running on a rig (still not perfectly identical for reasons I have not yet understood)