### PR TITLE
Add token to nav URLs

### DIFF
--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -94,6 +94,13 @@ function init (client, serverSettings, $) {
 
     $('#editprofilelink').toggle(settings.isEnabled('iob') || settings.isEnabled('cob') || settings.isEnabled('bwp') || settings.isEnabled('basal'));
 
+    var token = client.browserUtils.queryParms().token;
+    if (token) {
+      $('#showreportslink').attr("href", $('#showreportslink').attr("href") + '?token=' + token);
+      $('#editprofilelink').attr("href", $('#editprofilelink').attr("href") + '?token=' + token);
+      $('#editfoodlink').attr("href", $('#editfoodlink').attr("href") + '?token=' + token);
+      $('#clocklink').attr("href", $('#clocklink').attr("href") + '?token=' + token);
+    }
   }
 
   function wireForm ( ) {

--- a/views/index.html
+++ b/views/index.html
@@ -165,7 +165,7 @@
         <div id="drawer">
             <form id="settings-form" role="form" >
                 <ul class="navigation" role="navigation" aria-label="Settings">
-                  <li><a href="report" target="reports" class="translate">Reports</a></li>
+                  <li><a id="showreportslink" href="report" target="reports" class="translate">Reports</a></li>
                   <li class="profilecontrol"><a id="editprofilelink" href="profile" target="profileeditor" class="translate">Profile Editor</a></li>
                   <li class="foodcontrol"><a id="editfoodlink" href="food" target="foodeditor" class="translate">Food Editor</a></li>
                   <li><a id="admintoolslink" href="admin" target="admintools" class="translate">Admin Tools</a></li>


### PR DESCRIPTION
When you access a nightscout page with a token, the token is not included in the urls of the nav menu.  For example, if you have the index page opened, you cannot switch to the reports page without modifying the url yourself.

I've added a few lines to the browser-settings.js to fix this. I've left out the admin page because I don't know whether it makes sense to access that page via token.

This is my first PR (except for translations). I hope I haven't missed anything important.