### PR TITLE
Temporary disable Node 10 build from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: trusty
 node_js:
   - "8"
-  - "10"
 before_install: if [[ `npm --version` != "5.8.0" ]]; then npm install -g npm@latest; npm --version; fi
 matrix:
   fast_finish: true


### PR DESCRIPTION
Because it somehow fails the build.
For example https://travis-ci.org/nightscout/cgm-remote-monitor/builds/397657680

