### PR TITLE
remove python and python-software-properties from setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,8 +2,6 @@
 
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get update
-sudo apt-get install -y nodejs
-sudo apt-get install -y python-software-properties python git
-sudo apt-get install -y build-essential
+sudo apt-get install -y nodejs build-essential git
 
 npm install


### PR DESCRIPTION
As far as I see in the current codebase there are no references to python. 

Should be tested with reinstall on clean pi3 install.

Fixes https://github.com/nightscout/cgm-remote-monitor/issues/3577