### PR TITLE
only test Travis with Node 8 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: trusty
 node_js:
   - "8"
-  - "10"
 before_install: if [[ `npm --version` != "5.8.0" ]]; then npm install -g npm@latest; npm --version; fi
 matrix:
   fast_finish: true


### PR DESCRIPTION
can it be that simultaneuous running Travis instances cause problems. 
For example https://travis-ci.org/nightscout/cgm-remote-monitor/builds/402414140 failed, but tests were ok, and errored only with Node 8 with a `make error` due to `make: write error`


```
# tests 289
# pass 289
# fail 0
=============================================================================
Writing coverage object [/home/travis/build/nightscout/cgm-remote-monitor/coverage/coverage.json]
Writing coverage reports at [/home/travis/build/nightscout/cgm-remote-monitor/coverage]
=============================================================================
=============================== Coverage summary ===============================
Statements   : 40.9% ( 12815/31329 )
Branches     : 21.18% ( 7070/33383 )
Functions    : 32.41% ( 3154/9732 )
Lines        : 67.67% ( 6239/9220 )
================================================================================
make: write error
The command "make travis" exited with 1.
after_script
37.40s$ make report
test -f ./coverage/lcov.info && \
	(npm install coveralls && cat ./coverage/lcov.info | \
	./node_modules/.bin/coveralls) || echo "NO COVERAGE"
+ coveralls@3.0.2
added 7 packages from 20 contributors, updated 3 packages and audited 13433 packages in 12.614s
found 24 vulnerabilities (3 low, 15 moderate, 5 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
test -f ./coverage/lcov.info && \
	(npm install codacy-coverage && cat ./coverage/lcov.info | \
	YOURPACKAGE_COVERAGE=1 ./node_modules/codacy-coverage/bin/codacy-coverage.js) || echo "NO COVERAGE"
+ codacy-coverage@3.0.0
added 13 packages from 17 contributors and audited 13512 packages in 13.018s
found 24 vulnerabilities (3 low, 15 moderate, 5 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
Done. Your build exited with 1.
```` 

