### PR TITLE
temporary disable speechPlugin because it can't be disabled 

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -597,11 +597,11 @@ client.load = function load(serverSettings, callback) {
         $(this).addClass('playing');
       });
       
-      var speechPlugin = client.plugins('speech');
-      
-      if (speechPlugin) {
-         speechPlugin.say(alarmMessage);
-      }
+      //var speechPlugin = client.plugins('speech');
+      //
+      //if (speechPlugin) {
+      //   speechPlugin.say(alarmMessage);
+      //}
       
     }
 


### PR DESCRIPTION
and is enabled by default. Temporary fix for https://github.com/nightscout/cgm-remote-monitor/issues/3682

@sulkaharo can you add the code to be able to only enable it when the `speech` plugin is enabled?