### PR TITLE
upgrades, moment-locales-webpack-plugin integration, easier bundle-analyzer, dutch translations

### DIFF
--- a/lib/language.js
+++ b/lib/language.js
@@ -9974,6 +9974,7 @@ function init() {
       ,ru: 'Избыток инсулина равного %1U, необходимого для достижения нижнего целевого значения, углеводы не будут учтены'
       ,sv: 'Överskott av insulin motsvarande %1U mer än nödvändigt för att nå lågt målvärde, kolhydrater ej medräknade'
       ,nb: 'Insulin tilsvarende %1U mer enn det trengs for å nå lavt mål, karbohydrater ikke medregnet'
+      ,nl: 'Insulineoverschot van %1U om laag doel te behalen (excl. koolhydraten)'
       ,fi: 'Liikaa insuliinia: %1U enemmän kuin tarvitaan tavoitteeseen pääsyyn (huomioimatta hiilihydraatteja)'
       ,pt: 'Excesso de insulina equivalente a %1U além do necessário para atingir a meta inferior, sem levar em conta carboidratos'
       ,sk: 'Nadbytok inzulínu o %1U viac ako je potrebné na dosiahnutie spodnej cieľovej hranice. Neráta sa so sacharidmi.'
@@ -9991,6 +9992,7 @@ function init() {
       ,sv: 'Överskott av insulin motsvarande %1U mer än nödvändigt för att nå lågt målvärde, SÄKERSTÄLL ATT IOB TÄCKS AV KOLHYDRATER'
       ,es: 'Exceso de insulina en %1U más de la necesaria para alcanzar objetivo inferior. ASEGÚRESE QUE LA INSULINA ACTIVA IOB ESTA CUBIERTA POR CARBOHIDRATOS'
       ,nb: 'Insulin tilsvarende %1U mer enn det trengs for å nå lavt mål, PASS PÅ AT AKTIVT INSULIN ER DEKKET OPP MED KARBOHYDRATER'
+      ,nl: 'Insulineoverschot van %1U om laag doel te behalen, ZORG VOOR VOLDOENDE KOOLHYDRATEN VOOR DE ACTIEVE INSULINE'
       ,fi: 'Liikaa insuliinia: %1U enemmän kuin tarvitaan tavoitteeseen pääsyyn, VARMISTA RIITTÄVÄ HIILIHYDRAATTIEN SAANTI'
       ,pt: 'Excesso de insulina equivalente a %1U além do necessário para atingir a meta inferior. ASSEGURE-SE DE QUE A IOB ESTEJA COBERTA POR CARBOIDRATOS'
       ,sk: 'Nadbytok inzulínu o %1U viac ako je potrebné na dosiahnutie spodnej cieľovej hranice. UISTITE SA, ŽE JE TO POKRYTÉ SACHARIDMI'
@@ -11353,42 +11355,52 @@ function init() {
       'alexaUploadBattery': {
           en: 'Your uploader battery is at %1'
           , de: 'Der Akku deines Uploader Handys ist bei %1'
+          , nl: 'De batterij van je mobiel is bij %l'
       },
       'alexaReservoir': {
           en: 'You have %1 units remaining'
           , de: 'Du hast %1 Einheiten übrig'
+          , nl: 'Je hebt nog %l eenheden in je reservoir'
       },
       'alexaPumpBattery': {
         en: 'Your pump battery is at %1 %2'
         , de: 'Der Batteriestand deiner Pumpe ist bei %1 %2'
+        , nl: 'Je pomp batterij is bij %1 %2'
       },
       'alexaLastLoop': {
         en: 'The last successful loop was %1'
         , de: 'Der letzte erfolgreiche Loop war %1'
+        , nl: 'De meest recente goede loop was %1'
       },
     'alexaLoopNotAvailable': {
       en: 'Loop plugin does not seem to be enabled'
       , de: 'Das Loop Plugin scheint nicht aktiviert zu sein'
+      , nl: 'De Loop plugin is niet geactiveerd'
     },
     'alexaLoopForecast': {
       en: 'According to the loop forecast you are expected to be %1 over the next %2'
       , de: 'Entsprechend der Loop Vorhersage landest du bei %1 während der nächsten %2'
+      , nl: 'Volgens de Loop voorspelling is je waarde %1 over de volgnede %2'
     },
     'alexaForecastUnavailable': {
       en: 'Unable to forecast with the data that is available',
-      de: 'Mit den verfügbaren Daten ist eine Loop Vorhersage nicht möglich'
+      de: 'Mit den verfügbaren Daten ist eine Loop Vorhersage nicht möglich',
+      nl: 'Niet mogelijk om een voorspelling te doen met de data die beschikbaar is'
     },
     'alexaRawBG': {
       en: 'Your raw bg is %1'
       , de: 'Dein Rohblutzucker ist %1'
+      , nl: 'Je raw bloedwaarde is %1'
     },
     'alexaOpenAPSForecast': {
       en: 'The OpenAPS Eventual BG is %1'
       , de: 'Der von OpenAPS vorhergesagte Blutzucker ist %1'
+      , nl: 'OpenAPS uiteindelijke bloedglucose van %1'
     },
     'alexaCOB': {
       en: '%1 %2 carbohydrates on board'
       , de: '%1 %2 Gramm Kohlenhydrate wirkend.'
+      , nl: '%1 %2 actieve koolhydraten'
     },
     'Fat [g]': {
         cs: 'Tuk [g]'
@@ -11438,26 +11450,32 @@ function init() {
     'TDD average': {
       cs: 'Průměrná denní dávka'
       , fi: 'Päivän kokonaisinsuliinin keskiarvo'
+      , nl: 'Gemiddelde dagelijkse insuline (TDD)'
     }
     ,
     'Carbs average': {
       cs: 'Průměrné množství sacharidů'
       , fi: 'Hiilihydraatit keskiarvo'
+      , nl: 'Gemiddelde koolhydraten per dag'
     }
     ,
     'Eating Soon': {
       fi: 'Ruokailu pian'
+      , nl: 'Pre-maaltijd modus'
     }
     ,
     'Last entry {0} minutes ago': {
       fi: 'Edellinen verensokeri {0} minuuttia sitten'
+      , nl:  'Laatste waarde {0}  minuten geleden'
     }
     ,
     'change': {
       fi: 'muutos'
+      , nl: 'wijziging'
     },
     'Speech': {
       fi: 'Puhe'
+      , nl: 'Spraak'
     }
 
   };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1579,6 +1579,11 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -1868,13 +1873,6 @@
         "ssri": "^5.2.4",
         "unique-filename": "^1.1.0",
         "y18n": "^4.0.0"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-        }
       }
     },
     "cache-base": {
@@ -3305,9 +3303,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -6571,6 +6569,12 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -7670,6 +7674,15 @@
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
+    "moment-locales-webpack-plugin": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.0.7.tgz",
+      "integrity": "sha512-KjYpaAhmuzGFZl6534FlZoK7QtW3vqlxd+A17W9DlgHJ5yhXANy7AZJl7iYtZpWjAfMTAWiVrQ7YDZdkFO6uRw==",
+      "dev": true,
+      "requires": {
+        "lodash.difference": "^4.5.0"
+      }
     },
     "moment-timezone": {
       "version": "0.5.21",
@@ -11152,9 +11165,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.4.tgz",
-      "integrity": "sha512-RiB1kNcC9RMyqwRrjXC+EjgLoXULoDnCaOnEDzUCHkBN0bHwmtF5rzDMiDWU29gu0kXCRRWwtcTAVFWRECmU2Q==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.5.tgz",
+      "integrity": "sha512-Fm52gLqJqFBnT+Sn411NPDnsgaWiYeRLw42x7Va/mS8TKgaepwoGY7JLXHSEef3d3PmdFXSz1Zx7KMLL89E2QA==",
       "requires": {
         "commander": "~2.16.0",
         "source-map": "~0.6.1"
@@ -11876,9 +11889,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.16.0.tgz",
-      "integrity": "sha512-oNx9djAd6uAcccyfqN3hyXLNMjZHiRySZmBQ4c8FNmf1SNJGhx7n9TSvHNyXxgToRdH65g/Q97s94Ip9N6F7xg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.16.1.tgz",
+      "integrity": "sha512-6jpzObU18y7lXDJz7XCLvzgrqcJ0rZ2jhKvnTivza9gM2GvPW93xxtmEll2GgmdC0zVQAtbHrH/9BtyMjSDZfA==",
       "requires": {
         "@webassemblyjs/ast": "1.5.13",
         "@webassemblyjs/helper-module-context": "1.5.13",
@@ -11891,7 +11904,7 @@
         "ajv-keywords": "^3.1.0",
         "chrome-trace-event": "^1.0.0",
         "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^3.7.1",
+        "eslint-scope": "^4.0.0",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.3.0",
         "loader-utils": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "postinstall": "webpack --mode production --config webpack.config.js && npm run-script update-buster",
     "bundle": "webpack --mode production --config webpack.config.js && npm run-script update-buster",
     "bundle-dev": "webpack --mode development --config webpack.config.js && npm run-script update-buster",
+    "bundle-analyzer": "webpack --mode development --config webpack.config.js --profile --json > stats.json && webpack-bundle-analyzer stats.json",
     "update-buster": "node bin/generateCacheBuster.js >tmp/cacheBusterToken"
   },
   "config": {
@@ -96,15 +97,16 @@
     "socket.io": "^2.1.1",
     "style-loader": "^0.20.2",
     "traverse": "^0.6.6",
-    "uglify-js": "^3.4.4",
+    "uglify-js": "^3.4.5",
     "uuid": "^3.2.1",
-    "webpack": "^4.16.0"
+    "webpack": "^4.16.1"
   },
   "devDependencies": {
     "benv": "^3.3.0",
     "clear-require": "^2.0.0",
     "istanbul": "^0.4.5",
     "mocha": "~3.5.3",
+    "moment-locales-webpack-plugin": "^1.0.7",
     "should": "^13.2.1",
     "supertest": "^3.1.0",
     "webpack-bundle-analyzer": "^2.13.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,13 @@
 const path = require('path');
 const webpack = require('webpack');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
+
 
 var pluginArray = [];
 
 var sourceMapType = 'source-map';
 
 if (process.env.NODE_ENV !== 'development') {
-
-    console.log('Production environment detected. Enabling --optimize-minimize');
 
 /*
     console.log('Development environment detected, enabling Bundle Analyzer');
@@ -57,6 +57,14 @@ var jq = new webpack.ProvidePlugin({
 });
 
 pluginArray.push(jq);
+
+// Strip all locales except the ones defined in lib/language.js
+// (“en” is built into Moment and can’t be removed, 'dk' is not defined in moment)
+ var momentLocales = new MomentLocalesPlugin({
+            localesToKeep: ['bg', 'cs', 'de', 'el', 'es', 'fi', 'fr', 'he', 'hr', 'it', 'ko', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sv', 'zh_cn', 'zh_tw'],
+        }) ;
+pluginArray.push(momentLocales);
+
 
 module.exports = {
     context: path.resolve(__dirname, '.'),


### PR DESCRIPTION
1. webpack 4.16.0 gives problem with report test on Windows

```
Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments:
[0] _isAMomentObject: true, _isUTC: true, _useUTC: true, _l: undefined, _i: T00:00:00, _f: undefined, _strict: undefined, _locale: [object Object]
Error
    at Function.createFromInputFallback (E:\Git\src\cgm-remote-monitor\tmp\js\bundle.js:1:5989)
```

fixed it with an upgrade to 4.16.1

2. a lot of moment-locales are packacked with webpack. Limit to language that are available in Nightscout. Note that `dk` is not available in moment.js. This decreases
      js/bundle.js from 1.86 MiB to 1.72 MiB. 

3. make it possible to use `npm run bundle-analyzer` so that webpack.config.js does not have to be changed in order to run the bundle-analyzer

4. add missing Dutch translations
