### PR TITLE
Make bold in tooltips bolder and only show 3 digits for pump reservoir

### DIFF
--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -151,7 +151,7 @@ function init (client, d3) {
       client.tooltip.transition().duration(TOOLTIP_TRANS_MS).style('opacity', .9);
       client.tooltip.html('<strong>' + translate('BG')+ ':</strong> ' + client.sbx.scaleEntry( d ) +
         (d.type === 'mbg' ? '<br/><strong>' + translate('Device') + ': </strong>' + d.device : '') +
-        (d.type === 'forecast' ? '<br/><strong>' + translate('Forecast Type') + ': </strong>' + d.forecastType : '') +
+        (d.type === 'forecast' && d.forecastType ? '<br/><strong>' + translate('Forecast Type') + ': </strong>' + d.forecastType : '') +
         (rawbgInfo.value ? '<br/><strong>' + translate('Raw BG') + ':</strong> ' + rawbgInfo.value : '') +
         (rawbgInfo.noise ? '<br/><strong>' + translate('Noise') + ':</strong> ' + rawbgInfo.noise : '') +
         '<br/><strong>' + translate('Time') + ':</strong> ' + client.formatTime(new Date(d.mills)))

--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -205,7 +205,7 @@ function init (ctx) {
   function updateReservoir (prefs, result) {
     if (result.reservoir) {
       result.reservoir.label = 'Reservoir';
-      result.reservoir.display = result.reservoir.value + 'U';
+      result.reservoir.display = result.reservoir.value.toPrecision(3) + 'U';
       if (result.reservoir.value < prefs.urgentRes) {
         result.reservoir.level = levels.URGENT;
         result.reservoir.message = 'URGENT: Pump Reservoir Low';

--- a/static/css/jquery.tooltips.css
+++ b/static/css/jquery.tooltips.css
@@ -1,9 +1,13 @@
+.tooltip strong, b {
+    font-weight: 900
+}
 .tooltip {
   position: absolute;
   font-size: 10px;
-  padding: 3px 8px;
+  padding: 3px 5px;
   opacity: 0.9;
   z-index: 9999;
+  word-wrap: break-word;
 }
 .tooltip .tooltip-inner {
   background-color: #000;
@@ -12,6 +16,9 @@
   padding: 3px 8px;
   text-align: center;
   box-shadow: 0 0 5px 0 black;
+  border-radius: 3px;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
 }
 .tooltip .tooltip-arrow {
   position: absolute;

--- a/static/css/jquery.tooltips.css
+++ b/static/css/jquery.tooltips.css
@@ -1,5 +1,5 @@
-.tooltip strong, b {
-    font-weight: 900
+.tooltip strong, .tooltip b {
+    font-weight: 700
 }
 .tooltip {
   position: absolute;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,5 +1,5 @@
 
-@import url("//fonts.googleapis.com/css?family=Ubuntu:400,600");
+@import url('https://fonts.googleapis.com/css?family=Ubuntu:400,700');
 
 @font-face {
   font-family: 'nsicons';
@@ -71,7 +71,7 @@ html, body {
 }
 
 body {
-  font-family: 'Ubuntu', Verdana, Helvetica, Arial, sans-serif;
+  font-family: 'Ubuntu', sans-serif;
   background: #000;
   color: #bdbdbd;
 }


### PR DESCRIPTION
@jasoncalabrese reports differences in bold labels in tooltips. https://gitter.im/nightscout/public?at=5b5c2209bf75446606694d14

I examined them with Chrome (use Inspect, hover over a tooltip and use `F8` to pause Javascript and find  a word from the tooltip and find it in the HTML). I found the following differences between jquery.tipsy and jquery.tooltips.:
- some padding differences 
- difference with rounded corners 
- word-wrap: break-word
I fixed them in this PR and made the boldness (`font-weight`) of the tooltips pill labels `900` (very bold).

Example Chrome view (0.10.3-dev before this PR):
![image](https://user-images.githubusercontent.com/6500826/43361170-766c9fec-92c8-11e8-9ba3-889f837e0461.png)

The CSS path is `html body div.tooltip strong`

Second problem fixed in this PR is a wrapping problem with the pump pill because the word `ago` in dutch is rather long (`geleden`)  and causes the pills to wrap. By only showing three significant digits for the pump resorvoir, this is solved (e.g. 105U, 90.1U, 8.12U, 0.123U). 

@jasoncalabrese and @sulkaharo : please review