### PR TITLE
fix saving food

### DIFF
--- a/lib/server/food.js
+++ b/lib/server/food.js
@@ -11,7 +11,12 @@ function storage (env, ctx) {
   }
 
   function save (obj, fn) {
-    obj._id = new ObjectID(obj._id);
+    try {
+      obj._id = new ObjectID(obj._id);
+    } catch (err){
+      console.error(err);
+      obj._id = new ObjectID();
+    }
     obj.created_at = (new Date( )).toISOString( );
     api().save(obj, function (err, doc) {
       fn(err, doc);


### PR DESCRIPTION
Saving foods in the `/food` editor does not work.

This is caused by the following traceback you get when you save a food.

```
2018-08-04T10:25:32.244096+00:00 app[web.1]: Error: Argument passed in must be a single String of 12 bytes or a string of 24 hex characters
2018-08-04T10:25:32.244099+00:00 app[web.1]:     at new ObjectID (/app/node_modules/bson/lib/bson/objectid.js:50:11)
2018-08-04T10:25:32.244101+00:00 app[web.1]:     at Function.save (/app/lib/server/food.js:14:15)
2018-08-04T10:25:32.244103+00:00 app[web.1]:     at /app/lib/api/food/index.js:59:18
2018-08-04T10:25:32.244105+00:00 app[web.1]:     at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
2018-08-04T10:25:32.244106+00:00 app[web.1]:     at next (/app/node_modules/express/lib/router/route.js:137:13)
2018-08-04T10:25:32.244107+00:00 app[web.1]:     at check (/app/lib/authorization/index.js:182:9)
2018-08-04T10:25:32.244109+00:00 app[web.1]:     at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
2018-08-04T10:25:32.244110+00:00 app[web.1]:     at next (/app/node_modules/express/lib/router/route.js:137:13)
2018-08-04T10:25:32.244111+00:00 app[web.1]:     at Route.dispatch (/app/node_modules/express/lib/router/route.js:112:3)
2018-08-04T10:25:32.244113+00:00 app[web.1]:     at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
2018-08-04T10:25:32.249694+00:00 heroku[router]: at=info method=PUT path="/api/v1/food/" host=xxx.herokuapp.com request_id=yyy fwd="zzz" dyno=web.1 connect=0ms service=20ms status=500 bytes=1026 protocol=https
```

This PR fixes the ObjectID for food creation and makes it possible to save new foods or edit foods in the food editor. This fixes https://github.com/nightscout/cgm-remote-monitor/issues/3520