### PR TITLE
ensure treatments created_at in ISO format

### DIFF
--- a/lib/server/treatments.js
+++ b/lib/server/treatments.js
@@ -144,7 +144,8 @@ function prepareData(obj) {
 
   var results = {
     //TODO: validate format of created_at
-    created_at: obj.created_at || new Date().toISOString()
+    // Perform timezone conversion in case it is required
+    created_at: (obj.created_at ? new Date(obj.created_at) : new Date()).toISOString()
     , preBolusCarbs: ''
   };
 


### PR DESCRIPTION
Because string comparisons are used to retrieve treatments data (e.g., future entries $gte) they always need to be represented with the same timezone.  This commit ensures use of UTC

this commit fixes #2559
this commit fixes #2242
