### PR TITLE
Fixed edit/delete treatment bug (in reports)

### DIFF
--- a/static/report/js/report.js
+++ b/static/report/js/report.js
@@ -635,6 +635,7 @@
       var tquery = '?find[created_at][$gte]='+new Date(from).toISOString()+'&find[created_at][$lt]='+new Date(to).toISOString();
       return $.ajax('/api/v1/treatments.json'+tquery, {
         headers: client.headers()
+        , cache: false
         , success: function (xhr) {
           treatmentData = xhr.map(function (treatment) {
             var timestamp = new Date(treatment.timestamp || treatment.created_at);


### PR DESCRIPTION
Fix for GUI issue described in #3603:
"When going to Reports -> Treatments and using the green pencil to edit or the red x to delete, there is no indication of success, and confirming an edit or delete appears to have no effect."

Fix preventing aggressive caching of fetched treatment data and make sure a browser makes a new request after editing/deleting instead of using cached data.

Fun fact. The bug is not reproducible if Chrome Dev Tools are opened. The browser's cache policy differs in this case.