### PR TITLE
Create issue templates for NS repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/--bug-report.md
@@ -1,0 +1,29 @@
+---
+name: "\U0001F41BBug report"
+about: Create a report to help us improve things
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Your setup information**
+- What version of Nightscout (e.g. 0.10.3)
+- What type of CGM, and how do you get your data there? (e.g. G4 and ShareBridge, or wired receiver, etc.)
+- Is your issue specific to a browser (Firefox/Safari/Chrome?) or a device (Android phone, etc.)?
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/--feature-request--.md
+++ b/.github/ISSUE_TEMPLATE/--feature-request--.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F4A1Feature request\U0001F4A1"
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/--individual-troubleshooting-help.md
+++ b/.github/ISSUE_TEMPLATE/--individual-troubleshooting-help.md
@@ -1,0 +1,16 @@
+---
+name: "\U0001F198Individual troubleshooting help"
+about: Getting help with your own individual setup of Nightscout
+
+---
+
+Having issues getting Nightscout up and running? Instead of creating an issue here, please use one of the existing support channels for Nightscout.
+
+The main support channel is on Facebook: please join the CGM In The Cloud Facebook group (https://www.facebook.com/groups/cgminthecloud) and start a post there. 
+
+**Suggestions to include in your post when you are asking for help:**
+1. Include what you are trying to do: ("*I am trying to set up Nightscout for the first time.*")
+2. Include which step you are on and what the problem is: ("*I deployed on Heroku, but I'm not seeing any BG data.*")
+3. If possible, include a link to the version of documentation you are following ("*I'm following the OpenAPS Nightscout setup docs (https://openaps.readthedocs.io/en/latest/docs/While%20You%20Wait%20For%20Gear/nightscout-setup.html#nightscout-setup-with-heroku)*")
+
+Other places you can find support and assistance for Nightscout include Gitter's [nightscout/public](https://gitter.im/nightscout/public) channel.


### PR DESCRIPTION
This creates issue templates for the NS repo. To see an example, the oref0 (OpenAPS code) repository uses these as well: https://github.com/openaps/oref0/issues/new/choose

![Example from oref0 of how the issue template page looks like](https://user-images.githubusercontent.com/7468165/46509066-6c23ca80-c7f5-11e8-8145-47bc6541b75f.png)



