### PR TITLE
Immediate full UI update after data load

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1154,10 +1154,9 @@ client.load = function load(serverSettings, callback) {
     } else if (!inRetroMode()) {
       chart.update(false);
       client.plugins.updateVisualisations(client.nowSBX);
+      brushed();
     }
-
   }
-
 };
 
 module.exports = client;

--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 
-var UPDATE_THROTTLE = 1000;
+var UPDATE_THROTTLE = 5000;
 
 function boot (env, language) {
 


### PR DESCRIPTION
This fix causes the entire UI to update after new data has landed to the client from the websocket

* Have the UI fully update immediately after new data update
* Debounce the Mongo loading for 5 seconds after data has been updated to reduce load on Mongo