### PR TITLE
Remove unused alarm-pumpbatterylow-browser client setting

### DIFF
--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -36,7 +36,6 @@ function init (client, serverSettings, $) {
     $('#alarm-timeagowarnmins-browser').val(settings.alarmTimeagoWarnMins);
     $('#alarm-timeagourgent-browser').prop('checked', settings.alarmTimeagoUrgent);
     $('#alarm-timeagourgentmins-browser').val(settings.alarmTimeagoUrgentMins);
-    $('#alarm-pumpbatterylow-browser').prop('checked', settings.alarmPumpBatteryLow);
 
     $('#nightmode-browser').prop('checked', settings.nightMode);
     $('#editmode-browser').prop('checked', settings.editMode);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -27,7 +27,6 @@ function init ( ) {
     , alarmTimeagoWarnMins: 15
     , alarmTimeagoUrgent: true
     , alarmTimeagoUrgentMins: 30
-    , alarmPumpBatteryLow: false
     , language: 'en'
     , scaleY: 'log'
     , showPlugins: ''

--- a/views/index.html
+++ b/views/index.html
@@ -232,7 +232,6 @@
                           <input type="text" id="alarm-timeagourgentmins-browser" class="timeago-mins" value="30"/>
                           <span class="translate">mins</span>
                         </dd>
-                        <dd><input type="checkbox" id="alarm-pumpbatterylow-browser" /><label for="alarm-pumpbatterylow-browser" class="translate">Pump Battery Low Alarm</label></dd>
                     </dl>
                     <dl class="toggle">
                         <dt><span class="translate">Night Mode</span> <a class="tip" original-title="When enabled the page will be dimmed from 10pm - 6am."><i class="icon-help-circled"></i></a></dt>


### PR DESCRIPTION
I've tested and still receive pump battery low alarms with this code removed.