### PR TITLE
Reimplement Predictions support to Reports

### DIFF
--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -31,6 +31,7 @@ daytoday.html = function html(client) {
     + '<input type="checkbox" id="rp_optionsraw"><span style="color:gray;opacity:1">'+translate('Raw')+'</span>'
     + '<input type="checkbox" id="rp_optionsiob"><span style="color:blue;opacity:0.5">'+translate('IOB')+'</span>'
     + '<input type="checkbox" id="rp_optionscob"><span style="color:red;opacity:0.5">'+translate('COB')+'</span>'
+    + '<input type="checkbox" id="rp_optionspredicted"><span style="color:sienna;opacity:0.5">'+translate('Predictions')+'</span>'
     + '<input type="checkbox" id="rp_optionsopenaps"><span style="color:sienna;opacity:0.5">'+translate('OpenAPS')+'</span>'
     + '<input type="checkbox" id="rp_optionsdistribution"><span style="color:blue;opacity:0.5">'+translate('Insulin distribution')+'</span>'
     + '&nbsp;'+translate('Size')
@@ -39,6 +40,7 @@ daytoday.html = function html(client) {
     + '  <option x="1000" y="300" selected>1000x300px</option>'
     + '  <option x="1200" y="400">1200x400px</option>'
     + '  <option x="1550" y="600">1550x600px</option>'
+    + '  <option x="2400" y="800">2400x800px</option>'
     + '</select>'
     + '<br>'
     + translate('Scale') + ': '
@@ -46,6 +48,19 @@ daytoday.html = function html(client) {
     + translate('Linear')
     + '<input type="radio" name="rp_scale" id="rp_log">'
     + translate('Logarithmic')
+    + '<div id="rp_predictedSettings" style="display:none">'
+    + translate('Truncate predictions: ')
+    + '<input type="checkbox" id="rp_optionsPredictedTruncate" checked>'
+    + '<br>'
+    + translate('Predictions offset') + ': '
+    + '<b><label id="rp_predictedOffset"></label> minutes</b>'
+    + '&nbsp;&nbsp;&nbsp;&nbsp;'
+    + '<input type="button" onclick="predictMoreBackward();" value="' + translate('-30 min')+'">'
+    + '<input type="button" onclick="predictBackward();" value="' + translate('-5 min')+'">'
+    + '<input type="button" onclick="predictResetToZero();" value="' + translate('Zero')+'">'
+    + '<input type="button" onclick="predictForward();" value="' + translate('+5 min')+'">'
+    + '<input type="button" onclick="predictMoreForward();" value="' + translate('+30 min')+'">'
+    + '</div>'
     + '<br>'
     + '<div id="daytodaycharts">'
     + '</div>'
@@ -291,6 +306,115 @@ daytoday.report = function report_daytoday(datastorage,sorteddaystoshow,options)
           }
           return sel;
       }
+
+    // PREDICTIONS START
+    //
+    function preparePredictedData() {
+
+      var treatmentsTimestamps = []; // Only timestamps for (carbs and bolus insulin) treatments will be captured in this array
+      treatmentsTimestamps.push(dataRange[0]); // Create a fake timestamp at midnight so we can show predictions during night
+      for (var i in data.treatments) {
+        var treatment = data.treatments[i];
+        if (undefined != treatment.carbs && null != treatment.carbs && treatment.carbs > 0) {
+          if (treatment.timestamp)
+            treatmentsTimestamps.push(treatment.timestamp);
+          else if (treatment.created_at)
+            treatmentsTimestamps.push(treatment.created_at);
+        }
+        if (undefined != treatment.insulin && null != treatment.insulin && treatment.insulin > 0) {
+          if (treatment.timestamp)
+            treatmentsTimestamps.push(treatment.timestamp);
+        else if (treatment.created_at)
+          treatmentsTimestamps.push(treatment.created_at);
+        }
+      }
+
+      var predictions = [];
+      if (data && data.devicestatus) {
+        for (var i = data.devicestatus.length - 1; i >= 0; i--) {
+          if (data.devicestatus[i].loop && data.devicestatus[i].loop.predicted) {
+            predictions.push(data.devicestatus[i].loop.predicted);
+          } else if (data.devicestatus[i].openaps && data.devicestatus[i].openaps.suggested && data.devicestatus[i].openaps.suggested.predBGs) {
+            var entry = {};
+            entry.startDate = data.devicestatus[i].openaps.suggested.timestamp;
+            // For OpenAPS/AndroidAPS we fall back from COB if present, to UAM, then IOB
+            if (data.devicestatus[i].openaps.suggested.predBGs.COB) {
+              entry.values = data.devicestatus[i].openaps.suggested.predBGs.COB;
+            } else if (data.devicestatus[i].openaps.suggested.predBGs.UAM) {
+              entry.values = data.devicestatus[i].openaps.suggested.predBGs.UAM;
+            } else entry.values = data.devicestatus[i].openaps.suggested.predBGs.IOB;
+            predictions.push(entry);
+          }
+        }
+      }
+
+      var p = [];
+      if (predictions.length > 0 && treatmentsTimestamps.length > 0) {
+
+        // Iterate over all treatments, find the predictions for each and add them to the predicted array p
+        for (var treatmentsIndex = 0; treatmentsIndex < treatmentsTimestamps.length; treatmentsIndex++) {
+          var timestamp = treatmentsTimestamps[treatmentsIndex];
+          var predictedIndex = findPredicted(predictions, timestamp, predictedOffset); // Find predictions offset before or after timestamp
+
+          if (predictedIndex != null) {
+            var entry = predictions[predictedIndex]; // Start entry
+            var d = moment(entry.startDate);
+            var end = moment().endOf('day');
+            if (options.predictedTruncate) {
+              if (predictedOffset >= 0) {
+                // If we are looking forward we want to stop at the next treatment
+                if (treatmentsIndex < treatmentsTimestamps.length - 1) {
+                  end = moment(treatmentsTimestamps[treatmentsIndex + 1]);
+                }
+              } else {
+                // If we are looking back, then we want to stop at "this" treatment
+                end = moment(treatmentsTimestamps[treatmentsIndex]);
+              }
+            }
+            for (var entryIndex in entry.values) {
+              if (!d.isAfter(end)) {
+                var value = {};
+                value.sgv = client.utils.scaleMgdl(entry.values[entryIndex]);
+                value.date = d.toDate();
+                value.color = 'purple';
+                p.push(value);
+                d.add(5, 'minutes');
+              }
+            }
+          }
+        }
+      }
+      return p;
+    }
+
+    /* Find the earliest new predicted instance that has a timestamp equal to or larger than timestamp */
+    /* (so if we have bolused or eaten we want to find the prediction that Loop has estimated just after that) */
+    /* Returns the index into the predictions array that is the predicted we are looking for */
+    function findPredicted(predictions, timestamp, offset) {
+      var ts = moment(timestamp).add(offset, 'minutes');
+      var predicted = null;
+      if (offset && offset < 0) { // If offset is negative, start searching from first prediction going forward
+        for (var i = 0; i < predictions.length; i++) {
+          if (predictions[i] && predictions[i].startDate && moment(predictions[i].startDate) <= ts) {
+            predicted = i;
+          }
+        }
+      } else {  // If offset is positive or zero, start searching from last prediction going backward
+        for (var i = predictions.length - 1; i > 0; i--) {
+          if (predictions[i] && predictions[i].startDate && moment(predictions[i].startDate) >= ts) {
+            predicted = i;
+          }
+        }
+      }
+      return predicted;
+    }
+    //
+    // PREDICTIONS ENDS
+
+    
+    // bind up the context chart data to an array of circles
+    var contextData = (options.predicted ? data.sgv.concat(preparePredictedData()) : data.sgv);
+    var contextCircles = context.selectAll('circle').data(contextData);
 
     // if new circle then just display
     prepareContextCircles(contextCircles.enter().append('circle'));

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -229,9 +229,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-          "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
+          "version": "6.0.6",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.6.tgz",
+          "integrity": "sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA=="
         }
       }
     },
@@ -352,7 +352,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-slice": {
@@ -428,7 +428,7 @@
     },
     "async": {
       "version": "0.9.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
     },
     "async-each": {
@@ -929,7 +929,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -1218,7 +1218,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-security-policy-builder": {
@@ -1683,11 +1683,23 @@
         "debug": "~3.1.0",
         "engine.io-parser": "~2.1.0",
         "ws": "~3.3.1"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        }
       }
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "requires": {
         "component-emitter": "1.2.1",
@@ -1701,6 +1713,18 @@
         "ws": "~3.3.1",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        }
       }
     },
     "engine.io-parser": {
@@ -1926,7 +1950,7 @@
     },
     "expand-range": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
       "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
       "requires": {
         "is-number": "^0.1.1",
@@ -2215,7 +2239,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -3286,7 +3310,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -3708,21 +3732,12 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        },
-        "ws": {
-          "version": "4.1.0",
-          "resolved": "http://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0"
-          }
         }
       }
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "json-parse-better-errors": {
@@ -3796,9 +3811,9 @@
       }
     },
     "jwa": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
-      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
+      "integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
@@ -3806,11 +3821,11 @@
       }
     },
     "jws": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
+      "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
       "requires": {
-        "jwa": "^1.1.5",
+        "jwa": "^1.2.0",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4008,7 +4023,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -5270,7 +5285,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
         "through": "~2.3"
@@ -5344,9 +5359,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -5424,7 +5439,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -5638,7 +5653,7 @@
     },
     "regexpu-core": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "requires": {
         "regenerate": "^1.2.1",
@@ -5648,12 +5663,12 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
         "jsesc": "~0.5.0"
@@ -6454,7 +6469,7 @@
     },
     "simple-statistics": {
       "version": "0.7.0",
-      "resolved": "http://registry.npmjs.org/simple-statistics/-/simple-statistics-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/simple-statistics/-/simple-statistics-0.7.0.tgz",
       "integrity": "sha1-xQ8Tu9yX6aT9ICVjgtoX5o7asco="
     },
     "snapdragon": {
@@ -6615,7 +6630,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
@@ -6694,9 +6709,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
-      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -6761,7 +6776,7 @@
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -6895,7 +6910,7 @@
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "swagger-ui-dist": {
@@ -6942,7 +6957,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -7719,13 +7734,12 @@
       "dev": true
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "requires": {
         "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "safe-buffer": "~5.1.0"
       }
     },
     "x-xss-protection": {

--- a/static/report/js/predictions.js
+++ b/static/report/js/predictions.js
@@ -1,0 +1,40 @@
+
+var predictedOffset = 0;
+
+function predictForward() {
+    predictedOffset += 5;
+    $("#rp_predictedOffset").html(predictedOffset);
+    $("#rp_show").click();
+}
+
+function predictMoreForward() {
+    predictedOffset += 30;
+    $("#rp_predictedOffset").html(predictedOffset);
+    $("#rp_show").click();
+}
+
+function predictBackward() {
+    predictedOffset -= 5;
+    $("#rp_predictedOffset").html(predictedOffset);
+    $("#rp_show").click();
+}
+
+function predictMoreBackward() {
+    predictedOffset -= 30;
+    $("#rp_predictedOffset").html(predictedOffset);
+    $("#rp_show").click();
+}
+
+function predictResetToZero() {
+    predictedOffset = 0;
+    $("#rp_predictedOffset").html(predictedOffset);
+    $("#rp_show").click();
+}
+
+$(document).on('change', '#rp_optionspredicted', function() {
+    if (this.checked)
+        $("#rp_predictedSettings").show();
+    else
+        $("#rp_predictedSettings").hide();
+    predictResetToZero();
+});

--- a/static/report/js/report.js
+++ b/static/report/js/report.js
@@ -224,6 +224,8 @@
     options.iob = $('#rp_optionsiob').is(':checked');
     options.cob = $('#rp_optionscob').is(':checked');
     options.openAps = $('#rp_optionsopenaps').is(':checked');
+    options.predicted = $('#rp_optionspredicted').is(':checked');
+    options.predictedTruncate = $('#rp_optionsPredictedTruncate').is(':checked');
     options.basal = $('#rp_optionsbasal').is(':checked');
     options.notes = $('#rp_optionsnotes').is(':checked');
     options.food = $('#rp_optionsfood').is(':checked');
@@ -561,7 +563,7 @@
   
   function loadData(day, options, callback) {
     // check for loaded data
-    if ((options.openAps || options.iob || options.cob) && datastorage[day] && !datastorage[day].devicestatus.length) {
+    if ((options.openAps || options.predicted || options.iob || options.cob) && datastorage[day] && !datastorage[day].devicestatus.length) {
       // OpenAPS requested but data not loaded. Load anyway ...
     } else if (datastorage[day] && day !== moment().format('YYYY-MM-DD')) {
       callback(day);
@@ -682,7 +684,7 @@
         data.devicestatus = [];
         return $.Deferred().resolve();
       }
-      if(options.iob || options.cob || options.openAps) {
+      if (options.iob || options.cob || options.openAps || options.predicted) {
         $('#info-' + day).html('<b>'+translate('Loading device status data of')+' '+day+' ...</b>');
         var tquery = '?find[created_at][$gte]=' + new Date(from).toISOString() + '&find[created_at][$lt]=' + new Date(to).toISOString() + '&count=10000';
         return $.ajax('/api/v1/devicestatus.json'+tquery, {

--- a/views/reportindex.html
+++ b/views/reportindex.html
@@ -122,6 +122,7 @@
     <script src="/socket.io/socket.io.js?v=<%= locals.cachebuster %>"></script>
     <script src="/report/js/report.js?v=<%= locals.cachebuster %>"></script>
     <script src="/report/js/flotcandle.js?v=<%= locals.cachebuster %>"></script>
+    <script src="/report/js/predictions.js?v=<%= locals.cachebuster %>"></script>
     <script src="/report/js/loopalyzer.js?v=<%= locals.cachebuster %>"></script>
   </body>
 </html>


### PR DESCRIPTION
Reimplements https://github.com/nightscout/cgm-remote-monitor/pull/3179 
fixing merge conflicts was too much work so cherry picked:
```
lib/report_plugins/daytoday.js
static/report/js/predictions.js
static/report/js/report.js
```
from https://github.com/lixgbg/cgm-remote-monitor/tree/wip/report-predictions/lib/report_plugins

@lixgbg and @sulkaharo please review.
I tested it and after some problems that are now resolved it looks good to go. 