### PR TITLE
Point Travis to latest Xenial Linux VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
+sudo: required
+dist: xenial
 node_js:
   - "10"
   - "8"
-os: 
-  - osx
+#os: 
+#  - osx
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   # https://github.com/Homebrew/homebrew-core/issues/26358

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 #os: 
 #  - osx
 before_install:
+  - if [[ `npm --version` != "6.4.1" ]]; then npm install -g npm@latest; npm --version; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   # https://github.com/Homebrew/homebrew-core/issues/26358
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink python; fi


### PR DESCRIPTION
The change to got to OS X was made due to Linux builds using non-blocking IO, which caused Mocha to randomly detect false positives from unit tests. Changing to Xenial speeds up builds 4x, but let's monitor if we start getting the random fails again and if so, switch back to OS X builds