### PR TITLE
re-add out of range RMS

### DIFF
--- a/lib/report_plugins/glucosedistribution.js
+++ b/lib/report_plugins/glucosedistribution.js
@@ -463,8 +463,8 @@ glucosedistribution.report = function report_glucosedistribution(datastorage, so
     $('<tr><th>' + translate('Mean Hourly Change') + '</th><th>GVI</th><th>PGS</th></tr>').appendTo(stabilitytable);
     $('<tr><td class="tdborder">' + TDCHourly + unitString + '</td><td class="tdborder">' + GVI + '</td><td class="tdborder">' + PGS + '</td></tr>').appendTo(stabilitytable);
 
-//    $('<tr><th>Out of Range RMS</th></tr>').appendTo(stabilitytable);
-//    $('<tr><td class="tdborder">' + Math.round(RMS * 100) / 100 + unitString + '</td></tr>').appendTo(stabilitytable);
+    $('<tr><th>Out of Range RMS</th></tr>').appendTo(stabilitytable);
+    $('<tr><td class="tdborder">' + Math.round(RMS * 100) / 100 + unitString + '</td></tr>').appendTo(stabilitytable);
 
     stabilitytable.appendTo(stability);
     


### PR DESCRIPTION
The description for Out of Range RMS is on the page, but the metric value isn't there 🙂 

It was added in https://github.com/nightscout/cgm-remote-monitor/pull/3045, but removed in https://github.com/nightscout/cgm-remote-monitor/commit/26dd8584ff4644af542fd2cf01a8456481d25a43#diff-aedd33b75ca4a7c3a468cb4ecdba1b06R450

It still seems to work as expected:
<img width="632" alt="image" src="https://user-images.githubusercontent.com/1430443/53854064-9ee11300-3f8d-11e9-834d-2f3da0ff8d71.png">
