### PR TITLE
cover non-Heroku secure requests in HTTPS redirect exemption

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,10 +19,11 @@ function create(env, ctx) {
     console.info('Security settings: INSECURE_USE_HTTP=',insecureUseHttp,', SECURE_HSTS_HEADER=',secureHstsHeader);
     if (!insecureUseHttp) {
         app.use((req, res, next) => {
-        if (req.header('x-forwarded-proto') !== 'https')
+        if (req.header('x-forwarded-proto') == 'https' || req.secure) {
+            next();
+        } else {
             res.redirect(`https://${req.header('host')}${req.url}`);
-        else
-            next()
+        }
         })
         if (secureHstsHeader) { // Add HSTS (HTTP Strict Transport Security) header
           const helmet = require('helmet');


### PR DESCRIPTION
resolves #4427 by flipping conditional and testing for `req[uest].secure` which is set on pure-HTTPS-no-middleware setups (i.e. not Heroku)

This resolves the issue for me; with this commit I do not need to set `INSECURE_USE_HTTP` to `true` which is an accidental and strange workaround being that I'm HTTPS-only full-stop.