### PR TITLE
feat: display '50+ U', when there's no reservoir value for an Eros pod

### DIFF
--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -215,6 +215,10 @@ function init (ctx) {
       } else {
         result.reservoir.level = levels.NONE;
       }
+    } else if (result.manufacturer === 'Insulet' &&  result.model === 'Eros') {
+      result.reservoir = {
+        label: 'Reservoir', display: '50+ U'
+      }
     }
   }
 
@@ -264,7 +268,7 @@ function init (ctx) {
         if (pump.warnOnSuspend && pump.status.suspended) {
           result.status.level = levels.WARN;
           result.status.message = 'Pump Suspended';
-        };
+        }
       }
       result.status = { value: status, display: status, label: translate('Status') };
     }
@@ -277,6 +281,8 @@ function init (ctx) {
       level: levels.NONE
       , clock: pump.clock ? { value: moment(pump.clock) } : null
       , reservoir: pump.reservoir || pump.reservoir === 0 ? { value: pump.reservoir } : null
+      , manufacturer: pump.manufacturer
+      , model: pump.model
       , extended: pump.extended || null
     };
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/751143/57188884-30e89780-6ebb-11e9-8e71-ef46d3668954.png)


depends on https://github.com/LoopKit/Loop/pull/947 and https://github.com/ps2/rileylink_ios/pull/522