### PR TITLE
Fix BG & direction wrapping on Chrome

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -133,8 +133,10 @@
                 <div class="bgStatus current">
                     <div class="bgButton" aria-live="assertive" role="contentinfo" aria-label="Blood Sugar">  
                         <span class="pill rawbg hidden"><em></em><label></label></span>
-                        <span class="currentBG">---</span>
-                        <span class="pill direction"></span>
+                        <span style="white-space: nowrap;">
+                          <span class="currentBG">---</span>
+                          <span class="pill direction"></span>
+                        </span>
                     </div>
                     <ul class="dropdown-menu" id="silenceBtn"></ul>
                     <div class="majorPills"></div>


### PR DESCRIPTION
Before: <img width="456" alt="Screen Shot 2019-05-30 at 21 08 22" src="https://user-images.githubusercontent.com/1001330/58653784-22a56400-831f-11e9-9cee-7e8afed4a537.png">

After: <img width="362" alt="Screen Shot 2019-05-30 at 21 08 35" src="https://user-images.githubusercontent.com/1001330/58653786-22a56400-831f-11e9-91c1-93b3b6e41294.png">
