### PR TITLE
Fix distribution report totals

### DIFF
--- a/lib/report_plugins/glucosedistribution.js
+++ b/lib/report_plugins/glucosedistribution.js
@@ -128,23 +128,24 @@ glucosedistribution.report = function report_glucosedistribution(datastorage, so
     enabledHours[i] = $('#glucosedistribution-' + i).is(':checked');
   }
 
-  //console.log(enabledHours);
-
   var result = {};
 
   // Filter data for noise
-
-  var glucose_data = [data[0]];
-
-  // data cleaning pass 0 - remove duplicates and sort
+  // data cleaning pass 0 - remove duplicates and non-sgv entries, sort
   var seen = {};
   data = data.filter(function(item) {
+    if (!item.sgv || !item.bgValue || !item.displayTime || item.bgValue < 39) {
+      console.log(item);
+      return false;
+    }
     return seen.hasOwnProperty(item.displayTime) ? false : (seen[item.displayTime] = true);
   });
 
   data.sort(function(a, b) {
     return a.displayTime.getTime() - b.displayTime.getTime();
   });
+
+  var glucose_data = [data[0]];
 
   // data cleaning pass 1 - add interpolated missing points
   for (var i = 0; i <= data.length - 2; i++) {
@@ -169,7 +170,8 @@ glucosedistribution.report = function report_glucosedistribution(datastorage, so
       var bg = Math.floor(entry.bgValue + bgDelta * j);
       var t = new Date(entry.displayTime.getTime() + j * timePatch);
       var newEntry = {
-        bgValue: bg
+        sgv: displayUnits === 'mmol' ? bg / 18 : bg
+        , bgValue: bg
         , displayTime: t
       };
       glucose_data.push(newEntry);
@@ -207,9 +209,12 @@ glucosedistribution.report = function report_glucosedistribution(datastorage, so
     }
 
     if ((delta1 > 0 && delta2 < 0) || (delta1 < 0 && delta2 > 0)) {
-      var d = (nextEntry.bgValue - prevEntry.bgValue) / 2;
+      const d = (nextEntry.bgValue - prevEntry.bgValue) / 2;
+      const interpolatedValue = prevEntry.bgValue + d;
+
       var newEntry = {
-        bgValue: prevEntry.bgValue + d
+        sgv: displayUnits === 'mmol' ? interpolatedValue/18 : interpolatedValue
+        , bgValue: interpolatedValue
         , displayTime: entry.displayTime
       };
       glucose_data2.push(newEntry);
@@ -247,6 +252,7 @@ glucosedistribution.report = function report_glucosedistribution(datastorage, so
     result[range] = {};
     var r = result[range];
     r.rangeRecords = glucose_data.filter(function(r) {
+      if (!r.sgv) console.log('NO SGV', r);
       if (range === 'Low') {
         return r.sgv > 0 && r.sgv < options.targetLow;
       } else if (range === 'Normal') {

--- a/lib/report_plugins/glucosedistribution.js
+++ b/lib/report_plugins/glucosedistribution.js
@@ -252,7 +252,6 @@ glucosedistribution.report = function report_glucosedistribution(datastorage, so
     result[range] = {};
     var r = result[range];
     r.rangeRecords = glucose_data.filter(function(r) {
-      if (!r.sgv) console.log('NO SGV', r);
       if (range === 'Low') {
         return r.sgv > 0 && r.sgv < options.targetLow;
       } else if (range === 'Normal') {


### PR DESCRIPTION
Distribution totals were miscalculated due to data interpolation. This also adds filtering for non-sgv dexcom entries - we need a new feature so user can define what CGM system she's on and set the lower bound of acceptable CGM values appropriately