### PR TITLE
Clamp treatments & load less data

### DIFF
--- a/lib/data/dataloader.js
+++ b/lib/data/dataloader.js
@@ -222,8 +222,10 @@ function loadActivity(ddata, ctx, callback) {
 }
 
 function loadTreatments(ddata, ctx, callback) {
+
+    // Load 2.5 days to cover last 48 hours including overlapping temp boluses or temp targets
     var dateRange = {
-        $gte: new Date(ddata.lastUpdated - (ONE_DAY * 8)).toISOString()
+        $gte: new Date(ddata.lastUpdated - (ONE_DAY * 2.5)).toISOString()
     };
     if (ddata.page && ddata.page.frame) {
         dateRange['$lte'] = new Date(ddata.lastUpdated).toISOString();
@@ -256,6 +258,7 @@ function loadProfileSwitchTreatments(ddata, ctx, callback) {
         dateRange['$lte'] = new Date(ddata.lastUpdated).toISOString();
     }
 
+    // Load the latest profile switch treatment
     var tq = {
         find: {
             eventType: 'Profile Switch',
@@ -291,6 +294,17 @@ function loadProfileSwitchTreatments(ddata, ctx, callback) {
 }
 
 function loadSensorAndInsulinTreatments(ddata, ctx, callback) {
+    async.parallel([
+        loadLatestSingle.bind(null, ddata, ctx, 'Sensor Start')
+        ,loadLatestSingle.bind(null, ddata, ctx, 'Sensor Change')
+        ,loadLatestSingle.bind(null, ddata, ctx, 'Site Change')
+        ,loadLatestSingle.bind(null, ddata, ctx, 'Insulin Change')
+        ,loadLatestSingle.bind(null, ddata, ctx, 'Pump Battery Change')
+    ], callback);
+}
+
+function loadLatestSingle(ddata, ctx, dataType, callback) {
+
     var dateRange = {
         $gte: new Date(ddata.lastUpdated - (ONE_DAY * 32)).toISOString()
     };
@@ -302,13 +316,14 @@ function loadSensorAndInsulinTreatments(ddata, ctx, callback) {
     var tq = {
         find: {
             eventType: {
-                $in: ['Sensor Start', 'Sensor Change', 'Insulin Change', 'Pump Battery Change']
+                $eq: dataType
             },
             created_at: dateRange
         },
         sort: {
             created_at: -1
-        }
+        },
+        count: 1
     };
 
     ctx.treatments.list(tq, function(err, results) {

--- a/lib/data/treatmenttocurve.js
+++ b/lib/data/treatmenttocurve.js
@@ -2,6 +2,9 @@
 
 var _ = require('lodash');
 
+const MAX_BG_MMOL = 22;
+const MAX_BG_MGDL = MAX_BG_MMOL * 18;
+
 module.exports = function fitTreatmentsToBGCurve (ddata, env, ctx) {
 
   var settings = env.settings;
@@ -62,15 +65,16 @@ module.exports = function fitTreatmentsToBGCurve (ddata, env, ctx) {
       console.warn('found an invalid glucose value', treatment);
     } else if (treatment.glucose && treatment.units) {
       if (treatment.units === 'mmol') {
-        treatment.mmol = Number(treatment.glucose);
+        treatment.mmol = Math.min(Number(treatment.glucose), MAX_BG_MMOL);
       } else {
-        treatment.mgdl = Number(treatment.glucose);
+        treatment.mgdl = Math.min(Number(treatment.glucose), MAX_BG_MGDL);
       }
     } else if (treatment.glucose) {
       //no units, assume everything is the same
       //console.warn('found a glucose value without any units, maybe from an old version?', _.pick(treatment, '_id', 'created_at', 'enteredBy'));
       var units = settings.units === 'mmol' ? 'mmol' : 'mgdl';
-      treatment[units] = Number(treatment.glucose);
+
+      treatment[units] = settings.units === 'mmol' ? Math.min(Number(treatment.glucose), MAX_BG_MMOL) : Math.min(Number(treatment.glucose), MAX_BG_MGDL);
     } else {
       treatment.mgdl = mgdlByTime();
     }


### PR DESCRIPTION
* Reduces the amount of treatments loaded to the runtime signicantly (>50%)
* Clamp treatments during visualization to max BG of 22 so data with erroneous values is not drawn outside the screen