### PR TITLE
Added sanity check for the bridge interval value

### DIFF
--- a/lib/plugins/bridge.js
+++ b/lib/plugins/bridge.js
@@ -46,9 +46,17 @@ function options (env) {
     , minutes: env.extendedSettings.bridge.minutes || 1440
   };
 
+  var interval = env.extendedSettings.bridge.interval || 60000 * 2.5 // Default: 2.5 minutes
+
+  if (interval < 30000 || interval > 300000) {
+        // Invalid interval range. Revert to default
+        console.error("Invalid interval set: [" + interval + "ms]. Defaulting to 2.5 minutes.")
+        interval = 60000 * 2.5 // 2.4 minutes
+  }
+
   return {
     login: config
-    , interval: env.extendedSettings.bridge.interval || 60000 * 2.5
+    , interval: interval
     , fetch: fetch_config
     , nightscout: { }
     , maxFailures: env.extendedSettings.bridge.maxFailures || 3

--- a/lib/plugins/bridge.js
+++ b/lib/plugins/bridge.js
@@ -46,7 +46,7 @@ function options (env) {
     , minutes: env.extendedSettings.bridge.minutes || 1440
   };
 
-  var interval = env.extendedSettings.bridge.interval || 60000 * 2.5 // Default: 2.5 minutes
+  var interval = env.extendedSettings.bridge.interval || 60000 * 2.5; // Default: 2.5 minutes
 
   if (interval < 30000 || interval > 300000) {
         // Invalid interval range. Revert to default

--- a/lib/plugins/bridge.js
+++ b/lib/plugins/bridge.js
@@ -51,7 +51,7 @@ function options (env) {
   if (interval < 30000 || interval > 300000) {
         // Invalid interval range. Revert to default
         console.error("Invalid interval set: [" + interval + "ms]. Defaulting to 2.5 minutes.")
-        interval = 60000 * 2.5 // 2.4 minutes
+        interval = 60000 * 2.5 // 2.5 minutes
   }
 
   return {

--- a/lib/plugins/bridge.js
+++ b/lib/plugins/bridge.js
@@ -48,7 +48,7 @@ function options (env) {
 
   var interval = env.extendedSettings.bridge.interval || 60000 * 2.5; // Default: 2.5 minutes
 
-  if (interval < 30000 || interval > 300000) {
+  if (interval < 1000 || interval > 300000) {
         // Invalid interval range. Revert to default
         console.error("Invalid interval set: [" + interval + "ms]. Defaulting to 2.5 minutes.")
         interval = 60000 * 2.5 // 2.5 minutes

--- a/tests/bridge.test.js
+++ b/tests/bridge.test.js
@@ -44,7 +44,7 @@ describe('bridge', function ( ) {
   it('set too low bridge interval option from env', function () {
     var tooLowInterval = {
       extendedSettings: {
-        bridge: { interval: 10000 }
+        bridge: { interval: 900 }
       }
     };
 

--- a/tests/bridge.test.js
+++ b/tests/bridge.test.js
@@ -55,13 +55,26 @@ describe('bridge', function ( ) {
   });
 
   it('set too high bridge interval option from env', function () {
-    var tooLowInterval = {
+    var tooHighInterval = {
       extendedSettings: {
         bridge: { interval: 500000 }
       }
     };
 
-    var opts = bridge.options(tooLowInterval);
+    var opts = bridge.options(tooHighInterval);
+    should.exist(opts);
+
+    opts.interval.should.equal(150000);
+  });
+
+  it('set no bridge interval option from env', function () {
+    var noInterval = {
+      extendedSettings: {
+        bridge: { }
+      }
+    };
+
+    var opts = bridge.options(noInterval);
     should.exist(opts);
 
     opts.interval.should.equal(150000);

--- a/tests/bridge.test.js
+++ b/tests/bridge.test.js
@@ -10,6 +10,7 @@ describe('bridge', function ( ) {
       bridge: {
         userName: 'nightscout'
         , password: 'wearenotwaiting'
+        , interval: 60000
       }
     }
   };
@@ -27,6 +28,7 @@ describe('bridge', function ( ) {
 
     opts.login.accountName.should.equal('nightscout');
     opts.login.password.should.equal('wearenotwaiting');
+    opts.interval.should.equal(60000);
   });
 
   it('store entries from share', function (done) {
@@ -37,6 +39,32 @@ describe('bridge', function ( ) {
       }
     };
     bridge.bridged(mockEntries)(null);
+  });
+
+  it('set too low bridge interval option from env', function () {
+    var tooLowInterval = {
+      extendedSettings: {
+        bridge: { interval: 10000 }
+      }
+    };
+
+    var opts = bridge.options(tooLowInterval);
+    should.exist(opts);
+
+    opts.interval.should.equal(150000);
+  });
+
+  it('set too high bridge interval option from env', function () {
+    var tooLowInterval = {
+      extendedSettings: {
+        bridge: { interval: 500000 }
+      }
+    };
+
+    var opts = bridge.options(tooLowInterval);
+    should.exist(opts);
+
+    opts.interval.should.equal(150000);
   });
 
 });


### PR DESCRIPTION
Setting minimum all…owed value to 30 seconds and maximum to 5 minutes. This is to avoid input of very low values which might overload the dexcom servers.