### PR TITLE
Perform HTTP to HTTPS redirect using 307 status

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ function create(env, ctx) {
         if (req.header('x-forwarded-proto') == 'https' || req.secure) {
             next();
         } else {
-            res.redirect(`https://${req.header('host')}${req.url}`);
+            res.redirect(307, `https://${req.header('host')}${req.url}`);
         }
         })
         if (secureHstsHeader) { // Add HSTS (HTTP Strict Transport Security) header


### PR DESCRIPTION
302 and 307 basically do the same thing with just one important difference:
The default 302 redirect from express.js tells the browser to repeat the request with the new URL using the GET verb.
When using the 307 status code manually, this tells the browser to repeat the very same request against the new URL using all the same parameters, headers and most important HTTP verbs.

In practice this is important every time you want to change settings or flip a switch or enter your API key (that information will never arrive at the server)
It's even more important when you get to the site through a reverse proxy that doesn't properly set the X-Forwarded-Proto header.