### PR TITLE
Only set INSECURE_USE_HTTP as last resort

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,7 @@ $ npm install
 
 ## Installation notes for users with nginx or Apache reverse proxy for SSL/TLS offloading:
 
-- Set `INSECURE_USE_HTTP` to `false`, to be able to use non secure HTTP connections to Nightscout server
-- Your site redirects insecure connections to `https` by default. If you don't want that and use a Nginx or Apache proxy, set `INSECURE_USE_HTTP` to `true`. This will allow (unsafe) http traffic.
+- Your site redirects insecure connections to `https` by default. If you use a reverse proxy like nginx or Apache to handle the connection security for you, make sure it sets the `X-Forwarded-Proto` header. Otherwise nightscout will be unable to know if it was called through a secure connection and will try to redirect you to the https version. If you're unable to set this Header, you can change the `INSECURE_USE_HTTP` setting in nightscout to true in order to allow insecure connections without being redirected.
 - In case you use a proxy. Do not use an external network interfaces for hosting Nightscout. Make sure the unsecure port is not available from a remote network connection
 - HTTP Strict Transport Security (HSTS) headers are enabled by default, use settings `SECURE_HSTS_HEADER` and `SECURE_HSTS_HEADER_*`
 - See [Predefined values for your server settings](#predefined-values-for-your-server-settings-optional) for more details


### PR DESCRIPTION
I've changed the explanation for the `INSECURE_USE_HTTP` environment variable.
The old first line describing this setting in just one sentence was wrong and the next line basically suggested turning this security feature off in situations where it's not needed.
In the nightscout code you check if either the connection is secure by itself or if the X-Forwarded-Proto header is set (which it should be by default in all major reverse proxy applications).
It should be unnecessary to change that setting even in a reverse proxy environment.