### PR TITLE
feat: Add support for different color prediction lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,10 +478,11 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
   * `OPENAPS_URGENT` (`60`) - The number of minutes since the last loop that needs to be exceed before an urgent alarm is triggered
   * `OPENAPS_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display by default.  Any of the following fields: `status-symbol`, `status-label`, `iob`, `meal-assist`, `freq`, and `rssi`
   * `OPENAPS_RETRO_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display in retro mode. Any of the above fields.
-  * `OPENAPS_PRED_IOB_COLOR` (`#ff00ff`) - The color to use for IOB prediction lines
-  * `OPENAPS_PRED_COB_COLOR` (`#ff00ff`) - The color to use for COB prediction lines
-  * `OPENAPS_PRED_ZT_COLOR` (`#ff00ff`) - The color to use for ZT prediction lines
-  * `OPENAPS_PRED_UAM_COLOR` (`#ff00ff`) - The color to use for UAM prediction lines
+  * `OPENAPS_PRED_IOB_COLOR` (`#1e88e5`) - The color to use for IOB prediction lines. Colors can be in either `#RRGGBB` or `#RRGGBBAA` format.
+  * `OPENAPS_PRED_COB_COLOR` (`#FB8C00FF`) - The color to use for COB prediction lines. Same format as above.
+  * `OPENAPS_PRED_ACOB_COLOR` (`#FB8C0080`) - The color to use for ACOB prediction lines. Same format as above.
+  * `OPENAPS_PRED_ZT_COLOR` (`#00d2d2`) - The color to use for ZT prediction lines. Same format as above.
+  * `OPENAPS_PRED_UAM_COLOR` (`#c9bd60`) - The color to use for UAM prediction lines. Same format as above.
 
 
  Also see [Pushover](#pushover) and [IFTTT Maker](#ifttt-maker).

--- a/README.md
+++ b/README.md
@@ -478,10 +478,10 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
   * `OPENAPS_URGENT` (`60`) - The number of minutes since the last loop that needs to be exceed before an urgent alarm is triggered
   * `OPENAPS_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display by default.  Any of the following fields: `status-symbol`, `status-label`, `iob`, `meal-assist`, `freq`, and `rssi`
   * `OPENAPS_RETRO_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display in retro mode. Any of the above fields.
-  * `OPENAPS_PREB_IOB` (`#ff00ff`) - The color to use for IOB prediction lines
-  * `OPENAPS_PREB_COB` (`#ff00ff`) - The color to use for COB prediction lines
-  * `OPENAPS_PREB_ZT` (`#ff00ff`) - The color to use for ZT prediction lines
-  * `OPENAPS_PREB_UAM` (`#ff00ff`) - The color to use for UAM prediction lines
+  * `OPENAPS_PRED_IOB_COLOR` (`#ff00ff`) - The color to use for IOB prediction lines
+  * `OPENAPS_PRED_COB_COLOR` (`#ff00ff`) - The color to use for COB prediction lines
+  * `OPENAPS_PRED_ZT_COLOR` (`#ff00ff`) - The color to use for ZT prediction lines
+  * `OPENAPS_PRED_UAM_COLOR` (`#ff00ff`) - The color to use for UAM prediction lines
 
 
  Also see [Pushover](#pushover) and [IFTTT Maker](#ifttt-maker).

--- a/README.md
+++ b/README.md
@@ -478,6 +478,11 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.htm
   * `OPENAPS_URGENT` (`60`) - The number of minutes since the last loop that needs to be exceed before an urgent alarm is triggered
   * `OPENAPS_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display by default.  Any of the following fields: `status-symbol`, `status-label`, `iob`, `meal-assist`, `freq`, and `rssi`
   * `OPENAPS_RETRO_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display in retro mode. Any of the above fields.
+  * `OPENAPS_PREB_IOB` (`#ff00ff`) - The color to use for IOB prediction lines
+  * `OPENAPS_PREB_COB` (`#ff00ff`) - The color to use for COB prediction lines
+  * `OPENAPS_PREB_ZT` (`#ff00ff`) - The color to use for ZT prediction lines
+  * `OPENAPS_PREB_UAM` (`#ff00ff`) - The color to use for UAM prediction lines
+
 
  Also see [Pushover](#pushover) and [IFTTT Maker](#ifttt-maker).
 

--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -39,10 +39,10 @@ function init (ctx) {
       , warn: sbx.extendedSettings.warn ? sbx.extendedSettings.warn : 30
       , urgent: sbx.extendedSettings.urgent ? sbx.extendedSettings.urgent : 60
       , enableAlerts: sbx.extendedSettings.enableAlerts
-      , predIOB: sbx.extendedSettings.predIob ? sbx.extendedSettings.predIob : '#ff00ff'
-      , predCOB: sbx.extendedSettings.predCob ? sbx.extendedSettings.predCob : '#ff00ff'
-      , predZT: sbx.extendedSettings.predZt ? sbx.extendedSettings.predZt : '#ff00ff'
-      , predUAM: sbx.extendedSettings.predUam ? sbx.extendedSettings.predUam : '#ff00ff'
+      , predIOBColor: sbx.extendedSettings.predIobColor ? sbx.extendedSettings.predIobColor : '#ff00ff'
+      , predCOBColor: sbx.extendedSettings.predCobColor ? sbx.extendedSettings.predCobColor : '#ff00ff'
+      , predZTColor: sbx.extendedSettings.predZtColor ? sbx.extendedSettings.predZtColor : '#ff00ff'
+      , predUAMColor: sbx.extendedSettings.predUamColor ? sbx.extendedSettings.predUamColor : '#ff00ff'
     };
 
     if (firstPrefs) {
@@ -370,10 +370,10 @@ function init (ctx) {
       function toPoints (offset, forecastType) {
         return function toPoint (value, index) {
           var colors = {
-            'IOB': prefs.predIOB
-            , 'Zero-Temp': prefs.predZT
-            , 'COB': prefs.predCOB
-            , 'UAM': prefs.predUAM
+            'IOB': prefs.predIOBColor
+            , 'Zero-Temp': prefs.predZTColor
+            , 'COB': prefs.predCOBColor
+            , 'UAM': prefs.predUAMColor
           }
           
           return {

--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -371,7 +371,8 @@ function init (ctx) {
       function toPoints (offset, forecastType) {
         return function toPoint (value, index) {
           var colors = {
-            'IOB': prefs.predIOBColor
+            'Values': '#ff00ff'
+            , 'IOB': prefs.predIOBColor
             , 'Zero-Temp': prefs.predZTColor
             , 'COB': prefs.predCOBColor
             , 'Accel-COB': prefs.predACOBColor

--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -39,10 +39,11 @@ function init (ctx) {
       , warn: sbx.extendedSettings.warn ? sbx.extendedSettings.warn : 30
       , urgent: sbx.extendedSettings.urgent ? sbx.extendedSettings.urgent : 60
       , enableAlerts: sbx.extendedSettings.enableAlerts
-      , predIOBColor: sbx.extendedSettings.predIobColor ? sbx.extendedSettings.predIobColor : '#ff00ff'
-      , predCOBColor: sbx.extendedSettings.predCobColor ? sbx.extendedSettings.predCobColor : '#ff00ff'
-      , predZTColor: sbx.extendedSettings.predZtColor ? sbx.extendedSettings.predZtColor : '#ff00ff'
-      , predUAMColor: sbx.extendedSettings.predUamColor ? sbx.extendedSettings.predUamColor : '#ff00ff'
+      , predIOBColor: sbx.extendedSettings.predIobColor ? sbx.extendedSettings.predIobColor : '#1e88e5'
+      , predCOBColor: sbx.extendedSettings.predCobColor ? sbx.extendedSettings.predCobColor : '#FB8C00FF'
+      , predACOBColor: sbx.extendedSettings.predAcobColor ? sbx.extendedSettings.predAcobColor : '#FB8C0080'
+      , predZTColor: sbx.extendedSettings.predZtColor ? sbx.extendedSettings.predZtColor : '#00d2d2'
+      , predUAMColor: sbx.extendedSettings.predUamColor ? sbx.extendedSettings.predUamColor : '#c9bd60'
     };
 
     if (firstPrefs) {
@@ -373,6 +374,7 @@ function init (ctx) {
             'IOB': prefs.predIOBColor
             , 'Zero-Temp': prefs.predZTColor
             , 'COB': prefs.predCOBColor
+            , 'Accel-COB': prefs.predACOBColor
             , 'UAM': prefs.predUAMColor
           }
           

--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -39,6 +39,10 @@ function init (ctx) {
       , warn: sbx.extendedSettings.warn ? sbx.extendedSettings.warn : 30
       , urgent: sbx.extendedSettings.urgent ? sbx.extendedSettings.urgent : 60
       , enableAlerts: sbx.extendedSettings.enableAlerts
+      , predIOB: sbx.extendedSettings.predIob ? sbx.extendedSettings.predIob : '#ff00ff'
+      , predCOB: sbx.extendedSettings.predCob ? sbx.extendedSettings.predCob : '#ff00ff'
+      , predZT: sbx.extendedSettings.predZt ? sbx.extendedSettings.predZt : '#ff00ff'
+      , predUAM: sbx.extendedSettings.predUam ? sbx.extendedSettings.predUam : '#ff00ff'
     };
 
     if (firstPrefs) {
@@ -365,9 +369,16 @@ function init (ctx) {
 
       function toPoints (offset, forecastType) {
         return function toPoint (value, index) {
+          var colors = {
+            "IOB": prefs.predIOB
+            , "Zero-Temp": prefs.predZT
+            , "COB": prefs.predCOB
+            , "UAM": prefs.predUAM
+          }
+          
           return {
             mgdl: value
-            , color: '#ff00ff'
+            , color: colors[forecastType]
             , mills: prop.lastPredBGs.moment.valueOf() + times.mins(5 * index).msecs + offset
             , noFade: true
             , forecastType: forecastType

--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -370,10 +370,10 @@ function init (ctx) {
       function toPoints (offset, forecastType) {
         return function toPoint (value, index) {
           var colors = {
-            "IOB": prefs.predIOB
-            , "Zero-Temp": prefs.predZT
-            , "COB": prefs.predCOB
-            , "UAM": prefs.predUAM
+            'IOB': prefs.predIOB
+            , 'Zero-Temp': prefs.predZT
+            , 'COB': prefs.predCOB
+            , 'UAM': prefs.predUAM
           }
           
           return {


### PR DESCRIPTION
This pull request lets users modify the colors of each individual OpenAPS prediction line (iob, cob, zt, and uam).

It adds 4 new environment variables to configure these colors: `OPENAPS_PRED_IOB`, `OPENAPS_PRED_COB`, `OPENAPS_PRED_ZT`, and `OPENAPS_PRED_UAM` which take a hex color code as input. The default values of these are using the current color that is applied to all prediction lines (`#ff00ff`).

I decided to stick with the same color for all of them as the default, but I am open to opinions on whether they should have new defaults or if the current approach is best.