### PR TITLE
Load the latest 'Sensor Stop' event from last 32 days

### DIFF
--- a/lib/data/dataloader.js
+++ b/lib/data/dataloader.js
@@ -297,6 +297,7 @@ function loadSensorAndInsulinTreatments(ddata, ctx, callback) {
     async.parallel([
         loadLatestSingle.bind(null, ddata, ctx, 'Sensor Start')
         ,loadLatestSingle.bind(null, ddata, ctx, 'Sensor Change')
+        ,loadLatestSingle.bind(null, ddata, ctx, 'Sensor Stop')
         ,loadLatestSingle.bind(null, ddata, ctx, 'Site Change')
         ,loadLatestSingle.bind(null, ddata, ctx, 'Insulin Change')
         ,loadLatestSingle.bind(null, ddata, ctx, 'Pump Battery Change')


### PR DESCRIPTION
Load the latest 'Sensor Stop' event in case user has a Start and Stop event that are both outside the 2-day full data load window