### PR TITLE
New utils.toFixed() for cleaner labels

### DIFF
--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -44,7 +44,7 @@ function init(ctx) {
     if (_.isEmpty(iob) || iob.iob === undefined) {
       return {};
     }
-    var display = utils.toFixed(iob.iob);
+    var display = utils.toFixed(iob.iob, 2);
     return _.merge(iob, {
       display: display
       , displayLine: 'IOB: ' + display + 'U'
@@ -267,7 +267,7 @@ function init(ctx) {
     if (sbx.properties.iob && sbx.properties.iob.iob !== 0) {
       return translate('alexaIobUnits', {
         params: [
-            utils.toFixed(sbx.properties.iob.iob)
+            utils.toFixed(sbx.properties.iob.iob, 2)
         ]
       });
     }

--- a/lib/plugins/iob.js
+++ b/lib/plugins/iob.js
@@ -44,7 +44,7 @@ function init(ctx) {
     if (_.isEmpty(iob) || iob.iob === undefined) {
       return {};
     }
-    var display = utils.toFixed(iob.iob, 2);
+    var display = utils.toFixed(iob.iob);
     return _.merge(iob, {
       display: display
       , displayLine: 'IOB: ' + display + 'U'
@@ -267,7 +267,7 @@ function init(ctx) {
     if (sbx.properties.iob && sbx.properties.iob.iob !== 0) {
       return translate('alexaIobUnits', {
         params: [
-            utils.toFixed(sbx.properties.iob.iob, 2)
+            utils.toFixed(sbx.properties.iob.iob)
         ]
       });
     }

--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -738,7 +738,7 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
         var label = ' ' + treatment.carbs + ' g';
         if (treatment.protein) label += ' / ' + treatment.protein + ' g';
         if (treatment.fat) label += ' / ' + treatment.fat + ' g';
-        label += ' (' + (treatment.carbs / ic).toFixed(2) + 'U)';
+        label += ' (' + client.utils.toFixed((treatment.carbs / ic), 2) + 'U)';
 
         context.append('rect')
           .attr('y', yCarbsScale(treatment.carbs))
@@ -758,6 +758,7 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
       }
 
       if (treatment.insulin && options.insulin) {
+        var dataLabel = client.utils.toFixed(treatment.insulin,2)+ 'U';
         context.append('rect')
           .attr('y', yInsulinScale(treatment.insulin))
           .attr('height', chartHeight - yInsulinScale(treatment.insulin))
@@ -773,7 +774,7 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
           //.attr('y', yInsulinScale(treatment.insulin)-10)
           .attr('transform', 'rotate(-45,' + (xScale2(treatment.mills) + padding.left - 2) + ',' + (padding.top + yInsulinScale(treatment.insulin)) + ')' +
             'translate(' + (xScale2(treatment.mills) + padding.left + 10) + ',' + (padding.top + yInsulinScale(treatment.insulin)) + ')')
-          .text(Number(treatment.insulin).toFixed(2) + 'U');
+          .text(dataLabel);
       }
 
       // process the rest

--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -738,7 +738,7 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
         var label = ' ' + treatment.carbs + ' g';
         if (treatment.protein) label += ' / ' + treatment.protein + ' g';
         if (treatment.fat) label += ' / ' + treatment.fat + ' g';
-        label += ' (' + client.utils.toFixed((treatment.carbs / ic), 2) + 'U)';
+        label += ' (' + client.utils.toFixedMin((treatment.carbs / ic), 2) + 'U)';
 
         context.append('rect')
           .attr('y', yCarbsScale(treatment.carbs))
@@ -758,7 +758,7 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
       }
 
       if (treatment.insulin && options.insulin) {
-        var dataLabel = client.utils.toFixed(treatment.insulin,2)+ 'U';
+        var dataLabel = client.utils.toFixedMin(treatment.insulin,2)+ 'U';
         context.append('rect')
           .attr('y', yInsulinScale(treatment.insulin))
           .attr('height', chartHeight - yInsulinScale(treatment.insulin))

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,12 +25,22 @@ function init(ctx) {
     return settings.units === 'mmol' ? Math.round(bg * 10) / 10 : Math.round(bg);
   };
 
-  utils.toFixed = function toFixed(value,digits) {
+  utils.toFixed = function toFixed(value) {
+    if (value === undefined || value === 0) {
+      return '0';
+    } else {
+      var fixed = value.toFixed(2);
+      return fixed === '-0.00' ? '0.00' : fixed;
+    }
+  };
+
+  utils.toFixedMin = function toFixedMin(value,digits) {
     if (value == null || isNaN(value)) {
       return '0';
     }
     var mult = Math.pow(10,digits);
-    return String(Math.round(Number(value)*mult)/mult);
+    var fixed = Math.sign(value) * Math.round(Math.abs(value)*mult) / mult
+    return String(fixed);
   };
 
   // some helpers for input "date"

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ function init(ctx) {
   };
 
   utils.toFixed = function toFixed(value) {
-    if (value === undefined || value === 0) {
+    if (!value) {
       return '0';
     } else {
       var fixed = value.toFixed(2);
@@ -35,7 +35,7 @@ function init(ctx) {
   };
 
   utils.toFixedMin = function toFixedMin(value,digits) {
-    if (value == null || isNaN(value)) {
+    if (!value) {
       return '0';
     }
     var mult = Math.pow(10,digits);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,13 +25,12 @@ function init(ctx) {
     return settings.units === 'mmol' ? Math.round(bg * 10) / 10 : Math.round(bg);
   };
 
-  utils.toFixed = function toFixed(value) {
-    if (value === undefined || value === 0) {
-      return '0';
-    } else {
-      var fixed = value.toFixed(2);
-      return fixed === '-0.00' ? '0.00' : fixed;
+  utils.toFixed = function toFixed(value,digits) {
+  	if (value == null || isNaN(value)) {
+    	return '0';
     }
+    var mult = Math.pow(10,digits);
+    return String(Math.round(Number(value)*mult)/mult);
   };
 
   // some helpers for input "date"

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,8 +26,8 @@ function init(ctx) {
   };
 
   utils.toFixed = function toFixed(value,digits) {
-  	if (value == null || isNaN(value)) {
-    	return '0';
+    if (value == null || isNaN(value)) {
+      return '0';
     }
     var mult = Math.pow(10,digits);
     return String(Math.round(Number(value)*mult)/mult);

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -18,11 +18,13 @@ describe('utils', function ( ) {
   it('format numbers short', function () {
     var undef;
     utils.toFixedMin(3.345, 2).should.equal('3.35');
-    utils.toFixedMin(5.499999999, 0).should.equal('6');
+    utils.toFixedMin(5.499999999, 0).should.equal('5');
     utils.toFixedMin(5.499999999, 1).should.equal('5.5');
     utils.toFixedMin(5.499999999, 3).should.equal('5.5');
     utils.toFixedMin(123.45, -2).should.equal('100');
     utils.toFixedMin(-0.001, 2).should.equal('0');
+    utils.toFixedMin(-2.47, 1).should.equal('-2.5');
+    utils.toFixedMin(-2.44, 1).should.equal('-2.4');
 
     utils.toFixedMin(undef, 2).should.equal('0');
     utils.toFixedMin(null, 2).should.equal('0');

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -12,7 +12,16 @@ describe('utils', function ( ) {
   });
 
   it('format numbers', function () {
-    utils.toFixed(5.499999999).should.equal('5.50');
+    var undef;
+    utils.toFixed(3.345, 2).should.equal('3.35');
+    utils.toFixed(5.499999999, 0).should.equal('6');
+    utils.toFixed(5.499999999, 1).should.equal('5.5');
+    utils.toFixed(5.499999999, 3).should.equal('5.5');
+    utils.toFixed(123.45, -2).should.equal('100');
+
+    utils.toFixed(undef, 2).should.equal('0');
+    utils.toFixed(null, 2).should.equal('0');
+    utils.toFixed('text', 2).should.equal('0');
   });
 
   it('merge date and time', function () {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -12,16 +12,21 @@ describe('utils', function ( ) {
   });
 
   it('format numbers', function () {
-    var undef;
-    utils.toFixed(3.345, 2).should.equal('3.35');
-    utils.toFixed(5.499999999, 0).should.equal('6');
-    utils.toFixed(5.499999999, 1).should.equal('5.5');
-    utils.toFixed(5.499999999, 3).should.equal('5.5');
-    utils.toFixed(123.45, -2).should.equal('100');
+    utils.toFixed(5.499999999).should.equal('5.50');
+  });
 
-    utils.toFixed(undef, 2).should.equal('0');
-    utils.toFixed(null, 2).should.equal('0');
-    utils.toFixed('text', 2).should.equal('0');
+  it('format numbers short', function () {
+    var undef;
+    utils.toFixedMin(3.345, 2).should.equal('3.35');
+    utils.toFixedMin(5.499999999, 0).should.equal('6');
+    utils.toFixedMin(5.499999999, 1).should.equal('5.5');
+    utils.toFixedMin(5.499999999, 3).should.equal('5.5');
+    utils.toFixedMin(123.45, -2).should.equal('100');
+    utils.toFixedMin(-0.001, 2).should.equal('0');
+
+    utils.toFixedMin(undef, 2).should.equal('0');
+    utils.toFixedMin(null, 2).should.equal('0');
+    utils.toFixedMin('text', 2).should.equal('0');
   });
 
   it('merge date and time', function () {


### PR DESCRIPTION
New utils.toFixedMin() rounds to the specified number of digits, omits any trailing zeros.  Allows cleaner text labels on daytoday report.  Added tests.