### PR TITLE
Clock Close X logic change

### DIFF
--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -65,7 +65,12 @@ client.render = function render (xhr) {
   if (m < 10) m = "0" + m;
   $('#clock').text(h + ":" + m);
 
-  if (!window.serverSettings.settings.showClockClosebutton) {
+  var queryDict = {};
+  location.search.substr(1).split("&").forEach(function(item) { queryDict[item.split("=")[0]] = item.split("=")[1] });
+
+  console.log(queryDict);
+
+  if (!window.serverSettings.settings.showClockClosebutton && !queryDict['showClockClosebutton']) {
     $('#close').css('display', 'none');
   }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -47,7 +47,7 @@ function init () {
     , secureHstsHeaderIncludeSubdomains: false
     , secureHstsHeaderPreload: false
     , secureCsp: false
-    , showClockClosebutton: true
+    , showClockClosebutton: false
   };
 
   var valueMappers = {

--- a/views/index.html
+++ b/views/index.html
@@ -174,9 +174,9 @@
                   <li><a id="admintoolslink" href="admin" target="admintools" class="translate">Admin Tools</a></li>
                   <li class="multilink">
                   	<a class="translate">Clock Views:</a>
-                  	<a id="bgclocklink" href="/clock/bgclock" class="translate multilink">Clock</a>
-                  	<a id="clockcolorlink" href="/clock/clock-color" class="translate multilink">Color</a>
-                  	<a id="clocklink" href="/clock/clock" class="translate multilink">Simple</a>
+                  	<a id="bgclocklink" href="/clock/bgclock?showClockClosebutton=true" class="translate multilink">Clock</a>
+                  	<a id="clockcolorlink" href="/clock/clock-color?showClockClosebutton=true" class="translate multilink">Color</a>
+                  	<a id="clocklink" href="/clock/clock?showClockClosebutton=true" class="translate multilink">Simple</a>
                   </li>
                 </ul>
                 <fieldset class="browserSettings" id="browserSettings">


### PR DESCRIPTION
Changed logic for the Clock Close button: 1) The show now defaults to false. When enabled, the close X always appears, 2) The views also accept this parameter from a GET parameter, which is set when navigating to the view from the menu, so users can bookmark the page without the parameter