### PR TITLE
Don't show calculated insulin next to carbs

### DIFF
--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -738,7 +738,6 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
         var label = ' ' + treatment.carbs + ' g';
         if (treatment.protein) label += ' / ' + treatment.protein + ' g';
         if (treatment.fat) label += ' / ' + treatment.fat + ' g';
-        label += ' (' + client.utils.toFixedMin((treatment.carbs / ic), 2) + 'U)';
 
         context.append('rect')
           .attr('y', yCarbsScale(treatment.carbs))


### PR DESCRIPTION
In the DayToDay report, when showing a carb event, the label above the bar shows the carbs followed by an insulin amount: "30 g (2.5U)". The insulin amount is simply a calculated value using the IC ratio. But the user may not have given themselves any insulin, or they may have bolused a different amount.  This PR removes the calculated bolus.