### PR TITLE
Remove profile conversion warning

### DIFF
--- a/static/profile/js/profileeditor.js
+++ b/static/profile/js/profileeditor.js
@@ -671,13 +671,6 @@
     adjustedRecord.defaultProfile = currentprofile;
     adjustedRecord.units = client.settings.units;
 
-    if (record.convertedOnTheFly) {
-      var result = window.confirm(translate('Profile is going to be saved in newer format used in Nightscout 0.9.0 and above and will not be usable in older versions anymore.\nAre you sure?'));
-      if (!result) {
-        return;
-      }
-    }
-
     delete record.convertedOnTheFly;
     delete adjustedRecord.convertedOnTheFly;
 


### PR DESCRIPTION
This modal dialog about converting the profile to a format that 0.9.0 or earlier won't support is still popping on fresh installs, shouldn't be required at this point.