### PR TITLE
Rewording of the "wrong profile" dialog

### DIFF
--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -938,7 +938,7 @@ function init (client, d3) {
     var lastbasal = 0;
 
     if (!profile.activeProfileToTime(from)) {
-      window.alert(translate('Wrong profile setting.\nNo profile defined to displayed time.\nRedirecting to profile editor to create new profile.'));
+      window.alert(translate('Redirecting you to the Profile Editor to create a new profile.'));
       try {
         window.location.href = '/profile';
       } catch (err) {


### PR DESCRIPTION
This dialog as originally worded often confuses/worries people when it pops on fresh installs. Reworded to be clearer about what's happening.