### PR TITLE
Allow start nightscout from other directories but cgm-remote-monitor

### DIFF
--- a/app.js
+++ b/app.js
@@ -258,9 +258,16 @@ function create (env, ctx) {
   }
 
   // Production bundling
-  var tmpFiles = express.static(__dirname + '/tmp', {
-    maxAge: maxAge
-  });
+  var tmpFiles;
+  if (fs.existsSync(process.cwd() + '/tmp/cacheBusterToken')) {
+    tmpFiles = express.static('tmp', {
+      maxAge: maxAge
+    }); 
+  } else {
+    tmpFiles = express.static(__dirname + '/tmp', {
+      maxAge: maxAge
+    });
+  }
 
   // serve the static content
   app.use('/bundle', tmpFiles);

--- a/app.js
+++ b/app.js
@@ -18,12 +18,12 @@ function create (env, ctx) {
   if (!insecureUseHttp) {
     console.info('Redirecting http traffic to https because INSECURE_USE_HTTP=', insecureUseHttp);
     app.use((req, res, next) => {
-      if (req.header('x-forwarded-proto') == 'https' || req.secure) {
+      if (req.header('x-forwarded-proto') === 'https' || req.secure) {
         next();
       } else {
         res.redirect(307, `https://${req.header('host')}${req.url}`);
       }
-    })
+    });
     if (secureHstsHeader) { // Add HSTS (HTTP Strict Transport Security) header
       console.info('Enabled SECURE_HSTS_HEADER (HTTP Strict Transport Security)');
       const helmet = require('helmet');
@@ -61,7 +61,7 @@ function create (env, ctx) {
         }));
         app.use(helmet.referrerPolicy({ policy: 'no-referrer' }));
         app.use(helmet.featurePolicy({ features: { payment: ["'none'"], } }));
-        app.use(bodyParser.json({ type: ['json', 'application/csp-report'] }))
+        app.use(bodyParser.json({ type: ['json', 'application/csp-report'] }));
         app.post('/report-violation', (req, res) => {
           if (req.body) {
             console.log('CSP Violation: ', req.body)
@@ -84,7 +84,11 @@ function create (env, ctx) {
 
   let cacheBuster = 'developmentMode';
   if (process.env.NODE_ENV !== 'development') {
-    cacheBuster = fs.readFileSync(process.cwd() + '/tmp/cacheBusterToken').toString().trim();
+    if (fs.existsSync(process.cwd() + '/tmp/cacheBusterToken')) {
+      cacheBuster = fs.readFileSync(process.cwd() + '/tmp/cacheBusterToken').toString().trim();
+    } else {
+      cacheBuster = fs.readFileSync(__dirname + '/tmp/cacheBusterToken').toString().trim();
+    }
   }
   app.locals.cachebuster = cacheBuster;
 

--- a/app.js
+++ b/app.js
@@ -254,7 +254,7 @@ function create (env, ctx) {
   }
 
   // Production bundling
-  var tmpFiles = express.static('tmp', {
+  var tmpFiles = express.static(__dirname + '/tmp', {
     maxAge: maxAge
   });
 


### PR DESCRIPTION
If I start nightscout from other path, e.g. from `/opt` and nightscout is in `/opt/cgm-remote-monitor`, it tries to find `/opt/tmp` what does not exist.