### PR TITLE
Allow use cgm-remote-monitor as npm package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dev": "env-cmd ./my.env nodemon server.js 0.0.0.0",
     "prod": "env-cmd ./my.prod.env node server.js 0.0.0.0"
   },
+  "main": "server.js",
   "config": {
     "blanket": {
       "pattern": [


### PR DESCRIPTION
To use cgm-remote-monitor as npm package, the main attribute is required.