### PR TITLE
Fixed plugin settings being displayed in other settings pages

### DIFF
--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -104,7 +104,7 @@ function init (client, serverSettings, $) {
 
     showPluginsSettings.toggle(hasPluginsToShow);
 
-    const bs = $('.browserSettings');
+    const bs = $('#browserSettings');
     const toggleCheckboxes = [];
 
     if (pluginPrefs.length > 0) {


### PR DESCRIPTION
This pull request fixes a bug introduced in https://github.com/nightscout/cgm-remote-monitor/pull/4799/commits/2b0b19d6df60cffef6d091440313182f4e2a78db, where the plugin settings were being displayed in other pages - such as the profile editor.