### PR TITLE
Fixed issue with incorrect temporary target validation

### DIFF
--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -265,7 +265,7 @@ function init (client, $) {
 
     console.log('Validating careportal entry: ', data.eventType);
 
-    if (data.eventType == 'Temporary Target') {
+    if (data.duration !== 0 && data.eventType == 'Temporary Target') {
       if (isNaN(data.targetTop) || isNaN(data.targetBottom) || !data.targetBottom || !data.targetTop) {
         console.log('Bottom or Top target missing');
         allOk = false;


### PR DESCRIPTION
This fixes the issue described in #4859, by only running the validation code if the temporary target event is actually a target rather than a cancel event.