### PR TITLE
api-docs.html -> /api-docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The server status and settings are available from `/api/v1/status.json`.
 By default the `/entries` and `/treatments` APIs limit results to the the most recent 10 values from the last 2 days.
 You can get many more results, by using the `count`, `date`, `dateString`, and `created_at` parameters, depending on the type of data you're looking for.
 
-Once you've installed Nightscout, you can access API documentation by loading `/api-docs` URL in your instance.
+Once you've installed Nightscout, you can access API documentation by loading `/api-docs/` URL in your instance.
 
 #### Example Queries
 
@@ -213,7 +213,7 @@ Once you've installed Nightscout, you can access API documentation by loading `/
   * Boluses over 2U: `http://localhost:1337/api/v1/treatments.json?find[insulin][$gte]=2`
 
 The API is Swagger enabled, so you can generate client code to make working with the API easy.
-To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs.html or review [swagger.yaml](swagger.yaml).
+To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs/ or review [swagger.yaml](swagger.yaml).
 
 ## Environment
 


### PR DESCRIPTION
`/api-docs/` seems to be the correct path for the swagger UI.

- change `/api-docs.html` reference to `/api-docs/`
- also change `/api-docs` to `/api-docs/` as it is more exact