### PR TITLE
Parse target top and bottom as integers

### DIFF
--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -272,8 +272,8 @@ function init (client, $) {
         messages.push("Please enter a valid value for both top and bottom target to save a Temporary Target");
       } else {
 
-        let targetTop = data.targetTop;
-        let targetBottom = data.targetBottom;
+        let targetTop = parseInt(data.targetTop);
+        let targetBottom = parseInt(data.targetBottom);
 
         let minTarget = 4 * 18;
         let maxTarget = 18 * 18;


### PR DESCRIPTION
Fixes #4993.
The input variables `data.targetTop` and `data.targetBottom` are strings, so the `targetTop` and `targetBottom` variables were being assigned as strings too. This caused the verification checks to give incorrect results because those variables were not treated as numbers. Parsing the input variables as integers will convert them to the number type and allow these checks to work as intended.