### PR TITLE
Append token parameter in URL to side menu links

### DIFF
--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -135,7 +135,24 @@ function init (client, serverSettings, $) {
     });
 
     $('#editprofilelink').toggle(settings.isEnabled('iob') || settings.isEnabled('cob') || settings.isEnabled('bwp') || settings.isEnabled('basal'));
+    
+    //fetches token from url
+    var parts = (location.search || '?').substring(1).split('&');
+    var token = '';
+    parts.forEach(function (val) {
+      if (val.startsWith('token=')) {
+        token = val.substring('token='.length);
+      }
+    });
 
+    //if there is a token, append it to each of the links in the hamburger menu
+    if (token != '') {
+      token = '?token=' + token;
+      $('#reportlink').attr('href', 'report' + token);
+      $('#editprofilelink').attr('href', 'profile' + token);
+      $('#admintoolslink').attr('href', 'admin' + token);
+      $('#editfoodlink').attr('href', 'food' + token);
+    }
   }
 
   function wireForm () {

--- a/views/index.html
+++ b/views/index.html
@@ -168,7 +168,7 @@
         <div id="drawer">
             <form id="settings-form" role="form" >
                 <ul class="navigation" role="navigation" aria-label="Settings">
-                  <li><a href="report" target="reports" class="translate">Reports</a></li>
+                  <li><a id="reportlink" href="report" target="reports" class="translate">Reports</a></li>
                   <li><a id="editprofilelink" href="profile" target="profileeditor" class="translate">Profile Editor</a></li>
                   <li class="foodcontrol"><a id="editfoodlink" href="food" target="foodeditor" class="translate">Food Editor</a></li>
                   <li><a id="admintoolslink" href="admin" target="admintools" class="translate">Admin Tools</a></li>


### PR DESCRIPTION
When using a token for authentication, clicking on the links in the side menu will not remember the token parameter and may ask the user for an API secret if permission is not granted. This PR will check if a token is included in the URL and append the token parameter to the links in the side menu, and fixes #2119 and #2973 