### PR TITLE
Fix mg/dl /U sensitivity which does not need to by multiplied by 18

### DIFF
--- a/lib/plugins/basalprofile.js
+++ b/lib/plugins/basalprofile.js
@@ -64,7 +64,7 @@ function init (ctx) {
     var sensitivity = profile.getSensitivity(sbx.time);
 
     if (sbx.settings.units != profile.data[0].units) {
-      sensitivity *= (sbx.settings.units === 'mmol' ? 0.055 : 18);
+      sensitivity *= (sbx.settings.units === 'mmol' ? 0.055 : 1);
       var decimals = (sbx.settings.units === 'mmol' ? 10 : 1);
 
       sensitivity = Math.round(sensitivity * decimals) / decimals;


### PR DESCRIPTION
For example a sensitivity of 84 mg/dl /U is showing as 1512 mg/dl /U in the basal pill.