### PR TITLE
Fix black OpenAPS COB forecast dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,9 +481,9 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs/ or
   * `OPENAPS_URGENT` (`60`) - The number of minutes since the last loop that needs to be exceed before an urgent alarm is triggered
   * `OPENAPS_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display by default.  Any of the following fields: `status-symbol`, `status-label`, `iob`, `meal-assist`, `freq`, and `rssi`
   * `OPENAPS_RETRO_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display in retro mode. Any of the above fields.
-  * `OPENAPS_PRED_IOB_COLOR` (`#1e88e5`) - The color to use for IOB prediction lines. Colors can be in either `#RRGGBB` or `#RRGGBBAA` format.
-  * `OPENAPS_PRED_COB_COLOR` (`#FB8C00FF`) - The color to use for COB prediction lines. Same format as above.
-  * `OPENAPS_PRED_ACOB_COLOR` (`#FB8C0080`) - The color to use for ACOB prediction lines. Same format as above.
+  * `OPENAPS_PRED_IOB_COLOR` (`#1e88e5`) - The color to use for IOB prediction lines. Colors can be in `#RRGGBB` format, but [other CSS color units](https://www.w3.org/TR/2018/REC-css-color-3-20180619/#colorunits) may be used as well.
+  * `OPENAPS_PRED_COB_COLOR` (`#FB8C00`) - The color to use for COB prediction lines. Same format as above.
+  * `OPENAPS_PRED_ACOB_COLOR` (`#FB8C00`) - The color to use for ACOB prediction lines. Same format as above.
   * `OPENAPS_PRED_ZT_COLOR` (`#00d2d2`) - The color to use for ZT prediction lines. Same format as above.
   * `OPENAPS_PRED_UAM_COLOR` (`#c9bd60`) - The color to use for UAM prediction lines. Same format as above.
   * `OPENAPS_COLOR_PREDICTION_LINES` (`true`) - Enables / disables the colored lines vs the classic purple color.

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs/ or
   * `OPENAPS_URGENT` (`60`) - The number of minutes since the last loop that needs to be exceed before an urgent alarm is triggered
   * `OPENAPS_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display by default.  Any of the following fields: `status-symbol`, `status-label`, `iob`, `meal-assist`, `freq`, and `rssi`
   * `OPENAPS_RETRO_FIELDS` (`status-symbol status-label iob meal-assist rssi`) - The fields to display in retro mode. Any of the above fields.
-  * `OPENAPS_PRED_IOB_COLOR` (`#1e88e5`) - The color to use for IOB prediction lines. Colors can be in `#RRGGBB` format, but [other CSS color units](https://www.w3.org/TR/2018/REC-css-color-3-20180619/#colorunits) may be used as well.
+  * `OPENAPS_PRED_IOB_COLOR` (`#1e88e5`) - The color to use for IOB prediction lines. Colors can be in `#RRGGBB` format, but [other CSS color units](https://www.w3.org/TR/css-color-3/#colorunits) may be used as well.
   * `OPENAPS_PRED_COB_COLOR` (`#FB8C00`) - The color to use for COB prediction lines. Same format as above.
   * `OPENAPS_PRED_ACOB_COLOR` (`#FB8C00`) - The color to use for ACOB prediction lines. Same format as above.
   * `OPENAPS_PRED_ZT_COLOR` (`#00d2d2`) - The color to use for ZT prediction lines. Same format as above.

--- a/lib/plugins/openaps.js
+++ b/lib/plugins/openaps.js
@@ -54,8 +54,8 @@ function init (ctx) {
       , urgent: settings.urgent ? settings.urgent : 60
       , enableAlerts: settings.enableAlerts
       , predIOBColor: settings.predIobColor ? settings.predIobColor : '#1e88e5'
-      , predCOBColor: settings.predCobColor ? settings.predCobColor : '#FB8C00FF'
-      , predACOBColor: settings.predAcobColor ? settings.predAcobColor : '#FB8C0080'
+      , predCOBColor: settings.predCobColor ? settings.predCobColor : '#FB8C00'
+      , predACOBColor: settings.predAcobColor ? settings.predAcobColor : '#FB8C00'
       , predZTColor: settings.predZtColor ? settings.predZtColor : '#00d2d2'
       , predUAMColor: settings.predUamColor ? settings.predUamColor : '#c9bd60'
       , colorPredictionLines: settings.colorPredictionLines


### PR DESCRIPTION
In some rare circumstances, the COB forecast dots from OpenAPS change from their default orange color to a black color. Shown below are a couple of examples where this bug occurred.
![image](https://user-images.githubusercontent.com/32445075/66250745-55130380-e6fb-11e9-93f5-e7960fe94a32.png) ![image](https://user-images.githubusercontent.com/32445075/66250845-2138dd80-e6fd-11e9-92ce-58a62412de86.png)
To fix this, I removed the alpha values from the default COB forecast colors and I also added a link to W3C standards to show alternate values that can be used in the color environment variables.

I've noticed this happens mostly when moving the graph view backwards in time through periods where COB forecasts are visible. To reproduce this bug, it's easiest to add `FF` to the end of a commonly displayed forecast type's color variable (I used the IOB type, so `OPENAPS_PRED_IOB_COLOR=#1e88e5FF`) and scroll through the retro view until the dots turn black.