### PR TITLE
Make failing tests fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ report:
 
 test_onebyone:
 	python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
-	$(foreach var,$(wildcard tests/*.js),${MONGO_SETTINGS} ${MOCHA} --timeout 30000 --exit --bail -R tap $(var);)
+	for var in tests/*.js; do ${MONGO_SETTINGS} ${MOCHA} --timeout 30000 --exit --bail -R tap $$var; done | tap-set-exit
 
 test:
 	${MONGO_SETTINGS} ${MOCHA} --timeout 30000 --exit --bail -R tap ${TESTS}
@@ -52,7 +52,7 @@ travis:
 	python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
 #	NODE_ENV=test ${MONGO_SETTINGS} \
 #	${ISTANBUL} cover ${MOCHA} --report lcovonly -- --timeout 5000 -R tap ${TESTS}	
-	$(foreach var,$(wildcard tests/*.js),${MONGO_SETTINGS} ${MOCHA} --timeout 30000 --exit --bail -R tap $(var);)
+	for var in tests/*.js; do ${MONGO_SETTINGS} ${MOCHA} --timeout 30000 --exit --bail -R tap $$var; done | tap-set-exit
 
 docker_release:
 	# Get the version from the package.json file

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3903,6 +3903,12 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
       "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
     },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "dev": true
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -10711,6 +10717,27 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "tap-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-1.3.2.tgz",
+      "integrity": "sha1-EgxQiciMPIp5PvKIhn3jIeGPjCI=",
+      "dev": true,
+      "requires": {
+        "events-to-array": "^1.0.1",
+        "inherits": "~2.0.1",
+        "js-yaml": "^3.2.7",
+        "readable-stream": "^2"
+      }
+    },
+    "tap-set-exit": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tap-set-exit/-/tap-set-exit-1.1.1.tgz",
+      "integrity": "sha1-nGejf03FcOSZlCBGT45sGYaLVWE=",
+      "dev": true,
+      "requires": {
+        "tap-parser": "^1.0.4"
       }
     },
     "tapable": {

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "nyc": "^14.1.1",
     "should": "^13.2.3",
     "supertest": "^3.4.2",
+    "tap-set-exit": "^1.1.1",
     "terser-webpack-plugin": "^1.4.1",
     "webpack-bundle-analyzer": "^3.4.1",
     "webpack-dev-middleware": "^3.7.2",


### PR DESCRIPTION
So this started as a bit of a saga — I was looking into what it'd take to update d3, since that's an issue for the project, and in so doing realized that the tests weren't actually working — `make test` fails, but the project CI does not. I thought it was something I'd done in the setup, but no, it is in fact [failing in CI but not being reported](https://travis-ci.org/nightscout/cgm-remote-monitor/jobs/598564107) — Search for `not ok` in those results and you'll find the tap output of failing tests.

I can go annotate tests as failing so the build can go green with them marked if that's useful, but I figured I could start the conversation here with this PR.