### PR TITLE
changed gitter shield to discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ Languages with less than 90% coverage will be removed in a future Nightscout ver
 | Suomi (`fi`)|[@sulkaharo] |OK|
 | Français (`fr`)|Please volunteer|OK|
 | עברית (`he`)|Please volunteer|OK|
-| Hrvatski (`hr`)|[@OpossumGit]|Needs attention: 47.8% - committed 100% to dev|
+| Hrvatski (`hr`)|[@OpossumGit]|OK|
 | Italiano (`it`)|Please volunteer|OK|
 | 日本語 (`ja`)|[@LuminaryXion]|Working on this|
 | 한국어 (`ko`)|Please volunteer|Needs attention: 80.6%|

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Nightscout Web Monitor (a.k.a. cgm-remote-monitor)
 [![Dependency Status][dependency-img]][dependency-url]
 [![Coverage Status][coverage-img]][coverage-url]
 [![Codacy Badge][codacy-img]][codacy-url]
-[![Gitter chat][gitter-img]][gitter-url]
+[![Discord chat][discord-img]][discord-url]
 
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/) [![Deploy to Heroku][heroku-img]][heroku-url] [![Update your site][update-img]][update-fork]
 
@@ -35,8 +35,8 @@ Community maintained fork of the
 [coverage-url]: https://coveralls.io/github/nightscout/cgm-remote-monitor?branch=master
 [codacy-img]: https://www.codacy.com/project/badge/f79327216860472dad9afda07de39d3b
 [codacy-url]: https://www.codacy.com/app/Nightscout/cgm-remote-monitor
-[gitter-img]: https://img.shields.io/badge/Gitter-Join%20Chat%20%E2%86%92-1dce73.svg
-[gitter-url]: https://gitter.im/nightscout/public
+[discord-img]: https://img.shields.io/discord/629952586895851530?label=discord%20chat
+[discord-url]: https://discordapp.com/channels/629952586895851530/629952669967974410
 [heroku-img]: https://www.herokucdn.com/deploy/button.png
 [heroku-url]: https://heroku.com/deploy
 [update-img]: update.png

--- a/README.md
+++ b/README.md
@@ -35,13 +35,8 @@ Community maintained fork of the
 [coverage-url]: https://coveralls.io/github/nightscout/cgm-remote-monitor?branch=master
 [codacy-img]: https://www.codacy.com/project/badge/f79327216860472dad9afda07de39d3b
 [codacy-url]: https://www.codacy.com/app/Nightscout/cgm-remote-monitor
-<<<<<<< HEAD
 [discord-img]: https://img.shields.io/discord/629952586895851530?label=discord%20chat
 [discord-url]: https://discordapp.com/channels/629952586895851530/629952669967974410
-=======
-[discord-img]: https://img.shields.io/discord/629952586895851530
-[discord-url]: https://discordapp.com/channels/629952586895851530/629952669967974410?label=discord%20chat
->>>>>>> 7773fddaec7318a3261a95a973b87457a99e3290
 [heroku-img]: https://www.herokucdn.com/deploy/button.png
 [heroku-url]: https://heroku.com/deploy
 [update-img]: update.png

--- a/README.md
+++ b/README.md
@@ -35,8 +35,13 @@ Community maintained fork of the
 [coverage-url]: https://coveralls.io/github/nightscout/cgm-remote-monitor?branch=master
 [codacy-img]: https://www.codacy.com/project/badge/f79327216860472dad9afda07de39d3b
 [codacy-url]: https://www.codacy.com/app/Nightscout/cgm-remote-monitor
+<<<<<<< HEAD
 [discord-img]: https://img.shields.io/discord/629952586895851530?label=discord%20chat
 [discord-url]: https://discordapp.com/channels/629952586895851530/629952669967974410
+=======
+[discord-img]: https://img.shields.io/discord/629952586895851530
+[discord-url]: https://discordapp.com/channels/629952586895851530/629952669967974410?label=discord%20chat
+>>>>>>> 7773fddaec7318a3261a95a973b87457a99e3290
 [heroku-img]: https://www.herokucdn.com/deploy/button.png
 [heroku-url]: https://heroku.com/deploy
 [update-img]: update.png

--- a/lib/language.js
+++ b/lib/language.js
@@ -14048,31 +14048,37 @@ function init() {
     'Protein': {
       fi: 'Proteiini'
       , de: 'Protein'
+      ,hr: 'Proteini'
     },
     'Fat': {
       fi: 'Rasva'
       , de: 'Fett'
+      ,hr: 'Masti'
     },
     'Protein average': {
       fi: 'Proteiini keskiarvo'
       , de: 'Proteine Durchschnitt'
+      ,hr: 'Prosjek proteina'
     },
     'Fat average': {
       fi: 'Rasva keskiarvo'
       , de: 'Fett Durchschnitt'
-
+      ,hr: 'Prosjek masti'
     },
     'Total carbs': {
       fi: 'Hiilihydraatit yhteensä'
       , de: 'Kohlenhydrate gesamt'
+      ,hr: 'Ukupno ugh'
     },
     'Total protein': {
       fi: 'Proteiini yhteensä'
       , de: 'Protein gesamt'
+      ,hr: 'Ukupno proteini'
     },
     'Total fat': {
       fi: 'Rasva yhteensä'
       , de: 'Fett gesamt'
+      ,hr: 'Ukupno masti'
     }    
   };
 


### PR DESCRIPTION
Readme now points to DISCORD, not gitter anymore.

However, in order for it to work completely, someone (discord channel owner) needs to enable widget* on discord, as described in:
https://shields.io/category/chat
*click on discord shield overthere and watch the short video