### PR TITLE
fix: Fix value caching in the profile functions. 

### DIFF
--- a/lib/plugins/cob.js
+++ b/lib/plugins/cob.js
@@ -41,14 +41,17 @@ function init (ctx) {
     }
 
     var devicestatusCOB = cob.lastCOBDeviceStatus(devicestatus, time);
-
-    var treatmentCOB = (treatments !== undefined && treatments.length) ? cob.fromTreatments(treatments, devicestatus, profile, time, spec_profile) : {};
-
     var result = devicestatusCOB;
-    if (_.isEmpty(result)) {
+
+    const TEN_MINUTES = 10 * 60 * 1000;
+
+    if (_.isEmpty(result) || _.isNil(result.cob) || (Date.now() - result.mills) > TEN_MINUTES) {
+
+      console.log('Calculating COB');
+      var treatmentCOB = (treatments !== undefined && treatments.length) ? cob.fromTreatments(treatments, devicestatus, profile, time, spec_profile) : {};
+
       result = treatmentCOB;
       result.source = 'Care Portal';
-    } else if (treatmentCOB) {
       result.treatmentCOB = treatmentCOB;
     }
 

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -71,6 +71,16 @@ function init (profileData) {
   profile.getValueByTime = function getValueByTime (time, valueType, spec_profile) {
     if (!time) { time = Date.now(); }
 
+    //round to the minute for better caching
+    var minuteTime = Math.round(time / 60000) * 60000;
+
+    var cacheKey = (minuteTime + valueType + spec_profile + profile.profiletreatments_hash);
+    var returnValue = cache.get(cacheKey);
+
+    if (returnValue) {
+      return returnValue;
+    }
+
     // CircadianPercentageProfile support
     var timeshift = 0;
     var percentage = 100;
@@ -82,16 +92,6 @@ function init (profileData) {
     }
     var offset = timeshift % 24;
     time = time + offset * times.hours(offset).msecs;
-
-    //round to the minute for better caching
-    var minuteTime = Math.round(time / 60000) * 60000;
-
-    var cacheKey = (minuteTime + valueType + spec_profile + profile.profiletreatments_hash);
-    var returnValue = cache.get(cacheKey);
-
-    if (returnValue) {
-      return returnValue;
-    }
 
     var valueContainer = profile.getCurrentProfile(time, spec_profile)[valueType];
 


### PR DESCRIPTION
Looks like when Circadian profile support was added, the caching of value fetches broke, causing the calls to get profile data to be > 100x slower than before. Additionally, this changes the COB plugin to not calculate COB locally at all if a recent value is available from status uploads. When profiling the script execution speed using Chrome, the changes in this PR drop the script execution time of a full page reload from 3000ms to 330ms.