### PR TITLE
Further performance fixes

### DIFF
--- a/lib/client/chart.js
+++ b/lib/client/chart.js
@@ -16,6 +16,8 @@ var PADDING_BOTTOM = 30
   , FOCUS_MIN = 30
 ;
 
+var loadTime = Date.now();
+
 function init (client, d3, $) {
   var chart = { };
 
@@ -192,7 +194,9 @@ function init (client, d3, $) {
   chart.brush = d3.brushX()
     .on('start', brushStarted)
     .on('brush', function brush (time) {
-      client.loadRetroIfNeeded();
+      // layouting the graph causes a brushed event
+      // ignore retro data load the first two seconds
+      if (Date.now() - loadTime > 2000) client.loadRetroIfNeeded();
       client.brushed(time);
     })
     .on('end', brushEnded);

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -475,10 +475,22 @@ client.load = function load (serverSettings, callback) {
       client.ddata.inRetroMode = inRetroMode();
       client.ddata.profile = profile;
 
+      // retro data only ever contains device statuses
+      // Cleate a clone of the data for the sandbox given to plugins
+      
+      var mergedStatuses = client.ddata.devicestatus;
+
+      if (client.retro.data) {
+        mergedStatuses = _.merge({}, client.retro.data.devicestatus, client.ddata.devicestatus);
+      }
+      
+      var clonedData = _.clone(client.ddata);
+      clonedData.devicestatus = mergedStatuses;
+
       client.sbx = sandbox.clientInit(
         client.ctx
         , new Date(time).getTime() //make sure we send a timestamp
-        , _.merge({}, client.retro.data || {}, client.ddata)
+        , clonedData
       );
 
       //all enabled plugins get a chance to set properties, even if they aren't shown


### PR DESCRIPTION
Don't load retro data if not needed. Merge retro data faster if it's present.