### PR TITLE
Fix falsely suspended timeago alarms

### DIFF
--- a/lib/plugins/timeago.js
+++ b/lib/plugins/timeago.js
@@ -3,10 +3,10 @@
 var levels = require('../levels');
 var times = require('../times');
 var lastChecked = new Date();
-var lastSuspendTime = new Date("1900-01-01");
 
 function init(ctx) {
   var translate = ctx.language.translate;
+  var heartbeatMs = ctx.settings.heartbeat * 1000;
 
   var timeago = {
     name: 'timeago',
@@ -64,21 +64,14 @@ function init(ctx) {
   };
 
   timeago.checkStatus = function checkStatus(sbx) {
-
     // Check if the app has been suspended; if yes, snooze data missing alarmn for 15 seconds
     var now = new Date();
     var delta = now.getTime() - lastChecked.getTime();
     lastChecked = now;
 
-    if (delta > 15 * 1000) { // Looks like we've been hibernating
-      lastSuspendTime = now;
-    }
-
-    var timeSinceLastSuspended = now.getTime() - lastSuspendTime.getTime();
-
-    if (timeSinceLastSuspended < (10 * 1000)) {
-
-      console.log('Hibernation detected, suspending timeago alarm');
+    // More than 2 heartbeats since last call: looks like we've been hibernating
+    if (delta > 2 * heartbeatMs) {
+      console.log('Hibernation detected because of 2 missed hearbeats, suspending timeago alarm. heartbeatMs:', heartbeatMs, 'delta:', delta);
       return 'current';
     }
 

--- a/lib/plugins/timeago.js
+++ b/lib/plugins/timeago.js
@@ -3,6 +3,7 @@
 var levels = require('../levels');
 var times = require('../times');
 var lastChecked = new Date();
+var lastSuspendTime = new Date("1900-01-01");
 
 function init(ctx) {
   var translate = ctx.language.translate;
@@ -69,9 +70,25 @@ function init(ctx) {
     var delta = now.getTime() - lastChecked.getTime();
     lastChecked = now;
 
-    // More than 2 heartbeats since last call: looks like we've been hibernating
-    if (delta > 2 * heartbeatMs) {
-      console.log('Hibernation detected because of 2 missed hearbeats, suspending timeago alarm. heartbeatMs:', heartbeatMs, 'delta:', delta);
+    function isHibernationDetected() {
+      if (sbx.runtimeEnvironment === 'client') {
+        if (delta > 15 * 1000) { // Looks like we've been hibernating
+          lastSuspendTime = now;
+        }
+
+        var timeSinceLastSuspended = now.getTime() - lastSuspendTime.getTime();
+
+        return timeSinceLastSuspended < (10 * 1000);
+      } else if (sbx.runtimeEnvironment === 'server') {
+        return delta > 2 * heartbeatMs;
+      } else {
+        console.error('Cannot detect hibernation, because runtimeEnvironment is not detected from sbx.runtimeEnvironment:', sbx.runtimeEnvironment);
+        return false;
+      }
+    }
+
+    if (isHibernationDetected()) {
+      console.log('Hibernation detected, suspending timeago alarm');
       return 'current';
     }
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -44,6 +44,7 @@ function init () {
   sbx.serverInit = function serverInit (env, ctx) {
     reset();
 
+    sbx.runtimeEnvironment = 'server';
     sbx.time = Date.now();
     sbx.settings = env.settings;
     sbx.data = ctx.ddata.clone();
@@ -83,6 +84,7 @@ function init () {
   sbx.clientInit = function clientInit (ctx, time, data) {
     reset();
 
+    sbx.runtimeEnvironment = 'client';
     sbx.settings = ctx.settings;
     sbx.showPlugins = ctx.settings.showPlugins;
     sbx.time = time;

--- a/tests/bgnow.test.js
+++ b/tests/bgnow.test.js
@@ -9,6 +9,7 @@ var SIX_MINS = 360000;
 describe('BG Now', function ( ) {
   var ctx = {
     language: require('../lib/language')()
+    , settings: require('../lib/settings')()
   };
  
   ctx.levels = require('../lib/levels');

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -7,6 +7,7 @@ describe('IOB', function() {
   var ctx = {};
   ctx.language = require('../lib/language')();
   ctx.language.set('en');
+  ctx.settings = require('../lib/settings')();
 
   var iob = require('../lib/plugins/iob')(ctx);
 

--- a/tests/loop.test.js
+++ b/tests/loop.test.js
@@ -6,6 +6,7 @@ var moment = require('moment');
 
 var ctx = {
   language: require('../lib/language')()
+  , settings: require('../lib/settings')()
 };
 ctx.language.set('en');
 var env = require('../env')();

--- a/tests/openaps.test.js
+++ b/tests/openaps.test.js
@@ -6,6 +6,7 @@ var moment = require('moment');
 
 var ctx = {
   language: require('../lib/language')()
+  , settings: require('../lib/settings')()
 };
 ctx.language.set('en');
 var env = require('../env')();

--- a/tests/pump.test.js
+++ b/tests/pump.test.js
@@ -6,6 +6,7 @@ var moment = require('moment');
 
 var ctx = {
   language: require('../lib/language')()
+  , settings: require('../lib/settings')()
 };
 ctx.language.set('en');
 var env = require('../env')();

--- a/tests/timeago.test.js
+++ b/tests/timeago.test.js
@@ -7,6 +7,8 @@ describe('timeago', function() {
   ctx.ddata = require('../lib/data/ddata')();
   ctx.notifications = require('../lib/notifications')(env, ctx);
   ctx.language = require('../lib/language')();
+  ctx.settings = require('../lib/settings')();
+  ctx.settings.heartbeat = 0.5; // short heartbeat to speedup tests
 
   var timeago = require('../lib/plugins/timeago')(ctx);
 
@@ -39,6 +41,32 @@ describe('timeago', function() {
     should.not.exist(ctx.notifications.findHighestAlarm('Time Ago'));
 
     done();
+  });
+
+  it('should suspend alarms due to hibernation when 2 heartbeats are skipped', function() {
+    ctx.ddata.sgvs = [{ mills: Date.now() - times.mins(16).msecs, mgdl: 100, type: 'sgv' }];
+
+    var sbx = freshSBX()
+    var status = timeago.checkStatus(sbx);
+    // By default (no hibernation detected) a warning should be given
+    should.equal(status, 'warn')
+
+    // 10ms more than suspend-threshold to prevent flapping tests
+    var timeoutMs = 2 * ctx.settings.heartbeat * 1000 + 100;
+    return new Promise(function(resolve, reject) {
+      setTimeout(function() {
+        status = timeago.checkStatus(sbx);
+        // Because hibernation should now be detected, no warning should be given
+        should.equal(status, 'current')
+
+        // We immediately ask status again, so hibernation should not be detected anymore,
+        // and we should receive a warning again
+        status = timeago.checkStatus(sbx);
+        should.equal(status, 'warn')
+
+        resolve()
+      }, timeoutMs)
+    })
   });
 
   it('should trigger a warning when data older than 15m', function(done) {

--- a/tests/timeago.test.js
+++ b/tests/timeago.test.js
@@ -43,7 +43,7 @@ describe('timeago', function() {
     done();
   });
 
-  it('should suspend alarms due to hibernation when 2 heartbeats are skipped', function() {
+  it('should suspend alarms due to hibernation when 2 heartbeats are skipped on server', function() {
     ctx.ddata.sgvs = [{ mills: Date.now() - times.mins(16).msecs, mgdl: 100, type: 'sgv' }];
 
     var sbx = freshSBX()

--- a/tests/timeago.test.js
+++ b/tests/timeago.test.js
@@ -49,7 +49,9 @@ describe('timeago', function() {
     var sbx = freshSBX()
     var status = timeago.checkStatus(sbx);
     // By default (no hibernation detected) a warning should be given
-    should.equal(status, 'warn')
+    // we force no hibernation by checking status twice
+    status = timeago.checkStatus(sbx);
+    should.equal(status, 'warn');
 
     // 10ms more than suspend-threshold to prevent flapping tests
     var timeoutMs = 2 * ctx.settings.heartbeat * 1000 + 100;
@@ -57,12 +59,12 @@ describe('timeago', function() {
       setTimeout(function() {
         status = timeago.checkStatus(sbx);
         // Because hibernation should now be detected, no warning should be given
-        should.equal(status, 'current')
+        should.equal(status, 'current');
 
         // We immediately ask status again, so hibernation should not be detected anymore,
         // and we should receive a warning again
         status = timeago.checkStatus(sbx);
-        should.equal(status, 'warn')
+        should.equal(status, 'warn');
 
         resolve()
       }, timeoutMs)


### PR DESCRIPTION
This PR should fix that `timeago`-alerts aren't sent, because Hibernation was detected which silenced the alarms. At least, it does/did in my case 😄 (deployed this code to Heroku and verified the logs and tested the behaviour using Pushover)

When I looked at the logs in Papertrail, I saw a log-line each minute saying hibernation was detected, even though the app was still running fine in Heroku, preventing the alarm notifications when data isn't received for >15 minutes (or >30).

Looking at the code, I saw that the `delta` value checked for being > 15 seconds (which is always true). In Papertrail I saw the hibernation log-line each minute, so I searched for something like `setInterval` each minute. Eventually, I found `settings.heartbeat` which is 60secs by default (and matches the periodic log-lines), so I made the `delta`-check dependent on this value.

I tried adding a test and this is the best I could think of. I first tested with `timeago.checkNotifications(sbx)`, but found that when my test failed, other tests failed as well, so I switched to just testing `timeago.checkStatus(sbx)`. If there are better or more reliable ways, let me know.
All tests in `timeago.test.js` pass though on my machine, consistently now.

A more real-world test:
When I deployed this, I found that when I force-killed Spike, I received the `timeago` alerts again after 15 minutes (via Pushover).

Lastly, I want to express my gratitude for this project. I've been using it since a short while and I have nothing but good things to say. I'm impressed by the possibilities and integrations the project provides and I like it more and more every day, so thanks to all that have made this project possible!! 🥇 👍 👍 