### PR TITLE
API3 read-only documents

### DIFF
--- a/lib/api3/const.json
+++ b/lib/api3/const.json
@@ -17,6 +17,7 @@
     "NOT_FOUND": 404,
     "GONE": 410,
     "PRECONDITION_FAILED": 412,
+    "UNPROCESSABLE_ENTITY": 422,
     "INTERNAL_ERROR": 500
   },
 
@@ -39,6 +40,7 @@
     "HTTP_401_MISSING_OR_BAD_TOKEN": "Missing or bad access token or JWT",
     "HTTP_403_MISSING_PERMISSION": "Missing permission {0}",
     "HTTP_403_NOT_USING_HTTPS": "Not using SSL/TLS",
+    "HTTP_422_READONLY_MODIFICATION": "Trying to modify read-only document",
     "HTTP_500_INTERNAL_ERROR": "Internal Server Error",
     "STORAGE_ERROR": "Database error",
     "SOCKET_MISSING_OR_BAD_ACCESS_TOKEN": "Missing or bad accessToken",

--- a/lib/api3/generic/delete/operation.js
+++ b/lib/api3/generic/delete/operation.js
@@ -14,11 +14,40 @@ async function doDelete (opCtx) {
 
   await security.demandPermission(opCtx, `api:${col.colName}:delete`);
 
+  if (await validateDelete(opCtx) !== true)
+    return;
+
   if (req.query.permanent && req.query.permanent === "true") {
     await deletePermanently(opCtx);
   } else {
     await markAsDeleted(opCtx);
   }
+}
+
+
+async function validateDelete (opCtx) {
+
+  const { col, req, res } = opCtx;
+
+  const identifier = req.params.identifier;
+  const result = await col.storage.findOne(identifier);
+
+  if (!result)
+    throw new Error('empty result');
+
+  if (result.length === 0) {
+    return res.status(apiConst.HTTP.NOT_FOUND).end();
+  }
+  else {
+    const storageDoc = result[0];
+
+    if (storageDoc.isReadOnly === true) {
+      return opTools.sendJSONStatus(res, apiConst.HTTP.UNPROCESSABLE_ENTITY,
+        apiConst.MSG.HTTP_422_READONLY_MODIFICATION);
+    }
+  }
+
+  return true;
 }
 
 

--- a/lib/api3/generic/delete/operation.js
+++ b/lib/api3/generic/delete/operation.js
@@ -41,7 +41,7 @@ async function validateDelete (opCtx) {
   else {
     const storageDoc = result[0];
 
-    if (storageDoc.isReadOnly === true) {
+    if (storageDoc.isReadOnly === true || storageDoc.readOnly === true || storageDoc.readonly === true) {
       return opTools.sendJSONStatus(res, apiConst.HTTP.UNPROCESSABLE_ENTITY,
         apiConst.MSG.HTTP_422_READONLY_MODIFICATION);
     }

--- a/lib/api3/generic/update/validate.js
+++ b/lib/api3/generic/update/validate.js
@@ -21,7 +21,7 @@ function validate (opCtx, doc, storageDoc, options) {
   const immutable = ['identifier', 'date', 'utcOffset', 'eventType', 'device', 'app',
     'srvCreated', 'subject', 'srvModified', 'modifiedBy', 'isValid'];
 
-  if (storageDoc.isReadOnly === true || storageDoc.readOnly === true) {
+  if (storageDoc.isReadOnly === true || storageDoc.readOnly === true || storageDoc.readonly === true) {
     return opTools.sendJSONStatus(res, apiConst.HTTP.UNPROCESSABLE_ENTITY,
       apiConst.MSG.HTTP_422_READONLY_MODIFICATION);
   }

--- a/lib/api3/generic/update/validate.js
+++ b/lib/api3/generic/update/validate.js
@@ -21,6 +21,11 @@ function validate (opCtx, doc, storageDoc, options) {
   const immutable = ['identifier', 'date', 'utcOffset', 'eventType', 'device', 'app',
     'srvCreated', 'subject', 'srvModified', 'modifiedBy', 'isValid'];
 
+  if (storageDoc.isReadOnly === true) {
+    return opTools.sendJSONStatus(res, apiConst.HTTP.UNPROCESSABLE_ENTITY,
+      apiConst.MSG.HTTP_422_READONLY_MODIFICATION);
+  }
+
   for (const field of immutable) {
 
     // change of identifier is allowed in deduplication (for APIv1 documents)

--- a/lib/api3/generic/update/validate.js
+++ b/lib/api3/generic/update/validate.js
@@ -21,7 +21,7 @@ function validate (opCtx, doc, storageDoc, options) {
   const immutable = ['identifier', 'date', 'utcOffset', 'eventType', 'device', 'app',
     'srvCreated', 'subject', 'srvModified', 'modifiedBy', 'isValid'];
 
-  if (storageDoc.isReadOnly === true) {
+  if (storageDoc.isReadOnly === true || storageDoc.readOnly === true) {
     return opTools.sendJSONStatus(res, apiConst.HTTP.UNPROCESSABLE_ENTITY,
       apiConst.MSG.HTTP_422_READONLY_MODIFICATION);
   }

--- a/lib/api3/swagger.yaml
+++ b/lib/api3/swagger.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: '/api/v3'
 info:
-  version: '3.0.0'
+  version: '3.0.1'
   title: Nightscout API
   contact:
     name: NS development discussion channel
@@ -178,6 +178,8 @@ paths:
           $ref: '#/components/responses/403Forbidden'
         404:
           $ref: '#/components/responses/404NotFound'
+        422:
+          $ref: '#/components/responses/422UnprocessableEntity'
 
 
   #return HTTP STATUS 400 for all other verbs (PUT, PATCH, DELETE,...)
@@ -296,6 +298,8 @@ paths:
           $ref: '#/components/responses/412PreconditionFailed'
         410:
           $ref: '#/components/responses/410Gone'
+        422:
+          $ref: '#/components/responses/422UnprocessableEntity'
 
 
     ######################################################################################
@@ -356,6 +360,8 @@ paths:
           $ref: '#/components/responses/412PreconditionFailed'
         410:
           $ref: '#/components/responses/410Gone'
+        422:
+          $ref: '#/components/responses/422UnprocessableEntity'
 
 
     ######################################################################################
@@ -388,6 +394,8 @@ paths:
           $ref: '#/components/responses/403Forbidden'
         404:
           $ref: '#/components/responses/404NotFound'
+        422:
+          $ref: '#/components/responses/422UnprocessableEntity'
 
 
   ######################################################################################
@@ -886,6 +894,9 @@ components:
     410Gone:
       description: The requested document has already been deleted.
 
+    422UnprocessableEntity:
+      description: The client request is well formed but a server validation error occured. Eg. when trying to modify or delete a read-only document (having `isReadOnly=true`).
+
     search200:
       description: Successful operation returning array of documents matching the filtering criteria
       content:
@@ -1128,6 +1139,17 @@ components:
 
           example: false
 
+
+        isReadOnly:
+          type: boolean
+          description:
+            A flag set by client that locks the document from any changes. Every document marked with `isReadOnly=true` is forever immutable and cannot even be deleted.
+
+
+            Any attempt to modify the read-only document will end with status 422 UNPROCESSABLE ENTITY.
+
+
+          example: true
 
       required:
         - date


### PR DESCRIPTION
After discussion on the #api channel, it turned out that it would be useful to be able to lock some uploaded documents. In particular, this makes sense, for example, for read CGM values or device statuses. 
Now the API would be extended (including documentation) with the possibility to use the `isReadOnly` field, which would prevent subsequent upsert (insert/update), patch or delete operations.
Attempts to edit read-only documents would result in HTTP status 422.
