### PR TITLE
Use default entries count instead of distributed number literals

### DIFF
--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -408,7 +408,7 @@ function configure (app, wares, ctx, env) {
 
     // If "?count=" is present, use that number to decided how many to return.
     if (!query.count) {
-      query.count = 10;
+      query.count = consts.ENTRIES_DEFAULT_COUNT;
     }
     // bias towards entries, but allow expressing preference of storage layer
     var storage = req.params.echo || 'entries';
@@ -434,7 +434,7 @@ function configure (app, wares, ctx, env) {
 
     // If "?count=" is present, use that number to decided how many to return.
     if (!query.count) {
-      query.count = 10;
+      query.count = consts.ENTRIES_DEFAULT_COUNT;
     }
 
     // bias to entries, but allow expressing a preference
@@ -476,7 +476,7 @@ function configure (app, wares, ctx, env) {
     }
     var query = req.query;
     if (!query.count) {
-      query.count = 10
+      query.count = consts.ENTRIES_DEFAULT_COUNT;
     }
     // remove using the query
     req.model.remove(query, function(err, stat) {


### PR DESCRIPTION
The `ENTRIES_DEFAULT_COUNT` constant is already used elsewhere in the repository. By using it in place of the distributed number literals, we make the default entries value more configurable. It also reduces the risk of these numbers accidentally becoming out of sync, thus the software is more predictable.