### PR TITLE
[Clock] Fix incorrect delta calculation

### DIFF
--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -44,7 +44,7 @@ client.render = function render (xhr) {
       rec = element;
     }
     else if (element.sgv && rec && !delta) {
-      delta = (rec.sgv - element.sgv)/((rec.date - element.date)/(5*60*1000));
+      delta = ((rec.sgv - element.sgv)/((rec.date - element.date)/(5*60*1000))).toFixed(0);
     }
   });
 

--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -40,11 +40,11 @@ client.render = function render (xhr) {
   let delta;
 
   xhr.forEach(element => {
-    if (element.sgv && !rec && !delta) {
+    if (element.sgv && !rec) {
       rec = element;
     }
-    else if (element.sgv && rec && !delta) {
-      delta = ((rec.sgv - element.sgv)/((rec.date - element.date)/(5*60*1000))).toFixed(0);
+    else if (element.sgv && rec && delta==null) {
+      delta = (rec.sgv - element.sgv)/((rec.date - element.date)/(5*60*1000));
     }
   });
 


### PR DESCRIPTION
Nothing better than example:
Last 3 BG values: 90->100->100 - delta was incorrectly calculated showing -5 (difference between 1st and 3rd value normalized to 5 min. period), it should be 0 instead.

Caused by incorrect !delta condition which returns true for delta=0.
Changed to string, works nicely now (including mmol conversion).