### PR TITLE
Removed unsused var ic

### DIFF
--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -735,7 +735,6 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
       }
 
       if (treatment.carbs && options.carbs) {
-        var ic = profile.getCarbRatio(new Date(treatment.mills));
         var label = ' ' + treatment.carbs + ' g';
         if (treatment.protein) label += ' / ' + treatment.protein + ' g';
         if (treatment.fat) label += ' / ' + treatment.fat + ' g';


### PR DESCRIPTION
I was not able to 'npm run dev' because of the unused var:
...\cgm-remote-monitor\lib\report_plugins\daytoday.js
  738:13  error  'ic' is assigned a value but never used  no-unused-vars