### PR TITLE
Fix #5146 - display of treatment with only Fat and Protein set

### DIFF
--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -542,22 +542,25 @@ function init (client, d3) {
       // these used to be semicircles from 1.5708 to 4.7124, but that made the tooltip target too big
       { 'element': '', 'color': 'transparent', 'start': 3.1400, 'end': 3.1432, 'inner': radius.R2, 'outer': radius.R3 }
       , { 'element': '', 'color': 'transparent', 'start': 3.1400, 'end': 3.1432, 'inner': radius.R2, 'outer': radius.R4 }
-    ];
+    ]
+      , arc_data_1_elements = [];
 
     arc_data[0].outlineOnly = !treatment.carbs;
     arc_data[2].outlineOnly = !treatment.insulin;
 
     if (treatment.carbs > 0) {
-      arc_data[1].element = Math.round(treatment.carbs) + ' g';
+      arc_data_1_elements.push(Math.round(treatment.carbs) + ' g');
     }
 
     if (treatment.protein > 0) {
-      arc_data[1].element = arc_data[1].element + " / " + Math.round(treatment.protein) + ' g';
+      arc_data_1_elements.push(Math.round(treatment.protein) + ' g');
     }
 
     if (treatment.fat > 0) {
-      arc_data[1].element = arc_data[1].element + " / " + Math.round(treatment.fat) + ' g';
+      arc_data_1_elements.push(Math.round(treatment.fat) + ' g');
     }
+
+    arc_data[1].element = arc_data_1_elements.join(' / ');
 
     if (treatment.foodType) {
       arc_data[1].element = arc_data[1].element + " " + treatment.foodType;
@@ -1007,7 +1010,7 @@ function init (client, d3) {
   };
 
   renderer.drawTreatment = function drawTreatment (treatment, opts, carbratio) {
-    if (!treatment.carbs && !treatment.insulin) {
+    if (!treatment.carbs && !treatment.protein && !treatment.fat && !treatment.insulin) {
       return;
     }
 

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -163,7 +163,7 @@ function init (profileData) {
   profile.getUnits = function getUnits (spec_profile) {
     var pu = profile.getCurrentProfile(null, spec_profile)['units'] + ' ';
     if (pu.toLowerCase().includes('mmol')) return 'mmol';
-    return 'mgdl';
+    return 'mg/dl';
   };
 
   profile.getTimezone = function getTimezone (spec_profile) {


### PR DESCRIPTION
This is fix for #5146 - previously when Carb Correction was added without Carb (with only Fat/Protein or those both) it was visible differently. This PR fixes behavior of such treatment.

Also in tooltip for treatments BG was incorrectly calculated when set to mg/dl because of mismatch in https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/client/renderer.js#L635 - `mg/dl` being compared to `mgdl` returned false so was treated as `mmol` - this was also fixed.