### PR TITLE
Fix timeago alarms (again)

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -774,7 +774,8 @@ client.load = function load (serverSettings, callback) {
 
   function updateClock () {
     updateClockDisplay();
-    var interval = (60 - (new Date()).getSeconds()) * 1000 + 5;
+    // Update at least every 15 seconds
+    var interval = Math.min(15 * 1000, (60 - (new Date()).getSeconds()) * 1000 + 5);
     setTimeout(updateClock, interval);
 
     updateTimeAgo();

--- a/lib/plugins/timeago.js
+++ b/lib/plugins/timeago.js
@@ -3,11 +3,10 @@
 var levels = require('../levels');
 var times = require('../times');
 var lastChecked = new Date();
-var lastSuspendTime = new Date("1900-01-01");
+var lastRecoveryTimeFromSuspend = new Date("1900-01-01");
 
 function init(ctx) {
   var translate = ctx.language.translate;
-  var heartbeatMs = ctx.settings.heartbeat * 1000;
 
   var timeago = {
     name: 'timeago',
@@ -72,19 +71,16 @@ function init(ctx) {
 
     function isHibernationDetected() {
       if (sbx.runtimeEnvironment === 'client') {
-        if (delta > 15 * 1000) { // Looks like we've been hibernating
-          lastSuspendTime = now;
+        if (delta > 20 * 1000) { // Looks like we've been hibernating
+          lastRecoveryTimeFromSuspend = now;
         }
-
-        var timeSinceLastSuspended = now.getTime() - lastSuspendTime.getTime();
-
-        return timeSinceLastSuspended < (10 * 1000);
-      } else if (sbx.runtimeEnvironment === 'server') {
-        return delta > 2 * heartbeatMs;
-      } else {
-        console.error('Cannot detect hibernation, because runtimeEnvironment is not detected from sbx.runtimeEnvironment:', sbx.runtimeEnvironment);
-        return false;
+        var timeSinceLastRecovered = now.getTime() - lastRecoveryTimeFromSuspend.getTime();
+        return timeSinceLastRecovered < (10 * 1000);
       }
+
+      // Assume server never hibernates, or if it does, it's alarm-worthy
+      return false;
+
     }
 
     if (isHibernationDetected()) {

--- a/tests/timeago.test.js
+++ b/tests/timeago.test.js
@@ -43,33 +43,6 @@ describe('timeago', function() {
     done();
   });
 
-  it('should suspend alarms due to hibernation when 2 heartbeats are skipped on server', function() {
-    ctx.ddata.sgvs = [{ mills: Date.now() - times.mins(16).msecs, mgdl: 100, type: 'sgv' }];
-
-    var sbx = freshSBX()
-    var status = timeago.checkStatus(sbx);
-    // By default (no hibernation detected) a warning should be given
-    // we force no hibernation by checking status twice
-    status = timeago.checkStatus(sbx);
-    should.equal(status, 'warn');
-
-    // 10ms more than suspend-threshold to prevent flapping tests
-    var timeoutMs = 2 * ctx.settings.heartbeat * 1000 + 100;
-    return new Promise(function(resolve, reject) {
-      setTimeout(function() {
-        status = timeago.checkStatus(sbx);
-        // Because hibernation should now be detected, no warning should be given
-        should.equal(status, 'current');
-
-        // We immediately ask status again, so hibernation should not be detected anymore,
-        // and we should receive a warning again
-        status = timeago.checkStatus(sbx);
-        should.equal(status, 'warn');
-
-        resolve()
-      }, timeoutMs)
-    })
-  });
 
   it('should trigger a warning when data older than 15m', function(done) {
     ctx.notifications.initRequests();


### PR DESCRIPTION
The changes to the rendered had an unintended consequence of triggering the timeago detection less frequently, causing the code to think the client has been hibernating, thus suppressing the alarms. The update changes the clock to be updated more frequently (this updating the hibernation detection), fixing the issue