### PR TITLE
Add server teardown ability

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -1,11 +1,11 @@
 'use strict';
-
 var Stream = require('stream');
 
 function init (settings) {
   var beats = 0;
   var started = new Date( );
   var interval = settings.heartbeat * 1000;
+  let busInterval;
 
   var stream = new Stream;
 
@@ -24,9 +24,15 @@ function init (settings) {
     stream.emit('tick', ictus( ));
   }
 
+  stream.teardown = function ( ) {
+    console.log('Initiating server teardown');
+    clearInterval(busInterval);
+    stream.emit('teardown');
+  };
+
   stream.readable = true;
   stream.uptime = repeat;
-  setInterval(repeat, interval);
+  busInterval = setInterval(repeat, interval);
   return stream;
 }
 module.exports = init;

--- a/lib/plugins/bridge.js
+++ b/lib/plugins/bridge.js
@@ -5,9 +5,9 @@ var engine = require('share2nightscout-bridge');
 // Track the most recently seen record
 var mostRecentRecord;
 
-function init (env) {
+function init (env, bus) {
   if (env.extendedSettings.bridge && env.extendedSettings.bridge.userName && env.extendedSettings.bridge.password) {
-    return create(env);
+    return create(env, bus);
   } else {
     console.info('Dexcom bridge not enabled');
   }
@@ -56,26 +56,32 @@ function options (env) {
   };
 }
 
-function create (env) {
+function create (env, bus) {
 
   var bridge = { };
 
   var opts = options(env);
   var interval = opts.interval;
 
-  mostRecentRecord = new Date().getTime() - opts.fetch.minutes * 60000
+  mostRecentRecord = new Date().getTime() - opts.fetch.minutes * 60000;
 
   bridge.startEngine = function startEngine (entries) {
 
     opts.callback = bridged(entries);
 
-    setInterval(function () {
+    let timer = setInterval(function () {
       opts.fetch.minutes = parseInt((new Date() - mostRecentRecord) / 60000);
       opts.fetch.maxCount = parseInt((opts.fetch.minutes / 5) + 1);
-      opts.firstFetchCount = opts.fetch.maxCount
+      opts.firstFetchCount = opts.fetch.maxCount;
       console.log("Fetching Share Data: ", 'minutes', opts.fetch.minutes, 'maxCount', opts.fetch.maxCount);
       engine(opts);
     }, interval);
+
+    if (bus) {
+      bus.on('teardown', function serverTeardown () {
+        clearInterval(timer);
+      });
+    }
   };
 
   return bridge;

--- a/lib/plugins/mmconnect.js
+++ b/lib/plugins/mmconnect.js
@@ -4,16 +4,16 @@
 var _ = require('lodash'),
   connect = require('minimed-connect-to-nightscout');
 
-function init (env, entries, devicestatus) {
+function init (env, entries, devicestatus, bus) {
   if (env.extendedSettings.mmconnect && env.extendedSettings.mmconnect.userName && env.extendedSettings.mmconnect.password) {
-    return {run: makeRunner(env, entries, devicestatus)};
+    return {run: makeRunner(env, entries, devicestatus, bus)};
   } else {
     console.info('MiniMed Connect not enabled');
     return null;
   }
 }
 
-function makeRunner (env, entries, devicestatus) {
+function makeRunner (env, entries, devicestatus, bus) {
   var options = getOptions(env);
 
   var client = connect.carelink.Client(options);
@@ -22,9 +22,15 @@ function makeRunner (env, entries, devicestatus) {
   var handleData = makeHandler_(entries, devicestatus, options.sgvLimit, options.storeRawData);
 
   return function run () {
-    setInterval(function() {
+    let timer = setInterval(function() {
       client.fetch(handleData);
     }, options.interval);
+
+    if (bus) {
+      bus.on('teardown', function serverTeardown () {
+        clearInterval(timer);
+      });
+    }
   };
 }
 

--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -243,7 +243,7 @@ function boot (env, language) {
       return next();
     }
 
-    ctx.bridge = require('../plugins/bridge')(env);
+    ctx.bridge = require('../plugins/bridge')(env, ctx.bus);
     if (ctx.bridge) {
       ctx.bridge.startEngine(ctx.entries);
     }
@@ -255,7 +255,7 @@ function boot (env, language) {
       return next();
     }
 
-    ctx.mmconnect = require('../plugins/mmconnect').init(env, ctx.entries, ctx.devicestatus);
+    ctx.mmconnect = require('../plugins/mmconnect').init(env, ctx.entries, ctx.devicestatus, ctx.bus);
     if (ctx.mmconnect) {
       ctx.mmconnect.run();
     }

--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -73,6 +73,13 @@ function init (env, ctx, server) {
       'browser client etag': true,
       'browser client gzip': false
     });
+
+    ctx.bus.on('teardown', function serverTeardown () {
+      Object.keys(io.sockets.sockets).forEach(function(s) {
+        io.sockets.sockets[s].disconnect(true);
+      });
+      io.close();
+    });
   }
 
   function verifyAuthorization (message, callback) {

--- a/server.js
+++ b/server.js
@@ -54,6 +54,12 @@ require('./lib/server/bootevent')(env, language).boot(function booted (ctx) {
       return;
     }
 
+    ctx.bus.on('teardown', function serverTeardown () {
+      server.close();
+      clearTimeout(sendStartupAllClearTimer);
+      ctx.store.client.close();
+    });
+
     ///////////////////////////////////////////////////
     // setup socket io for data and message transmission
     ///////////////////////////////////////////////////
@@ -68,7 +74,7 @@ require('./lib/server/bootevent')(env, language).boot(function booted (ctx) {
     });
 
     //after startup if there are no alarms send all clear
-    setTimeout(function sendStartupAllClear () {
+    let sendStartupAllClearTimer = setTimeout(function sendStartupAllClear () {
       var alarm = ctx.notifications.findHighestAlarm();
       if (!alarm) {
         ctx.bus.emit('notification', {

--- a/tests/api3.basic.test.js
+++ b/tests/api3.basic.test.js
@@ -19,7 +19,7 @@ describe('Basic REST API3', function() {
 
 
   after(function after () {
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.create.test.js
+++ b/tests/api3.create.test.js
@@ -72,7 +72,7 @@ describe('API3 CREATE', function() {
 
 
   after(() => {
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.delete.test.js
+++ b/tests/api3.delete.test.js
@@ -28,7 +28,7 @@ describe('API3 UPDATE', function() {
 
 
   after(() => {
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.generic.workflow.test.js
+++ b/tests/api3.generic.workflow.test.js
@@ -46,7 +46,7 @@ describe('Generic REST API3', function() {
 
 
   after(() => {
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.patch.test.js
+++ b/tests/api3.patch.test.js
@@ -51,7 +51,7 @@ describe('API3 PATCH', function() {
 
 
   after(() => {
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.read.test.js
+++ b/tests/api3.read.test.js
@@ -38,7 +38,7 @@ describe('API3 READ', function() {
 
 
   after(() => {
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.search.test.js
+++ b/tests/api3.search.test.js
@@ -65,7 +65,7 @@ describe('API3 SEARCH', function() {
 
 
   after(() => {
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.security.test.js
+++ b/tests/api3.security.test.js
@@ -7,7 +7,7 @@ const request = require('supertest')
   , moment = require('moment')
   ;
 require('should');
-  
+
 describe('Security of REST API3', function() {
   const self = this
     , instance = require('./fixtures/api3/instance')
@@ -26,10 +26,10 @@ describe('Security of REST API3', function() {
     self.token = authResult.token;
   });
 
-  
+
   after(() => {
-    self.http.server.close();
-    self.https.server.close();
+    self.http.ctx.bus.teardown();
+    self.https.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.socket.test.js
+++ b/tests/api3.socket.test.js
@@ -49,7 +49,7 @@ describe('Socket.IO in REST API3', function() {
     if(self.instance && self.instance.clientSocket && self.instance.clientSocket.connected) {
       self.instance.clientSocket.disconnect();
     }
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 

--- a/tests/api3.update.test.js
+++ b/tests/api3.update.test.js
@@ -51,7 +51,7 @@ describe('API3 UPDATE', function() {
 
 
   after(() => {
-    self.instance.server.close();
+    self.instance.ctx.bus.teardown();
   });
 
 


### PR DESCRIPTION
Right now, when the Nightscout server is started, a number of timers remain hooked up and remain active during the tests. 
The purpose of this PR is to prepare a valid server shutdown by calling `ctx.bus.teardown`, which causes a `teardown` event to be sent into the bus. 
Any place in code that needs to clean up something when shutting down the server can now start listening to the `teardown` event from the bus.