### PR TITLE
Restore glucose distribution test

### DIFF
--- a/tests/reports.test.js
+++ b/tests/reports.test.js
@@ -268,7 +268,7 @@ describe('reports', function ( ) {
       result.indexOf('50 g').should.be.greaterThan(-1); // daytoday
       result.indexOf('TDD average:</b> 2.9U').should.be.greaterThan(-1); // daytoday
       result.indexOf('<td class="tdborder">0%</td><td class="tdborder">100%</td><td class="tdborder">0%</td><td class="tdborder">2</td>').should.be.greaterThan(-1); //dailystats
-      //TODO FIXME result.indexOf('td class="tdborder" style="background-color:#8f8"><strong>Normal: </strong></td><td class="tdborder">64.7%</td><td class="tdborder">6</td>').should.be.greaterThan(-1); // distribution
+      result.indexOf('<td class="tdborder" style="background-color:#8f8"><strong>In Range: </strong></td><td class="tdborder">47.6%</td><td class="tdborder">10</td>').should.be.greaterThan(-1); // distribution
       result.indexOf('<td>16 (100%)</td>').should.be.greaterThan(-1); // hourlystats
       result.indexOf('<div id="success-grid">').should.be.greaterThan(-1); //success
       result.indexOf('<b style="padding-left:4em">CAL</b>:  Scale: 1.10 Intercept: 31102 Slope: 776.91').should.be.greaterThan(-1); //calibrations


### PR DESCRIPTION
This test broke for two reasons:
- The text "Normal" was changed to "In Range" but this test was not updated
- The mock data was changed after this test was implemented, which resulted in different numerical values in the rendered HTML. Thus, we could not find the elements we were looking for.

I updated this test to reflect the new wording and also the new test values.

This test just verifies that the distribution module is successfully rendered, and IMO it shouldn't be this fragile (in particular I don't think we should couple it to computations done on the mock data). I'll follow up with another PR to make these tests more robust while maintaining their purpose.