### PR TITLE
Remove redundant checks on entry ID

### DIFF
--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -14,8 +14,7 @@ const expand = braces.expand;
 const ID_PATTERN = /^[a-f\d]{24}$/;
 
 function isId (value) {
-  //TODO: why did we need tht length check?
-  return value && ID_PATTERN.test(value) && value.length === 24;
+  return ID_PATTERN.test(value);
 }
 
 /**


### PR DESCRIPTION
Both the truthy `value` check and the string length check are already done in the regex test, and thus there is no need to explicitly include these checks.