### PR TITLE
Add sensor code and tx id fields to CGM Start treatment

### DIFF
--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -52,7 +52,7 @@ function init (client, $) {
     submitHooks = {};
 
     _.forEach(careportal.allEventTypes, function each (event) {
-      inputMatrix[event.val] = _.pick(event, ['bg', 'insulin', 'carbs', 'protein', 'fat', 'prebolus', 'duration', 'percent', 'absolute', 'profile', 'split', 'reasons', 'targets']);
+      inputMatrix[event.val] = _.pick(event, ['bg', 'insulin', 'carbs', 'protein', 'fat', 'prebolus', 'duration', 'percent', 'absolute', 'profile', 'split', 'sensor', 'reasons', 'targets']);
       submitHooks[event.val] = event.submitHook;
     });
   }
@@ -85,6 +85,7 @@ function init (client, $) {
     $('#carbsGivenLabel').css('display', displayType(inputMatrix[eventType]['carbs']));
     $('#proteinGivenLabel').css('display', displayType(inputMatrix[eventType]['protein']));
     $('#fatGivenLabel').css('display', displayType(inputMatrix[eventType]['fat']));
+    $('#sensorInfo').css('display', displayType(inputMatrix[eventType]['sensor']));
     $('#durationLabel').css('display', displayType(inputMatrix[eventType]['duration']));
     $('#percentLabel').css('display', displayType(inputMatrix[eventType]['percent'] && $('#absolute').val() === ''));
     $('#absoluteLabel').css('display', displayType(inputMatrix[eventType]['absolute'] && $('#percent').val() === ''));
@@ -103,6 +104,8 @@ function init (client, $) {
     resetIfHidden(inputMatrix[eventType]['carbs'], '#carbsGiven');
     resetIfHidden(inputMatrix[eventType]['protein'], '#proteinGiven');
     resetIfHidden(inputMatrix[eventType]['fat'], '#fatGiven');
+    resetIfHidden(inputMatrix[eventType]['sensor'], '#sensorCode');
+    resetIfHidden(inputMatrix[eventType]['sensor'], '#transmitterId');
     resetIfHidden(inputMatrix[eventType]['duration'], '#duration');
     resetIfHidden(inputMatrix[eventType]['absolute'], '#absolute');
     resetIfHidden(inputMatrix[eventType]['percent'], '#percent');
@@ -195,6 +198,8 @@ function init (client, $) {
     $('#carbsGiven').val('');
     $('#proteinGiven').val('');
     $('#fatGiven').val('');
+    $('#sensorCode').val('');
+    $('#transmitterId').val('');
     $('#insulinGiven').val('');
     $('#duration').val('');
     $('#percent').val('');
@@ -222,6 +227,8 @@ function init (client, $) {
       , carbs: $('#carbsGiven').val()
       , protein: $('#proteinGiven').val()
       , fat: $('#fatGiven').val()
+      , sensorCode: $('#sensorCode').val()
+      , transmitterId: $('#transmitterId').val()
       , insulin: $('#insulinGiven').val()
       , duration: times.msecs(parse_duration($('#duration').val())).mins < 1 ? $('#duration').val() : times.msecs(parse_duration($('#duration').val())).mins
       , percent: $('#percent').val()
@@ -369,6 +376,8 @@ function init (client, $) {
     pushIf(data.carbs, translate('Carbs Given') + ': ' + data.carbs);
     pushIf(data.protein, translate('Protein Given') + ': ' + data.protein);
     pushIf(data.fat, translate('Fat Given') + ': ' + data.fat);
+    pushIf(data.sensorCode, translate('Sensor Code') + ': ' + data.sensorCode);
+    pushIf(data.transmitterId, translate('Transmitter ID') + ': ' + data.transmitterId);
     pushIf(data.insulin, translate('Insulin Given') + ': ' + data.insulin);
     pushIf(data.eventType === 'Combo Bolus', translate('Combo Bolus') + ': ' + data.splitNow + '% : ' + data.splitExt + '%');
     pushIf(data.duration, translate('Duration') + ': ' + data.duration + ' ' + translate('mins'));

--- a/lib/plugins/careportal.js
+++ b/lib/plugins/careportal.js
@@ -16,87 +16,87 @@ function init() {
     return [
       { val: '<none>'
         , name: '<none>'
-        , bg: true, insulin: true, carbs: true, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: true, carbs: true, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'BG Check'
         , name: 'BG Check'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Snack Bolus'
         , name: 'Snack Bolus'
-        , bg: true, insulin: true, carbs: true, protein: true, fat: true, prebolus: true, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: true, carbs: true, protein: true, fat: true, prebolus: true, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Meal Bolus'
         , name: 'Meal Bolus'
-        , bg: true, insulin: true, carbs: true, protein: true, fat: true, prebolus: true, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: true, carbs: true, protein: true, fat: true, prebolus: true, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Correction Bolus'
         , name: 'Correction Bolus'
-        , bg: true, insulin: true, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: true, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Carb Correction'
         , name: 'Carb Correction'
-        , bg: true, insulin: false, carbs: true, protein: true, fat: true, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: true, protein: true, fat: true, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Combo Bolus'
         , name: 'Combo Bolus'
-        , bg: true, insulin: true, carbs: true, protein: true, fat: true, prebolus: true, duration: true, percent: false, absolute: false, profile: false, split: true
+        , bg: true, insulin: true, carbs: true, protein: true, fat: true, prebolus: true, duration: true, percent: false, absolute: false, profile: false, split: true, sensor: false
       }
       , { val: 'Announcement'
         , name: 'Announcement'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Note'
         , name: 'Note'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Question'
         , name: 'Question'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Exercise'
         , name: 'Exercise'
-        , bg: false, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: false, absolute: false, profile: false, split: false
+        , bg: false, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Site Change'
         , name: 'Pump Site Change'
-        , bg: true, insulin: true, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: true, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Sensor Start'
         , name: 'CGM Sensor Start'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: true
       }
       , { val: 'Sensor Change'
         , name: 'CGM Sensor Insert'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Sensor Stop'
         , name: 'CGM Sensor Stop'
-        , bg: true,  insulin: false, carbs: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true,  insulin: false, carbs: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Pump Battery Change'
         , name: 'Pump Battery Change'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
             }
       , { val: 'Insulin Change'
         , name: 'Insulin Cartridge Change'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Temp Basal Start'
         , name: 'Temp Basal Start'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: true, absolute: true, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: true, absolute: true, profile: false, split: false, sensor: false
       }
       , { val: 'Temp Basal End'
         , name: 'Temp Basal End'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
       , { val: 'Profile Switch'
         , name: 'Profile Switch'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: false, absolute: false, profile: true, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: true, percent: false, absolute: false, profile: true, split: false, sensor: false
       }
       , { val: 'D.A.D. Alert'
         , name: 'D.A.D. Alert'
-        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false
+        , bg: true, insulin: false, carbs: false, protein: false, fat: false, prebolus: false, duration: false, percent: false, absolute: false, profile: false, split: false, sensor: false
       }
     ];
 

--- a/views/index.html
+++ b/views/index.html
@@ -352,6 +352,17 @@
                             <input type="number" step="any" min="0" id="fatGiven" placeholder="Amount in grams" class="titletranslate" pattern="\d*" />
                         </label>
                     </fieldset>
+                    <fieldset id="sensorInfo">
+                      <legend class="translate">Sensor</legend>
+                      <label id="sensorCodeLabel" for="sensorCode" class="left-column short-label">
+                        <span class="translate">Sensor Code</span>
+                        <input type="text" id="sensorCode" />
+                      </label>
+                      <label id="txIdLabel" for="transmitterId" class="left-column short-label">
+                        <span class="translate">Tx ID</span>
+                        <input type="text" id="transmitterId" />
+                      </label>
+                    </fieldset>
                     <label id="insulinGivenLabel" for="insulinGiven" class="left-column short-label">
                         <span class="translate">Insulin Given</span>
                         <input type="number" step="any" min="0" id="insulinGiven" placeholder="Amount in units" class="titletranslate" pattern="[0-9.,]*" />


### PR DESCRIPTION
Added input fields to the treatment drawer to specify Sensor Code and Transmitter ID.  Updated Care Portal to show these fields for the CGM Start Sensor treatment and capture input values in specific properties on the treatment event.  The intent is to allow applications like Logger to deterministically locate and make use of the values entered when processing sensor starts.