### PR TITLE
Added indexes to 'entries' and 'treatments' along with other updates

### DIFF
--- a/lib/server/entries.js
+++ b/lib/server/entries.js
@@ -140,7 +140,16 @@ function storage(env, ctx) {
   api.query_for = query_for;
   api.getEntry = getEntry;
   api.aggregate = require('./aggregate')({ }, api);
-  api.indexedFields = [ 'date', 'type', 'sgv', 'mbg', 'sysTime', 'dateString' ];
+  api.indexedFields = [
+    'date'
+    , 'type'
+    , 'sgv'
+    , 'mbg'
+    , 'sysTime'
+    , 'dateString'
+    , { "type" : 1, "date" : -1, "dateString" : 1 }
+    , { "key600" : 1, "type" : 1, "date" : -1, "dateString" : 1 }
+ ];
   return api;
 }
 

--- a/lib/server/entries.js
+++ b/lib/server/entries.js
@@ -148,7 +148,6 @@ function storage(env, ctx) {
     , 'sysTime'
     , 'dateString'
     , { 'type' : 1, 'date' : -1, 'dateString' : 1 }
-    , { 'key600' : 1, 'type' : 1, 'date' : -1, 'dateString' : 1 }
  ];
   return api;
 }

--- a/lib/server/entries.js
+++ b/lib/server/entries.js
@@ -147,8 +147,8 @@ function storage(env, ctx) {
     , 'mbg'
     , 'sysTime'
     , 'dateString'
-    , { "type" : 1, "date" : -1, "dateString" : 1 }
-    , { "key600" : 1, "type" : 1, "date" : -1, "dateString" : 1 }
+    , { 'type' : 1, 'date' : -1, 'dateString' : 1 }
+    , { 'key600' : 1, 'type' : 1, 'date' : -1, 'dateString' : 1 }
  ];
   return api;
 }
@@ -169,4 +169,3 @@ storage.queryOpts = {
 // expose module
 storage.storage = storage;
 module.exports = storage;
-

--- a/lib/server/treatments.js
+++ b/lib/server/treatments.js
@@ -133,7 +133,9 @@ function storage (env, ctx) {
     , 'NSCLIENT_ID'
     , 'percent'
     , 'absolute'
-    , 'duration'
+    , 'duration
+    , { "key600" : 1, "created_at" : 1}
+    , { "eventType" : 1, "duration" : 1, "created_at" : 1 }
   ];
 
   api.remove = remove;

--- a/lib/server/treatments.js
+++ b/lib/server/treatments.js
@@ -133,9 +133,9 @@ function storage (env, ctx) {
     , 'NSCLIENT_ID'
     , 'percent'
     , 'absolute'
-    , 'duration
-    , { "key600" : 1, "created_at" : 1}
-    , { "eventType" : 1, "duration" : 1, "created_at" : 1 }
+    , 'duration'
+    , { 'key600' : 1, 'created_at' : 1 }
+    , { 'eventType' : 1, 'duration' : 1, 'created_at' : 1 }
   ];
 
   api.remove = remove;

--- a/lib/server/treatments.js
+++ b/lib/server/treatments.js
@@ -134,7 +134,6 @@ function storage (env, ctx) {
     , 'percent'
     , 'absolute'
     , 'duration'
-    , { 'key600' : 1, 'created_at' : 1 }
     , { 'eventType' : 1, 'duration' : 1, 'created_at' : 1 }
   ];
 

--- a/lib/storage/mongo-storage.js
+++ b/lib/storage/mongo-storage.js
@@ -37,11 +37,11 @@ function init (env, cb, forceNewConnection) {
                 console.log('Error connecting to MongoDB: %j - retrying in ' + timeout/1000 + ' sec', err);
                 setTimeout(connect_with_retry, timeout, i+1);
             } else if (err.message) {
-                throw new Error('MongoDB connection string '+env.storageURI+' seems invalid: '+err.message) ; 
+                throw new Error('MongoDB connection string '+env.storageURI+' seems invalid: '+err.message) ;
             }
           } else {
             console.log('Successfully established a connected to MongoDB');
-            
+
             var dbName = env.storageURI.split('/').pop().split('?');
             dbName=dbName[0]; // drop Connection Options
             mongo.db = client.db(dbName);

--- a/lib/storage/mongo-storage.js
+++ b/lib/storage/mongo-storage.js
@@ -66,7 +66,7 @@ function init (env, cb, forceNewConnection) {
   mongo.ensureIndexes = function ensureIndexes (collection, fields) {
     fields.forEach(function (field) {
       console.info('ensuring index for: ' + field);
-      collection.ensureIndex(field, function (err) {
+      collection.createIndex(field, { 'background': true }, function (err) {
         if (err) {
           console.error('unable to ensureIndex for: ' + field + ' - ' + err);
         }

--- a/testing/populate.js
+++ b/testing/populate.js
@@ -3,19 +3,22 @@
 var mongodb = require('mongodb');
 var env = require('./../env')();
 
-var util = require('./helpers/util');
+var util = require('./util');
 
 main();
 
 function main() {
   var MongoClient = mongodb.MongoClient;
-  MongoClient.connect(env.storageURI, function connected(err, db) {
+  MongoClient.connect(env.storageURI, { "useUnifiedTopology" : true, "useNewUrlParser" : true }, function connected(err, client) {
 
     console.log('Connecting to mongo...');
     if (err) {
       console.log('Error occurred: ', err);
       throw err;
     }
+
+    var db = client.db();
+
     populate_collection(db);
   });
 }


### PR DESCRIPTION
Hi, 

I'm a database administrator from mLab. I wanted to share some of the index recommendations we've been making for Nightscout users. These recommendations use the equality->sort->range  methodology described here:
https://docs.mlab.com/indexing/#sorting-efficiently

Specifically: 

* treatments - { "key600" : 1, "created_at" : 1}
* treatments - { "eventType" : 1, "duration" : 1, "created_at" : 1 }
* entries - { "type" : 1, "date" : -1, "dateString" : 1 }
* entries - { "key600" : 1, "type" : 1, "date" : -1, "dateString" : 1 }

I also made a few minor updates elsewhere, such as specifying `createIndex` instead of `ensureIndex` and adding some fixes to `testing/populate.js`. 

