### PR TITLE
client - mobile - Axis label font is scaled on small screens

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -516,6 +516,11 @@ a, a:visited, a:link {
 }
 
 @media (max-width: 750px) {
+  .x.axis {
+    font-size: 2.5vmin !important;
+  }
+
+
   .bgStatus {
     width: 50%;
     padding: 0 0 20px 0;
@@ -657,6 +662,10 @@ a, a:visited, a:link {
   #chartContainer {
     font-size: 14px;
   }
+  .y.axis {
+    font-size: 2.5vmin !important;
+  }
+
 }
 
 @media (max-height: 600px) {


### PR DESCRIPTION
On phones or other small screens, the axis labels (especially x axis)
were previously an unreadable jumble of too-close letters

Developer note: I do not like using `important` but it seemed impossible otherwise. I do not think that in this case I'm violating any important principle by doing so.


![IMG_6940](https://user-images.githubusercontent.com/17858976/74208729-c1c27f80-4c52-11ea-89e5-31b4030c5e93.jpg)