### PR TITLE
client - mobile - Number of options for focus hours is reduced

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -651,6 +651,10 @@ a, a:visited, a:link {
   .focus-range li {
     display: block;
   }
+  .focus-hours-extra {
+    display:none !important;
+  }
+
 }
 
 @media (max-height: 700px) {
@@ -770,6 +774,10 @@ a, a:visited, a:link {
   .focus-range li {
     display: block;
   }
+  .focus-hours-extra {
+    display:none !important;
+  }
+
 
   .statusPills {
     display: inline;

--- a/views/index.html
+++ b/views/index.html
@@ -146,9 +146,9 @@
 
       <ul class="focus-range">
         <li data-hours="1" class="translate">Hours:</li>
-        <li data-hours="2">2</li>
-        <li data-hours="3">3</li>
-        <li data-hours="4">4</li>
+        <li data-hours="2" class="focus-hours-extra">2</li>
+        <li data-hours="3" class="focus-hours-extra">3</li>
+        <li data-hours="4" class="focus-hours-extra">4</li>
         <li data-hours="6">6</li>
         <li data-hours="12">12</li>
         <li data-hours="24">24</li>


### PR DESCRIPTION
On small screens, the number of options for focus hours (1, 2, 3, 6, 12, 24)
is reduced. On mobile, focus options are displayed in a vertical manner and
were stealing valuable space from the BG/treatment graph itself.

Note that although "1 hour" is an option, it is effectively "hidden" from most people because you have to know to click on the word "Hours". (In future, I'd like to further improve this by making it a `select` element which is rendered the same was as today on big screens, but renders as a normal select on mobile which would be a picker wheel. But that's for the future.)

I don't love using `!important` but I don't think there's any big rule of cascading that I'm breaking by using it in this situation.