### PR TITLE
[DEV][FIX] Fix dbsize plugin to make it hideable again

### DIFF
--- a/app.json
+++ b/app.json
@@ -99,7 +99,7 @@
     },
     "ENABLE": {
       "description": "Plugins to enable for your site. Must be a space-delimited, lower-case list. Include the word 'bridge' here if you are receiving data from the Dexcom Share service. Include 'mmconnect' if you are bridging from the MiniMed CareLink service.",
-      "value": "careportal basal",
+      "value": "careportal basal dbsize",
       "required": false
     },
     "MMCONNECT_USER_NAME": {
@@ -129,7 +129,7 @@
     },
     "SHOW_PLUGINS": {
       "description": "Default setting for whether or not these plugins are checked (active) by default, not merely enabled. Include plugins here as in the ENABLE line; space-separated and lower-case.",
-      "value": "careportal",
+      "value": "careportal dbsize",
       "required": false
     },
     "SHOW_RAWBG": {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -173,7 +173,7 @@
     },
     "enable": {
       "type": "string",
-      "defaultValue": "basal bwp cage careportal iob cob rawbg sage iage treatmentnotify boluscalc profile food"
+      "defaultValue": "basal bwp cage careportal iob cob rawbg sage iage treatmentnotify boluscalc profile food dbsize"
     },
     "night_mode": {
       "type": "string",
@@ -185,7 +185,7 @@
     },
     "show_plugins": {
       "type": "string",
-      "defaultValue": "careportal"
+      "defaultValue": "careportal dbsize"
     },
     "show_rawbg": {
       "type": "string",

--- a/lib/plugins/dbsize.js
+++ b/lib/plugins/dbsize.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var levels = require('../levels');
 
 function init (ctx) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -31,7 +31,7 @@ function init () {
     , alarmPumpBatteryLow: false
     , language: 'en'
     , scaleY: 'log'
-    , showPlugins: ''
+    , showPlugins: 'dbsize'
     , showForecast: 'ar2'
     , focusHours: 3
     , heartbeat: 60
@@ -260,7 +260,7 @@ function init () {
   function adjustShownPlugins () {
     var showPluginsUnset = settings.showPlugins && 0 === settings.showPlugins.length;
 
-    settings.showPlugins += ' delta direction upbat dbsize';
+    settings.showPlugins += ' delta direction upbat';
     if (settings.showRawbg === 'always' || settings.showRawbg === 'noise') {
       settings.showPlugins += ' rawbg';
     }


### PR DESCRIPTION
Fix bug that forced dbsize plugin to be enabled and always checked on plugin list (= forced to be enabled).
After fix it is enabled by default, but user can uncheck it on plugin list to hide it.