### PR TITLE
Removed duplicate if-statement

### DIFF
--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -24,11 +24,6 @@ function init (env, ctx) {
       return;
     }
 
-    if (env.extendedSettings.loop.developerTeamId === undefined || env.extendedSettings.loop.developerTeamId.length != 10) {
-      completion("Loop notification failed: LOOP_DEVELOPER_TEAM_ID not set.");
-      return;
-    }
-
     if (ctx.ddata.profiles === undefined || ctx.ddata.profiles.length < 1 || ctx.ddata.profiles[0].loopSettings === undefined) {
       completion("Loop notification failed: Could not find loopSettings in profile.");
       return;


### PR DESCRIPTION
Removed the additional if statement checking for the loop specific developer team id. This since the exact same if-statement existed just above it.

Closes: #5530 

Signed-off-by:
Simon Persson, simon@akep.se