### PR TITLE
Fix Issue #5486 - Device Status Days Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ For remote overrides, the following extended settings must be configured:
   Plugins only have access to their own extended settings, all the extended settings of client plugins will be sent to the browser.
 
   * `DEVICESTATUS_ADVANCED` (`true`) - Defaults to true. Users who only have a single device uploading data to Nightscout can set this to false to reduce the data use of the site.
+  * `DEVICESTATUS_DAYS` (`1`) - Defaults to 1, can optionally be set to 2. Users can use this to show 48 hours of device status data for in retro mode, rather than the default 24 hours.
 
 #### Pushover
   In addition to the normal web based alarms, there is also support for [Pushover](https://pushover.net/) based alarms and notifications.

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ For remote overrides, the following extended settings must be configured:
   Plugins only have access to their own extended settings, all the extended settings of client plugins will be sent to the browser.
 
   * `DEVICESTATUS_ADVANCED` (`true`) - Defaults to true. Users who only have a single device uploading data to Nightscout can set this to false to reduce the data use of the site.
-  * `DEVICESTATUS_DAYS` (`1`) - Defaults to 1, can optionally be set to 2. Users can use this to show 48 hours of device status data for in retro mode, rather than the default 24 hours.
+  * `DEVICESTATUS_DAYS` (`1`) - Defaults to 1, can optionally be set to 2. Users can use this to show 48 hours of device status data for in retro mode, rather than the default 24 hours. Setting this value to 2 will roughly double the bandwidth usage of nightscout, so users with a data cap may not want to update this setting.
 
 #### Pushover
   In addition to the normal web based alarms, there is also support for [Pushover](https://pushover.net/) based alarms and notifications.

--- a/env.js
+++ b/env.js
@@ -170,6 +170,8 @@ function findExtendedSettings (envs) {
 
   extended.devicestatus = {};
   extended.devicestatus.advanced = true;
+  extended.devicestatus.days = 1;
+  if(process.env['DEVICESTATUS_DAYS'] && process.env['DEVICESTATUS_DAYS'] == '2') extended.devicestatus.days = 1;
 
   function normalizeEnv (key) {
     return key.toUpperCase().replace('CUSTOMCONNSTR_', '');

--- a/lib/data/dataloader.js
+++ b/lib/data/dataloader.js
@@ -361,8 +361,10 @@ function loadFood(ddata, ctx, callback) {
 }
 
 function loadDeviceStatus(ddata, env, ctx, callback) {
+    var retroDays = 1;
+    if(env.extendedSettings.devicestatus && env.extendedSettings.devicestatus.days) retroDays = env.extendedSettings.devicestatus.days;
     var dateRange = {
-        $gte: new Date(ddata.lastUpdated - ONE_DAY).toISOString()
+        $gte: new Date( ddata.lastUpdated - (ONE_DAY * retroDays) ).toISOString()
     };
     if (ddata.page && ddata.page.frame) {
         dateRange['$lte'] = new Date(ddata.lastUpdated).toISOString();

--- a/lib/data/dataloader.js
+++ b/lib/data/dataloader.js
@@ -361,10 +361,10 @@ function loadFood(ddata, ctx, callback) {
 }
 
 function loadDeviceStatus(ddata, env, ctx, callback) {
-    var retroDays = 1;
-    if(env.extendedSettings.devicestatus && env.extendedSettings.devicestatus.days) retroDays = env.extendedSettings.devicestatus.days;
+    var retroDays = ONE_DAY;
+    if(env.extendedSettings.devicestatus && env.extendedSettings.devicestatus.days && env.extendedSettings.devicestatus.days == 2) retroDays = TWO_DAYS;
     var dateRange = {
-        $gte: new Date( ddata.lastUpdated - (ONE_DAY * retroDays) ).toISOString()
+        $gte: new Date( ddata.lastUpdated - (retroDays) ).toISOString()
     };
     if (ddata.page && ddata.page.frame) {
         dateRange['$lte'] = new Date(ddata.lastUpdated).toISOString();


### PR DESCRIPTION
I'm attempting to fix #5486 , by allowing the number of days in Retro mode to be either a default of 1 or 2 days.  The value is set in `env.js`, used in `lib/data/dataloader.js`, and documented in `README.md`. I don't have a site with live data so I don't have a way to test this myself. I had started to run js-beautify on the source files, but there were a lot more changes than just the lines I was working with.