### PR TITLE
Quick hack for Auto-Bolus insulin labels jdc

### DIFF
--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -569,7 +569,7 @@ function init (client, d3) {
       var unit_of_measurement = ' U'; // One international unit of insulin (1 IU) is shown as '1 U'
       var enteredBy = '' + treatment.enteredBy;
 
-      if ((treatment.insulin < 1 && !treatment.carbs && enteredBy.indexOf('openaps') > -1) || treatment.isSMB) { // don't show the unit of measurement for insulin boluses < 1 without carbs (e.g. oref0 SMB's). Otherwise lot's of small insulin only dosages are often unreadable
+      if ((treatment.insulin < 0.5 && !treatment.carbs ) || treatment.isSMB) { // don't show the unit of measurement for insulin boluses < 1 without carbs (e.g. oref0 SMB's). Otherwise lot's of small insulin only dosages are often unreadable
         unit_of_measurement = '';
         // remove leading zeros to avoid overlap with adjacent boluses
         dosage_units = (dosage_units + "").replace(/^0/, "");


### PR DESCRIPTION
Remove the "U" from label for boluses under 0.5 j