### PR TITLE
do not redirect to profile editor by default

### DIFF
--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -1034,6 +1034,9 @@ function init (client, d3) {
 
   renderer.addBasals = function addBasals (client) {
 
+    if (!client.settings.isEnabled('basal')) {
+      return;
+    }
     var mode = client.settings.extendedSettings.basal.render;
     var profile = client.sbx.data.profile;
     var linedata = [];


### PR DESCRIPTION
In a default configuration, there is no treatment data.  The code to redirect
the UI to the profile editor is buried deep within the chart rendering code for
basals.  This plugin is only supposed to go into action when enabled via
ENABLE=basal.  This commit fixes first-use experience for the default
configuration intended to draw real-time CGM traces and no basal information is
expected.  Since no basal information is expected unless plugin is enabled via
ENABLE=basal, this allows skipping instead of redirecting to the profile editor.