### PR TITLE
Fix Issue #5763 - Change $.ajax to /api/v1/profile

### DIFF
--- a/static/profile/js/profileeditor.js
+++ b/static/profile/js/profileeditor.js
@@ -681,12 +681,13 @@
     // This is a crude way of preventing the user from changing the inputs whilst waiting.
     // If the user was able to make changes, they'd be lost when the done callback redraws anyway.
     $('#pe_form').hide();
-    
+    var headers = client.headers();
+    headers['Content-Type'] = 'application/json';
     $.ajax({
       method: 'PUT'
       , url: '/api/v1/profile/'
-      , data: adjustedRecord
-      , headers: client.headers()
+      , data: JSON.stringify(adjustedRecord)
+      , headers: headers 
     }).done(function postSuccess (data, status) {
       console.info('profile saved', data);
       $('#pe_form').show(); // allow edits again


### PR DESCRIPTION
This is meant to fix Issue #5673.  I suspect that this profile save issue is related to the parameterLimit in Express for requests with type x-www-form-urlencoded (1000 is default).  This change just changes the content-type header and sends the profile data as JSON. In this case the only request limit would be sending 100kb of data.