### PR TITLE
MINOR: Change DISPLAY_UNITS to use readENV's default value and added…

### DIFF
--- a/env.js
+++ b/env.js
@@ -15,15 +15,8 @@ var env = {
 };
 
 // Module to constrain all config and environment parsing to one spot.
-// See the
+// See README.md for info about all the supported ENV VARs
 function config ( ) {
-  /*
-   * See README.md for info about all the supported ENV VARs
-   */
-  env.DISPLAY_UNITS = readENV('DISPLAY_UNITS', 'mg/dl');
-
-  console.log('Units set to', env.DISPLAY_UNITS );
-
   env.PORT = readENV('PORT', 1337);
   env.HOSTNAME = readENV('HOSTNAME', null);
   env.IMPORT_CONFIG = readENV('IMPORT_CONFIG', null);
@@ -82,12 +75,6 @@ function setAPISecret() {
       var shasum = crypto.createHash('sha1');
       shasum.update(readENV('API_SECRET'));
       env.api_secret = shasum.digest('hex');
-
-      if (!readENV('TREATMENTS_AUTH', true)) {
-
-      }
-
-
     }
   }
 }
@@ -125,9 +112,13 @@ function updateSettings() {
     UNITS: 'DISPLAY_UNITS'
   };
 
+  var envDefaultOverrides = {
+    DISPLAY_UNITS: 'mg/dl'
+  };
+
   env.settings.eachSettingAsEnv(function settingFromEnv (name) {
     var envName = envNameOverrides[name] || name;
-    return readENV(envName);
+    return readENV(envName, envDefaultOverrides[envName]);
   });
 
   //should always find extended settings last
@@ -146,11 +137,11 @@ function readENV(varName, defaultValue) {
     || process.env[varName]
     || process.env[varName.toLowerCase()];
 
-  if (varName == 'DISPLAY_UNITS' && value) {
-    if (value.toLowerCase().includes('mmol')) {
+  if (varName == 'DISPLAY_UNITS') {
+    if (value && value.toLowerCase().includes('mmol')) {
       value = 'mmol';
     } else {
-      value = 'mg/dl';
+      value = defaultValue;
     }
   }
 

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -2,7 +2,7 @@
 
 require('should');
 
-describe('env', function ( ) {
+describe('env', function () {
   it( 'show the right plugins', function () {
     process.env.SHOW_PLUGINS = 'iob';
     process.env.ENABLE = 'iob cob';
@@ -68,4 +68,88 @@ describe('env', function ( ) {
     env.insecureUseHttp.should.be.false(); // not defined should be false
     env.secureHstsHeader.should.be.true();
   });
+
+  describe( 'DISPLAY_UNITS', function () {
+    const MMOL = 'mmol';
+    const MGDL = 'mg/dl';
+    describe ( 'mmol', function () {
+      it( 'mmol => mmol', function () {
+        process.env.DISPLAY_UNITS = MMOL;
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MMOL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+
+      it( 'mmol/l => mmol', function () {
+        process.env.DISPLAY_UNITS = 'mmol/l';
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MMOL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+
+      it( 'mmol/L => mmol', function () {
+        process.env.DISPLAY_UNITS = 'mmol/L';
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MMOL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+
+      it( 'MMOL => mmol', function () {
+        process.env.DISPLAY_UNITS = 'MMOL';
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MMOL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+    } );
+
+    describe ( 'mg/dl', function () {
+      it( 'mg/dl => mg/dl', function () {
+        process.env.DISPLAY_UNITS = MGDL;
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MGDL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+
+      it( 'mg/dL => mg/dl', function () {
+        process.env.DISPLAY_UNITS = 'mg/dL';
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MGDL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+
+      it( 'MG/DL => mg/dl', function () {
+        process.env.DISPLAY_UNITS = 'MG/DL';
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MGDL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+
+      it( 'mgdl => mg/dl', function () {
+        process.env.DISPLAY_UNITS = 'mgdl';
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MGDL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+    } );
+
+    describe ( 'default: mg/dl', function () {
+      it( '<random> => mg/dl', function () {
+        var random;
+        while (!random || random.toLowerCase() === MGDL)
+          random = [...Array(~~(Math.random()*20)+1)].map(i=>(~~(Math.random()*36)).toString(36)).join('');
+
+        process.env.DISPLAY_UNITS = random;
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MGDL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+
+      it( '<null> => mg/dl', function () {
+        delete process.env.DISPLAY_UNITS;
+        var env = require( '../env' )();
+        env.settings.units.should.equal( MGDL );
+        delete process.env.DISPLAY_UNITS;
+      } );
+    } );
+  } );
 })


### PR DESCRIPTION
… several tests for DISPLAY_UNITS

readENV() was hard coding the default value of DISPLAY_UNITS, and
ignoring the default value for no particular reason. Fixed that. Also, I
added a full test suite for DISPLAY_UNITS environment settings to make
sure that it works as intended. Finally, I've added the console log for
the DISPLAY_UNITS since there's no particular reason why we log that setting
and not others.