### PR TITLE
Support for Tomato app and OpenAPS

### DIFF
--- a/lib/server/entries.js
+++ b/lib/server/entries.js
@@ -88,6 +88,10 @@ function storage(env, ctx) {
         totalCreated = 0;
 
     docs.forEach(function(doc) {
+      // Normalize dates to be in UTC, store offset in utcOffset
+      if(doc.device == "Tomato" && !doc.dateString) {
+        doc.dateString = doc.sysTime
+      }
 
       // Normalize dates to be in UTC, store offset in utcOffset
 

--- a/lib/server/entries.js
+++ b/lib/server/entries.js
@@ -88,9 +88,13 @@ function storage(env, ctx) {
         totalCreated = 0;
 
     docs.forEach(function(doc) {
-      // Normalize dates to be in UTC, store offset in utcOffset
+      // Custom logic for Tomato app.
       if(doc.device == "Tomato" && !doc.dateString) {
+        // Missing fields: dateString, type
         doc.dateString = doc.sysTime
+        if(doc.sgv) {
+          doc.type = 'sgv'
+        }
       }
 
       // Normalize dates to be in UTC, store offset in utcOffset


### PR DESCRIPTION
The miaomiao is an add-on for the FreeStyle Libre CGM, which streams readings from the Libre via Bluetooth to a phone. There is an official app for the Miaomiao called Tomato, which can upload data to a NightScout instance. However, the app seems to miss some fields in the upload of data, which blocks usage with OpenAPS. This is unfortunate, as the Tomato app has much better accuracy (particularly during swings) than Xdrip and Spike, as well as being easily installable without Xcode. 

The two missing fields on the uploaded glucose records are `type` and `dateString`. Without these fields, OpenAPS 0.6.0 complains "missing glucose data". This PR includes a simple workaround which fixes that. 

I hope this is useful to others. Understandably it's a problem with Tomato, not NightScout. This is just a pragmatic solution to a problem I had a couple months back (been using it ever since), hoping to share for community benefit. Thank you for all your work!

