### PR TITLE
prepare hotfix for MMConnect/EU - 2020-06-28

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6963,9 +6963,8 @@
       }
     },
     "minimed-connect-to-nightscout": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/minimed-connect-to-nightscout/-/minimed-connect-to-nightscout-1.3.2.tgz",
-      "integrity": "sha512-1fF1ekFafvzNB9VzoP5T74KVJ32UDi9s4IE8ezNGOJ1XUAAq3qgWYGC4tZgug51sbMvr7c77XQw0bIPl2RpU9Q==",
+      "version": "github:nightscout/minimed-connect-to-nightscout#69837649ba554161f9cb734463bc6600c5ea7ae6",
+      "from": "github:nightscout/minimed-connect-to-nightscout#hotfix-2020-06-28-EU",
       "requires": {
         "common": "^0.2.5",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lodash": "^4.17.15",
     "memory-cache": "^0.2.0",
     "mime": "^2.4.4",
-    "minimed-connect-to-nightscout": "nightscout/minimed-connect-to-nightscout#hotfix-2020-06-28-EU",
+    "minimed-connect-to-nightscout": "nightscout/minimed-connect-to-nightscout#hotfix-2020-06-28-EU-01",
     "moment": "^2.24.0",
     "moment-locales-webpack-plugin": "^1.1.0",
     "moment-timezone": "^0.5.26",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lodash": "^4.17.15",
     "memory-cache": "^0.2.0",
     "mime": "^2.4.4",
-    "minimed-connect-to-nightscout": "^1.3.2",
+    "minimed-connect-to-nightscout": "nightscout/minimed-connect-to-nightscout#hotfix-2020-06-28-EU",
     "moment": "^2.24.0",
     "moment-locales-webpack-plugin": "^1.1.0",
     "moment-timezone": "^0.5.26",


### PR DESCRIPTION
Prepare to handle issue #5719.  This patch adjusts dependencies to
target a community edition fork of minimed-connect-to-nightscout.  The
new dependency targets information provided to begin addressing
changes to Medtronic Carelink services starting late June 2020.