### PR TITLE
effected temp basal amounts

### DIFF
--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -1168,7 +1168,7 @@ function init (client, d3) {
           .attr('dy', '.35em')
           .attr('x', chart().xScaleBasals((Math.max(t.mills, from) + Math.min(t.mills + times.mins(t.duration).msecs, to)) / 2))
           .attr('y', 10)
-          .text((t.percent ? (t.percent > 0 ? '+' : '') + t.percent + '%' : '') + (isNaN(t.absolute) ? '' : Number(t.absolute).toFixed(2) + 'U') + (t.relative ? 'C: +' + t.relative + 'U' : ''));
+          .text((t.percent ? (t.percent > 0 ? '+' : '') + t.percent + '%' : '') + (isNaN(t.absolute) ? '' : Number(t.amount || t.absolute).toFixed(2) + 'U') + (t.relative ? 'C: +' + t.relative + 'U' : ''));
         // better hide if not fit
         if (text.node().getBBox().width > chart().xScaleBasals(t.mills + times.mins(t.duration).msecs) - chart().xScaleBasals(t.mills)) {
           text.attr('display', 'none');

--- a/lib/plugins/treatmentnotify.js
+++ b/lib/plugins/treatmentnotify.js
@@ -145,7 +145,7 @@ function init() {
       (lastTreatment.insulin ? '\n' + translate('Insulin') + ': ' + sbx.roundInsulinForDisplayFormat(lastTreatment.insulin) + 'U' : '')+
       (lastTreatment.duration ? '\n' + translate('Duration') + ': ' + lastTreatment.duration + ' min' : '')+
       (lastTreatment.percent ? '\n' + translate('Percent') + ': ' + (lastTreatment.percent > 0 ? '+' : '') + lastTreatment.percent + '%' : '')+
-      (!isNaN(lastTreatment.absolute) ? '\n' + translate('Value') + ': ' + lastTreatment.absolute + 'U' : '')+
+      (!isNaN(lastTreatment.absolute) ? '\n' + translate('Value') + ': ' + (lastTreatment.amount || lastTreatment.absolute) + 'U' : '')+
       (lastTreatment.enteredBy ? '\n' + translate('Entered By') + ': ' + lastTreatment.enteredBy : '') +
 
       (lastTreatment.notes ? '\n' + translate('Notes') + ': ' + lastTreatment.notes : '');

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -366,7 +366,7 @@ function init (profileData) {
 
     //special handling for absolute to support temp to 0
     if (treatment && !isNaN(treatment.absolute) && treatment.duration > 0) {
-      tempbasal = Number(treatment.absolute);
+      tempbasal = Number(treatment.amount || treatment.absolute);
     } else if (treatment && treatment.percent) {
       tempbasal = basal * (100 + treatment.percent) / 100;
     }

--- a/lib/report_plugins/treatments.js
+++ b/lib/report_plugins/treatments.js
@@ -130,7 +130,7 @@ treatments.report = function report_treatments(datastorage, sorteddaystoshow, op
     pushIf(data.insulin, translate('Insulin Given') + ': ' + data.insulin);
     pushIf(data.duration, translate('Duration') + ': ' + data.duration);
     pushIf(data.percent, translate('Percent') + ': ' + data.percent);
-    pushIf(!isNaN(data.absolute), translate('Basal value') + ': ' + data.absolute);
+    pushIf(!isNaN(data.amount || data.absolute), translate('Basal value') + ': ' + (data.amount || data.absolute));
     pushIf(data.preBolus, translate('Carb Time') + ': ' + data.preBolus + ' ' + translate('mins'));
     pushIf(data.notes, translate('Notes') + ': ' + data.notes);
     pushIf(data.enteredBy, translate('Entered By') + ': ' + data.enteredBy);
@@ -331,7 +331,7 @@ treatments.report = function report_treatments(datastorage, sorteddaystoshow, op
         .append($('<td>').attr('align','center').append(tr.fat ? tr.fat : ''))
         .append($('<td>').attr('align','center').append(tr.duration ? tr.duration.toFixed(0) : ''))
         .append($('<td>').attr('align','center').append(tr.percent ? tr.percent : ''))
-        .append($('<td>').attr('align','center').append('absolute' in tr ? tr.absolute.toFixed(2) : ''))
+        .append($('<td>').attr('align','center').append('absolute' in tr ? (tr.amount || tr.absolute).toFixed(2) : ''))
         .append($('<td>').attr('align','center').append(tr.profile ? tr.profile : ''))
         .append($('<td>').append(tr.enteredBy ? tr.enteredBy : ''))
         .append($('<td>').append(tr.notes ? tr.notes : ''))


### PR DESCRIPTION
https://github.com/nightscout/cgm-remote-monitor/issues/4971

* For loop/omnipod users, nightscout does not correctly calculate effected temp basal amounts for omnipod
* Loop users as of September 2019 updates have new data in the form of `.amount` contains effected rate 

Impacts nightscout reports for loop/omnipod users and becomes detectable comparing reports or even adding things up manually.
It looks to me like the issue in the daytoday reports traces through to [line 369](https://github.com/nightscout/cgm-remote-monitor/blob/dev/lib/profilefunctions.js#L351-L383) in `getTempBasal`.


There are 18 *other* places that similarly use `.absolute` and conceivably some of them will need a similar patch or update to use a method to calculate effected rates.  Thoughts?

```
lib/client/careportal.js:279:      data.absolute = Number(absolute);
lib/client/careportal.js:415:    pushIf('absolute' in data, translate('Basal value') + ': ' + data.absolute);
lib/client/renderer.js:1171:          .text((t.percent ? (t.percent > 0 ? '+' : '') + t.percent + '%' : '') + (isNaN(t.absolute) ? '' : Number(t.absolute).toFixed(2) + 'U') + (t.relative ? 'C: +' + t.relative + 'U' : ''));
lib/plugins/basalprofile.js:86:        !isNaN(basalValue.treatment.absolute) ? basalValue.treatment.absolute + 'U/h' : '';
lib/plugins/bgnow.js:166:      recent.mean - delta.absolute / delta.elapsedMins * 5 : recent.mean - delta.absolute;
lib/plugins/bgnow.js:191:      info.push({label: translate('Absolute Delta'), value: sbx.roundBGToDisplayFormat(sbx.scaleMgdl(delta.absolute)) + ' ' + sbx.unitsLabel});
lib/plugins/treatmentnotify.js:148:      (!isNaN(lastTreatment.absolute) ? '\n' + translate('Value') + ': ' + lastTreatment.absolute + 'U' : '')+
lib/profilefunctions.js:368:    if (treatment && !isNaN(treatment.absolute) && treatment.duration > 0) {
lib/profilefunctions.js:369:      tempbasal = Number(treatment.amount || treatment.absolute);
lib/report_plugins/daytoday.js:674:          //            .text((t.percent ? (t.percent > 0 ? '+' : '') + t.percent + '%' : '') + (t.absolute ? Number(t.absolute).toFixed(2) + 'U' : ''));
lib/report_plugins/treatments.js:133:    pushIf(!isNaN(data.absolute), translate('Basal value') + ': ' + data.absolute);
lib/report_plugins/treatments.js:205:            data.absolute = $('#rped_absolute').val();
lib/report_plugins/treatments.js:213:            if (data.absolute === '') {
lib/report_plugins/treatments.js:214:              delete data.absolute;
lib/report_plugins/treatments.js:241:        $('#rped_absolute').val('absolute' in data ? data.absolute : '');
lib/report_plugins/treatments.js:334:        .append($('<td>').attr('align','center').append('absolute' in tr ? tr.absolute.toFixed(2) : ''))
lib/server/treatments.js:169:  obj.absolute = Number(obj.absolute);
lib/server/websocket.js:315:             if (data.data.absolute) {
lib/server/websocket.js:316:              query_similiar.absolute = data.data.absolute;

```