### PR TITLE
Adapt to MongoDB Atlas

### DIFF
--- a/app.json
+++ b/app.json
@@ -117,6 +117,11 @@
       "value": "US",
       "required": false
     },
+    "MONGODB_URI": {
+      "description": "The MongoDB Connection String to connect to your MongoDB cluster",
+      "value": "",
+      "required": true
+    },
     "MONGO_COLLECTION": {
       "description": "The Mongo collection where CGM data is stored.",
       "value": "entries",
@@ -149,7 +154,6 @@
     }
   },
   "addons": [
-    "mongolab:sandbox",
     "papertrail"
   ]
 }


### PR DESCRIPTION
- Require MONGODB_URI during heroku setup
- Remove "mongolab:sandbox" from addons

Related Loopdocs PR here:
 - https://github.com/LoopKit/loopdocs/pull/191