### PR TITLE
Sanitize extendedClientSettings

### DIFF
--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -216,7 +216,15 @@ function init (ctx) {
   plugins.extendedClientSettings = function extendedClientSettings (allExtendedSettings) {
     var clientSettings = {};
     _each(clientDefaultPlugins, function eachClientPlugin (plugin) {
-      clientSettings[plugin.name] = allExtendedSettings[plugin.name];
+      var settings = allExtendedSettings[plugin.name];
+      if(settings) {
+        // sanitize private settings
+        var settingscopy = JSON.parse(JSON.stringify(settings));
+        delete settingscopy.apnsKey;
+        delete settingscopy.apnsKeyId;
+        delete settingscopy.developerTeamId;
+        clientSettings[plugin.name] = settingscopy;
+      }
     });
 
     //HACK:  include devicestatus

--- a/tests/api.status.sanitized.test.js
+++ b/tests/api.status.sanitized.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var request = require('supertest');
+var language = require('../lib/language')();
+
+require('should');
+
+describe('Status REST api sanitization', function ( ) {
+  var self = this;
+
+  var api = require('../lib/api/');
+  beforeEach(function (done) {
+    process.env.API_SECRET = 'this is my long pass phrase';
+    process.env.LOOP_APNS_KEY = 'abc123privatekey';
+    process.env.LOOP_APNS_KEY_ID = 'abc123pkid';
+    process.env.LOOP_DEVELOPER_TEAM_ID = 'team123id';
+    process.env.ENABLE = ['bridge loop pump iob cob basal careportal sage cage bage openaps override'];
+    self.env = require('../env')();
+    self.env.settings.authDefaultRoles = 'readable';
+    this.wares = require('../lib/middleware/')(self.env);
+    self.app = require('express')();
+    self.app.enable('api');
+    require('../lib/server/bootevent')(self.env, language).boot(function booted(ctx) {
+      self.ctx = ctx;
+      self.ctx.ddata = require('../lib/data/ddata')();
+      self.app.use('/api', api(self.env, ctx));
+      done();
+    });
+  });
+
+  it('/status.json', function (done) {
+    request(self.app)
+      .get('/api/status.json')
+      .expect(200)
+      .end(function (err, res)  {
+        res.body.apiEnabled.should.equal(true);
+        res.body.settings.enable.should.containEql('loop');
+        // do not leak private settings
+        should.not.exist(res.body.extendedSettings.loop.apnsKey);
+        should.not.exist(res.body.extendedSettings.loop.apnsKeyId);
+        should.not.exist(res.body.extendedSettings.loop.developerTeamId);
+        // do not destroy settings in env
+        self.env.extendedSettings.loop.apnsKey.should.equal(process.env.LOOP_APNS_KEY);
+        self.env.extendedSettings.loop.apnsKeyId.should.equal(process.env.LOOP_APNS_KEY_ID);
+        self.env.extendedSettings.loop.developerTeamId.should.equal(process.env.LOOP_DEVELOPER_TEAM_ID);
+        done( );
+      });
+  });
+
+
+});
+


### PR DESCRIPTION
## What

Sanitize extendedClientSettings to not include the private APNS (Apple Push Notification Service) key, and other related values (that are less sensitive, but still should not be shared: APNS Key Id, and Developer Team ID).

## Why

The APNS key is used for loop "Remote Override" functionality, where Nightscout can send an Apple push notification to the loop app running on the looper's iPhone to enable or disable a temporary override remotely. 

This private key is currently being exposed to the public when someone has configured Nightscout to use this remote overrides loop setting.

This private key could be used to craft a remote override command to any looper's iPhone that is exposing this key, allowing any random person to change the insulin delivery settings at will. This is a **_very bad thing_**. 

Here is a (anonymized) screenshot demonstrating the key found with a simple google search:

![leaked_pkey](https://user-images.githubusercontent.com/708572/97304592-52b5a700-1832-11eb-88ea-a18149c54f41.png)

## Testing

I have written a unit test to check that the private key is not shared.

I have been running this code live for quite some time now, with no unintentional regressions or side-effects. 

## Remediation

All Nightscout users that have configured remote overrides should (after updating their nightscout site) immediately replace the APNS key with a new one, and delete the old key.