### PR TITLE
Removed translation key duplicate

### DIFF
--- a/translations/en/en.json
+++ b/translations/en/en.json
@@ -218,7 +218,6 @@
     ,"Glucose Reading":"Glucose Reading"
     ,"Measurement Method":"Measurement Method"
     ,"Meter":"Meter"
-    ,"Insulin Given":"Insulin Given"
     ,"Amount in grams":"Amount in grams"
     ,"Amount in units":"Amount in units"
     ,"View all treatments":"View all treatments"


### PR DESCRIPTION
The "Insulin Given" key is already found on line 129, so this one on 221 is a duplicate.