### PR TITLE
Build Docker image for arm64 architecture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,12 @@ jobs:
     if: github.ref == 'refs/heads/dev' && github.repository_owner == 'nightscout'
     env:
       DOCKER_IMAGE: nightscout/cgm-remote-monitor
+      PLATFORMS: linux/amd64,linux/arm64
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -58,11 +63,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Build, tag and push the dev Docker image
         if: success()
-        run: |
-          docker build --no-cache=true -t ${{ env.DOCKER_IMAGE }}:dev_${{ github.sha }} .
-          docker image push ${{ env.DOCKER_IMAGE }}:dev_${{ github.sha }}
-          docker tag ${{ env.DOCKER_IMAGE }}:dev_${{ github.sha }} ${{ env.DOCKER_IMAGE }}:latest_dev
-          docker image push ${{ env.DOCKER_IMAGE }}:latest_dev
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          no-cache: true
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:dev_${{ github.sha }}
+            ${{ env.DOCKER_IMAGE }}:latest_dev
 
   publish_master:
     name: Publish master branch to Docker Hub

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Send Coverage
         run: npm run-script coverage
 
-  publish_dev:
-    name: Publish dev branch to Docker Hub
+  publish:
+    name: Publish to Docker Hub
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/dev' && github.repository_owner == 'nightscout'
@@ -62,7 +62,7 @@ jobs:
         if: success()
         uses: actions/checkout@v2
       - name: Build, tag and push the dev Docker image
-        if: success()
+        if: success() && github.ref == 'refs/heads/dev'
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -73,30 +73,18 @@ jobs:
             ${{ env.DOCKER_IMAGE }}:dev_${{ github.sha }}
             ${{ env.DOCKER_IMAGE }}:latest_dev
 
-  publish_master:
-    name: Publish master branch to Docker Hub
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.repository_owner == 'nightscout'
-    env:
-      DOCKER_IMAGE: nightscout/cgm-remote-monitor
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-      - name: Clean git Checkout
-        if: success()
-        uses: actions/checkout@v2
-      - name: get-npm-version
-        if: success()
+      - name: Get Nightscout release version
+        if: success() && github.ref == 'refs/heads/master'
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master
       - name: Build, tag and push the master Docker image
-        if: success()
-        run: |
-          docker build --no-cache=true -t ${{ env.DOCKER_IMAGE }}:${{ steps.package-version.outputs.current-version }} .
-          docker image push ${{ env.DOCKER_IMAGE }}:${{ steps.package-version.outputs.current-version }}
-          docker tag ${{ env.DOCKER_IMAGE }}:${{ steps.package-version.outputs.current-version }} ${{ env.DOCKER_IMAGE }}:latest
-          docker image push ${{ env.DOCKER_IMAGE }}:latest
+        if: success() && github.ref == 'refs/heads/master'
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          no-cache: true
+          platforms: ${{ env.PLATFORMS }}
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:${{ steps.package-version.outputs.current-version }}
+            ${{ env.DOCKER_IMAGE }}:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     name: Publish to Docker Hub
     needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/dev' && github.repository_owner == 'nightscout'
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') && github.repository_owner == 'nightscout'
     env:
       DOCKER_IMAGE: nightscout/cgm-remote-monitor
       PLATFORMS: linux/amd64,linux/arm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
           context: .
           push: true
           no-cache: true
+          platforms: ${{ env.PLATFORMS }}
           tags: |
             ${{ env.DOCKER_IMAGE }}:dev_${{ github.sha }}
             ${{ env.DOCKER_IMAGE }}:latest_dev


### PR DESCRIPTION
This adds multi-platform Docker image building and publishing support to the CI via [`docker buildx`](https://docs.docker.com/buildx/working-with-buildx/). In addition, the Docker image will be built for `arm64` alongside `amd64`. For simplicity, I also merged the two `publish_dev` and `publish_master` jobs into one job named `publish`. 

Fixes #6932.