### PR TITLE
sanitize x-forwarded-for header

### DIFF
--- a/lib/api/status.js
+++ b/lib/api/status.js
@@ -2,6 +2,7 @@
 
 function configure (app, wares, env, ctx) {
   var express = require('express'),
+    forwarded = require('forwarded-for'),
     api = express.Router( )
     ;
 
@@ -21,7 +22,8 @@ function configure (app, wares, env, ctx) {
     var authToken = req.query.token || req.query.secret || '';
 
     function getRemoteIP (req) {
-      return req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+      const address = forwarded(req, req.headers);
+      return address.ip;
     }
 
     var date = new Date();

--- a/lib/api3/security.js
+++ b/lib/api3/security.js
@@ -4,11 +4,13 @@ const apiConst = require('./const.json')
   , _ = require('lodash')
   , shiroTrie = require('shiro-trie')
   , opTools = require('./shared/operationTools')
+  , forwarded = require('forwarded-for')
   ;
 
 
 function getRemoteIP (req) {
-  return req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+  const address = forwarded(req, req.headers);
+  return address.ip;
 }
 
 

--- a/lib/api3/storageSocket.js
+++ b/lib/api3/storageSocket.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const apiConst = require('./const');
+const forwarded = require('forwarded-for');
 
 /**
  * Socket.IO broadcaster of any storage change
@@ -28,7 +29,8 @@ function StorageSocket (app, env, ctx) {
     self.namespace = io.of(NAMESPACE);
     self.namespace.on('connection', function onConnected (socket) {
 
-      const remoteIP = socket.request.headers['x-forwarded-for'] || socket.request.connection.remoteAddress;
+      const address = forwarded(socket.request, socket.request.headers);
+      const remoteIP = address.ip;
       console.log(LOG + 'Connection from client ID: ', socket.client.id, ' IP: ', remoteIP);
 
       socket.on('disconnect', function onDisconnect () {

--- a/lib/authorization/index.js
+++ b/lib/authorization/index.js
@@ -6,9 +6,11 @@ const shiroTrie = require('shiro-trie');
 
 const consts = require('./../constants');
 const sleep = require('util').promisify(setTimeout);
+const forwarded = require('forwarded-for');
 
 function getRemoteIP (req) {
-  return req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+  const address = forwarded(req, req.headers);
+  return address.ip;
 }
 
 function init (env, ctx) {

--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -3,6 +3,7 @@
 var times = require('../times');
 var calcData = require('../data/calcdelta');
 var ObjectID = require('mongodb').ObjectID;
+const forwarded = require('forwarded-for');
 
 function init (env, ctx, server) {
 
@@ -127,7 +128,8 @@ function init (env, ctx, server) {
       var timeDiff;
       var history;
 
-      var remoteIP = socket.request.headers['x-forwarded-for'] || socket.request.connection.remoteAddress;
+      const address = forwarded(socket.request, socket.request.headers);
+      const remoteIP = address.ip;
       console.log(LOG_WS + 'Connection from client ID: ', socket.client.id, ' IP: ', remoteIP);
 
       io.emit('clients', ++watchers);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5641,9 +5641,14 @@
       "dev": true
     },
     "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "forwarded-for": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-1.1.0.tgz",
+      "integrity": "sha512-1Yam9ht7GyMXMBvuwJfUYqpdtLVodtT5ee5JMBzGiSwVVeh37ZN8LuOWkNHd6ho2zUxpSZCHuQrt1Vjl2AxDNA=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -9953,11 +9958,11 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
     },
@@ -11593,7 +11598,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "fast-password-entropy": "^1.1.1",
     "file-loader": "^6.2.0",
     "flot": "^0.8.3",
+    "forwarded-for": "^1.1.0",
     "helmet": "^4.0.0",
     "jquery": "^3.5.1",
     "jquery-ui-bundle": "^1.12.1-migrate",


### PR DESCRIPTION
Many proxies (NGINX included) will generate a list of IPs in v4 and
v6 formats.  The forwarded-for library is a well-maintained library for
express that sanitizes, checks, and validates trusted proxy IPs.  This helps
eliminate XSS or other attempts to inject invalid material through the
x-forwarded-for header.

This has been updated to filter when ingesting input rather than when creating html output.