### PR TITLE
respect per route body-parser configuration

### DIFF
--- a/lib/api/activity/index.js
+++ b/lib/api/activity/index.js
@@ -12,23 +12,14 @@ function configure(app, wares, ctx) {
         , api = express.Router();
 
     api.use(wares.compression());
-    api.use(wares.bodyParser({
-        limit: 1048576 * 50
-    }));
     // text body types get handled as raw buffer stream
-    api.use(wares.bodyParser.raw({
-        limit: 1048576
-    }));
+    api.use(wares.rawParser);
     // json body types get handled as parsed json
     api.use(wares.bodyParser.json({
-        limit: 1048576
-        , extended: true
+      limit: '50Mb'
     }));
     // also support url-encoded content-type
-    api.use(wares.bodyParser.urlencoded({
-        limit: 1048576
-        , extended: true
-    }));
+    api.use(wares.urlencodedParser);
     // invoke common middleware
     api.use(wares.sendJSONStatus);
 
@@ -94,9 +85,7 @@ function configure(app, wares, ctx) {
             });
         }
 
-        api.post('/activity/', wares.bodyParser({
-            limit: 1048576 * 50
-        }), ctx.authorization.isPermitted('api:activity:create'), post_response);
+        api.post('/activity/', ctx.authorization.isPermitted('api:activity:create'), post_response);
 
         api.delete('/activity/:_id', ctx.authorization.isPermitted('api:activity:delete'), function(req, res) {
             ctx.activity.remove(req.params._id, function() {

--- a/lib/api/alexa/index.js
+++ b/lib/api/alexa/index.js
@@ -11,12 +11,12 @@ function configure (app, wares, ctx, env) {
   // invoke common middleware
   api.use(wares.sendJSONStatus);
   // text body types get handled as raw buffer stream
-  api.use(wares.bodyParser.raw());
+  api.use(wares.rawParser);
   // json body types get handled as parsed json
-  api.use(wares.bodyParser.json({
-    limit: 1048576
-    , extended: true
-  }));
+  api.use(wares.jsonParser);
+  // also support url-encoded content-type
+  api.use(wares.urlencodedParser);
+  // text body types get handled as raw buffer stream
 
   ctx.virtAsstBase.setupVirtAsstHandlers(ctx.alexa);
 

--- a/lib/api/devicestatus/index.js
+++ b/lib/api/devicestatus/index.js
@@ -13,14 +13,12 @@ function configure (app, wares, ctx, env) {
   // invoke common middleware
   api.use(wares.sendJSONStatus);
   // text body types get handled as raw buffer stream
-  api.use(wares.bodyParser.raw());
+  api.use(wares.rawParser);
   // json body types get handled as parsed json
-  api.use(wares.bodyParser.json({
-    limit: 1048576
-    , extended: true
-  }));
+  api.use(wares.jsonParser);
   // also support url-encoded content-type
-  api.use(wares.bodyParser.urlencoded({ extended: true }));
+  api.use(wares.urlencodedParser);
+  // text body types get handled as raw buffer stream
 
   api.use(ctx.authorization.isPermitted('api:devicestatus:read'));
 

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -41,20 +41,18 @@ function configure (app, wares, ctx, env) {
   // invoke common middleware
   api.use(wares.sendJSONStatus);
   // text body types get handled as raw buffer stream
-  api.use(wares.bodyParser.raw());
+  api.use(wares.rawParser);
   // json body types get handled as parsed json
   api.use(wares.bodyParser.json({
-    limit: 1048576
-    , extended: true
+    limit: '50Mb'
   }));
+  // also support url-encoded content-type
+  api.use(wares.urlencodedParser);
+  // text body types get handled as raw buffer stream
   // shortcut to use extension to specify output content-type
   api.use(wares.extensions([
         'json', 'svg', 'csv', 'txt', 'png', 'html', 'tsv'
     ]));
-  // also support url-encoded content-type
-  api.use(wares.bodyParser.urlencoded({
-    extended: true
-  }));
 
   api.use(ctx.authorization.isPermitted('api:entries:read'));
   /**

--- a/lib/api/food/index.js
+++ b/lib/api/food/index.js
@@ -9,14 +9,13 @@ function configure (app, wares, ctx) {
     // invoke common middleware
     api.use(wares.sendJSONStatus);
     // text body types get handled as raw buffer stream
-    api.use(wares.bodyParser.raw( ));
+    api.use(wares.rawParser);
     // json body types get handled as parsed json
-    api.use(wares.bodyParser.json({
-      limit: 1048576
-      , extended: true
-    }));  
+    api.use(wares.jsonParser);
     // also support url-encoded content-type
-    api.use(wares.bodyParser.urlencoded({ extended: true }));
+    api.use(wares.urlencodedParser);
+    // text body types get handled as raw buffer stream
+    // shortcut to use extension to specify output content-type
 
     api.use(ctx.authorization.isPermitted('api:food:read'));
 

--- a/lib/api/googlehome/index.js
+++ b/lib/api/googlehome/index.js
@@ -11,9 +11,10 @@ function configure (app, wares, ctx, env) {
   // invoke common middleware
   api.use(wares.sendJSONStatus);
   // text body types get handled as raw buffer stream
-  api.use(wares.bodyParser.raw());
+  api.use(wares.rawParser);
   // json body types get handled as parsed json
-  api.use(wares.bodyParser.json());
+  api.use(wares.jsonParser);
+
 
   ctx.virtAsstBase.setupVirtAsstHandlers(ctx.googleHome);
 

--- a/lib/api/profile/index.js
+++ b/lib/api/profile/index.js
@@ -9,14 +9,12 @@ function configure (app, wares, ctx) {
     // invoke common middleware
     api.use(wares.sendJSONStatus);
     // text body types get handled as raw buffer stream
-    api.use(wares.bodyParser.raw( ));
+    api.use(wares.rawParser);
     // json body types get handled as parsed json
-    api.use(wares.bodyParser.json({
-        limit: 1048576
-        , extended: true
-    })); 
+    api.use(wares.jsonParser);
     // also support url-encoded content-type
-    api.use(wares.bodyParser.urlencoded({ extended: true }));
+    api.use(wares.urlencodedParser);
+    // text body types get handled as raw buffer stream
 
     api.use(ctx.authorization.isPermitted('api:profile:read'));
 

--- a/lib/api/treatments/index.js
+++ b/lib/api/treatments/index.js
@@ -13,24 +13,16 @@ function configure (app, wares, ctx, env) {
     , api = express.Router();
 
   api.use(wares.compression());
-  api.use(wares.bodyParser({
-    limit: 1048576 * 50
-    , extended: true
-  }));
+
   // text body types get handled as raw buffer stream
-  api.use(wares.bodyParser.raw({
-    limit: 1048576
-  }));
+  api.use(wares.rawParser);
   // json body types get handled as parsed json
   api.use(wares.bodyParser.json({
-    limit: 1048576
-    , extended: true
+    limit: '50Mb'
   }));
   // also support url-encoded content-type
-  api.use(wares.bodyParser.urlencoded({
-    limit: 1048576
-    , extended: true
-  }));
+  api.use(wares.urlencodedParser);
+
   // invoke common middleware
   api.use(wares.sendJSONStatus);
 
@@ -150,9 +142,7 @@ function configure (app, wares, ctx, env) {
       });
     }
 
-    api.post('/treatments/', wares.bodyParser({
-      limit: 1048576 * 50
-    }), ctx.authorization.isPermitted('api:treatments:create'), post_response);
+    api.post('/treatments/', ctx.authorization.isPermitted('api:treatments:create'), post_response);
 
     /**
      * @function delete_records

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -10,10 +10,21 @@ function extensions (list) {
   return require('./express-extension-to-accept')(list);
 }
 
-function configure () {
+function configure (env) {
   return {
     sendJSONStatus: wares.sendJSONStatus( ),
     bodyParser: wares.bodyParser,
+    jsonParser: wares.bodyParser.json({
+      limit: '1Mb',
+    }),
+    urlencodedParser: wares.bodyParser.urlencoded({
+      limit: '1Mb',
+      extended: true,
+      parameterLimit: 50000
+    }),
+    rawParser: wares.bodyParser.raw({
+      limit: '1Mb'
+    }),
     compression: wares.compression,
     extensions: extensions
   };

--- a/lib/server/app.js
+++ b/lib/server/app.js
@@ -26,8 +26,6 @@ function create (env, ctx) {
   var appInfo = env.name + ' ' + env.version;
   app.set('title', appInfo);
   app.enable('trust proxy'); // Allows req.secure test on heroku https connections.
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: true }));
   var insecureUseHttp = env.insecureUseHttp;
   var secureHstsHeader = env.secureHstsHeader;
   if (!insecureUseHttp) {


### PR DESCRIPTION
This change allows each route to express policies for interpreting and parsing
the request body.  Before this change uploads to entries or treatments api
would error if they were larger than 100Kb due to the preference being set for
the whole server.  This change removes the global preference in favor of
allowing each route to choose it's own request size limit.

We also refactor usage of body-parser to be more consistent throughout the code
base.  Most routes can use jsonParser, rawPraser, and urlencodedParser provided
by the common wares component.  Anything doing something else should be called
out as such.  For example, treatments, activity, and entries allow uploads up
to 50Mb.  Other v1 endpoints are using the common configuration set to 1Mb.