### PR TITLE
Fix api-secret header name in swagger configuration.

### DIFF
--- a/lib/server/swagger.json
+++ b/lib/server/swagger.json
@@ -881,7 +881,7 @@
     "securitySchemes": {
       "api_secret": {
         "type": "apiKey",
-        "name": "api_secret",
+        "name": "api-secret",
         "in": "header",
         "description": "The hash of the API_SECRET env var"
       },

--- a/lib/server/swagger.yaml
+++ b/lib/server/swagger.yaml
@@ -656,7 +656,7 @@ components:
   securitySchemes:
     api_secret:
       type: apiKey
-      name: api_secret
+      name: api-secret
       in: header
       description: The hash of the API_SECRET env var
     token_in_url:


### PR DESCRIPTION
Without this change, the /api-docs/ endpoint would send the header "`api_secret`" instead of the expected "`api-secret`" header.