### PR TITLE
Ability to disable pushover emergency priority

### DIFF
--- a/lib/plugins/pushover.js
+++ b/lib/plugins/pushover.js
@@ -37,15 +37,18 @@ function init (env, ctx) {
         , message: notify.message
         , sound: notify.pushoverSound || 'gamelan'
         , timestamp: new Date()
-        //USE PUSHOVER_EMERGENCY for WARN and URGENT so we get the acks
-        , priority: notify.level >= ctx.levels.WARN ? pushover.PRIORITY_EMERGENCY : pushover.PRIORITY_NORMAL
       };
 
-      if (ctx.levels.isAlarm(notify.level)) {
-        //ADJUST RETRY TIME based on WARN or URGENT
-        msg.retry = notify.level === ctx.levels.URGENT ? times.mins(2).secs : times.mins(15).secs;
-        if (env.settings && env.settings.baseURL) {
-          msg.callback = env.settings.baseURL + '/api/v1/notifications/pushovercallback';
+      if (pushoverAPI.emergencyPriority) {
+        //USE PUSHOVER_EMERGENCY for WARN and URGENT so we get the acks
+        msg.priority = notify.level >= ctx.levels.WARN ? pushover.PRIORITY_EMERGENCY : pushover.PRIORITY_NORMAL
+
+        if (ctx.levels.isAlarm(notify.level)) {
+          //ADJUST RETRY TIME based on WARN or URGENT
+          msg.retry = notify.level === ctx.levels.URGENT ? times.mins(2).secs : times.mins(15).secs;
+          if (env.settings && env.settings.baseURL) {
+            msg.callback = env.settings.baseURL + '/api/v1/notifications/pushovercallback';
+          }
         }
       }
       return msg;
@@ -99,6 +102,8 @@ function init (env, ctx) {
 
 function setupPushover (env) {
   var apiToken = env.extendedSettings && env.extendedSettings.pushover && env.extendedSettings.pushover.apiToken;
+  // emergencyPriority 'on' is the default, that's why the first negation is there
+  var emergencyPriority = !(env.extendedSettings && env.extendedSettings.pushover && env.extendedSettings.pushover.emergencyPriority === false);
 
   function keysByType (type, fallback) {
     fallback = fallback || [];
@@ -136,6 +141,7 @@ function setupPushover (env) {
     pushoverAPI.userKeys = userKeys;
     pushoverAPI.alarmKeys = alarmKeys;
     pushoverAPI.announcementKeys = announcementKeys;
+    pushoverAPI.emergencyPriority = emergencyPriority;
 
     return pushoverAPI;
   }


### PR DESCRIPTION
We were in the need to both not flag the pushover messages as emergency so that quite hours could be used as well as not have them do the retry.

Instead of removing it entirely on our fork I decided to try and contribute this back with a simple `PUSHOVER_EMERGENCY_PRIORITY` setting than can be `on` or `off`, `on` being the default (current behavior).

If this is desired and willing to be accepted I can try working out docs and maybe some tests.