### PR TITLE
Fix bug with pump plugin and Virtual assistant

### DIFF
--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -163,10 +163,12 @@ function init (ctx) {
   function virtAsstBatteryHandler (next, slots, sbx) {
     var battery = _.get(sbx, 'properties.pump.data.battery');
     if (battery) {
+      var options = {};
+      options.ci = true;
       var response = translate('virtAsstPumpBattery', {
               params: [
                   battery.value,
-                  battery.unit
+                  translate(battery.unit, options)
               ]
           });
       next(translate('virtAsstTitlePumpBattery'), response);


### PR DESCRIPTION
At the moment I am working on creating a plugin for the Russian-language voice assistant Yandex.Alice. In the process of work, I come across some bugs, one of them is fixed in this PR.
When the voice assistant asks for the battery level in a language other than English, an incompletely translated phrase is returned, for example

> "заряд батареи 24 percent"

The first part of the phrase is translated correctly, but the second remains. The problem is how exactly the pump plugin integrates with the plugin `virtAsstBase`. The changes are simple and can be seen below.

You can test it if you make pump battery request using GoogleHome or Alexa in any language other than English.