### PR TITLE
Fixes an issue where treatment units were all rewritten on load, regardless of units

### DIFF
--- a/lib/data/ddata.js
+++ b/lib/data/ddata.js
@@ -265,7 +265,11 @@ function init () {
     ddata.tempbasalTreatments = ddata.processDurations(tempbasalTreatments, false);
 
     // filter temp target
-    var tempTargetTreatments = ddata.treatments.filter(function filterTargets (t) {
+    var tempTargetTreatments = ddata.treatments.filter(function filterTargets (tt) {
+
+      // Clone the treatment before modifying it
+      let t = _.cloneDeep(tt);
+
       //check for a units being sent
       if (t.units) {
         if (t.units == 'mmol') {


### PR DESCRIPTION
Fixes an issue reported by AAPS dev team. The current behavior overwrites treatment units to mg/dl regardless of the original units and adds null targets on events missing the target. The fixed code changes the code to work as intended, where the units are only changed for temp target treatments.