### PR TITLE
Change deduping interval

### DIFF
--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -294,7 +294,7 @@ function init (env, ctx, server) {
       socket.on('dbAdd', function dbAdd (data, callback) {
         console.log(LOG_WS + 'dbAdd client ID: ', socket.client.id, ' data: ', data);
         var collection = supportedCollections[data.collection];
-        var maxtimediff = times.mins(1).msecs;
+        var maxtimediff = times.secs(2).msecs;
 
         var check = checkConditions('dbAdd', data);
         if (check) {


### PR DESCRIPTION
Current behaviour of 1 min interval for deduplication is effectively blocking synchronization of 2 consequent events of the same type (like profile switch). I believe 2 sec should be enough for handling data with accuracy of seconds only