### PR TITLE
Mark nodejs 16 as an acceptable LTS version

### DIFF
--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -35,7 +35,7 @@ function boot (env, language) {
 
     const isLTS = process.release.lts ? true : false;
   
-    if (isLTS && (semver.satisfies(nodeVersion, '^14.0.0') || semver.satisfies(nodeVersion, '^12.0.0') || semver.satisfies(nodeVersion, '^10.0.0'))) {
+    if (isLTS && (semver.satisfies(nodeVersion, '^16.0.0') || semver.satisfies(nodeVersion, '^14.0.0') || semver.satisfies(nodeVersion, '^12.0.0') || semver.satisfies(nodeVersion, '^10.0.0'))) {
       //Latest Node 10 LTS and Node 12 LTS are recommended and supported.
       //Require at least Node 8 LTS and Node 10 LTS without known security issues
       console.debug('Node LTS version ' + nodeVersion + ' is supported');


### PR DESCRIPTION
https://nodejs.org lists version 16.14.0 as latest available LTS, mark it as an acceptable one to run with.