### PR TITLE
Fix expiration time on remote notifications for Loop

### DIFF
--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -112,8 +112,12 @@ function init (env, ctx) {
       alert += " - " + data.enteredBy
     }
 
+    // Track time notification was sent
+    let now = new Date()
+    payload['sent-at'] = now.toISOString();
+
     // Expire after 5 minutes.
-    let expiration = new Date((new Date()).getTime() + 5 * 60 * 1000)
+    let expiration = new Date(now.getTime() + 5 * 60 * 1000)
     payload['expiration'] = expiration.toISOString();
 
     let notification = new apn.Notification();

--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -71,9 +71,9 @@ function init (env, ctx) {
         payload["override-duration-minutes"] = parseInt(data.duration);
       }
       alert = data.reasonDisplay + " Temporary Override";
-    } else if (data.eventType === 'Remote Carbs Entry') { 
+    } else if (data.eventType === 'Remote Carbs Entry') {
       payload["carbs-entry"] = parseFloat(data.remoteCarbs);
-      if(payload["carbs-entry"] > 0.0 ) { 
+      if(payload["carbs-entry"] > 0.0 ) {
          payload["absorption-time"] = 3.0;
          if (data.remoteAbsorption !== undefined && parseFloat(data.remoteAbsorption) > 0.0) {
            payload["absorption-time"] = parseFloat(data.remoteAbsorption);
@@ -83,19 +83,19 @@ function init (env, ctx) {
          }
          alert  = "Remote Carbs Entry: "+payload["carbs-entry"]+" grams\n";
          alert += "Absorption Time: "+payload["absorption-time"]+" hours";
-      } else { 
+      } else {
          completion("Loop remote carbs failed. Incorrect carbs entry: ", data.remoteCarbs);
          return;
       }
-   
-   } else if (data.eventType === 'Remote Bolus Entry') { 
+
+   } else if (data.eventType === 'Remote Bolus Entry') {
       payload["bolus-entry"] = parseFloat(data.remoteBolus);
-      if(payload["bolus-entry"] > 0.0 ) { 
+      if(payload["bolus-entry"] > 0.0 ) {
          alert  = "Remote Bolus Entry: "+payload["bolus-entry"]+" U\n";
          if (data.otp !== undefined && data.otp.length > 0) {
             payload["otp"] = ""+data.otp
          }
-      } else { 
+      } else {
          completion("Loop remote bolus failed. Incorrect bolus entry: ", data.remoteBolus);
          return;
       }
@@ -112,11 +112,14 @@ function init (env, ctx) {
       alert += " - " + data.enteredBy
     }
 
+    // Expire after 5 minutes.
+    let expiration = new Date((new Date()).getTime() + 5 * 60 * 1000)
+    payload['expiration'] = expiration.toISOString();
+
     let notification = new apn.Notification();
     notification.alert = alert;
     notification.topic = loopSettings.bundleIdentifier;
     notification.contentAvailable = 1;
-    notification.expiry =  Math.round((Date.now() / 1000)) + 60 * 5; // Allow this to enact within 5 minutes.
     notification.payload = payload;
 
     provider.send(notification, [loopSettings.deviceToken]).then( (response) => {


### PR DESCRIPTION
Because APNS can sometimes deliver notifications late, it is critical that Loop not enact remote overrides if this happens. The previous method attempting to do this was not working as expected.