### PR TITLE
Omnipod reservoir fixes

### DIFF
--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -236,11 +236,7 @@ function init (ctx) {
   function updateReservoir (prefs, result) {
     if (result.reservoir) {
       result.reservoir.label = 'Reservoir';
-      if (result.reservoir_display_override) {
-        result.reservoir.display = result.reservoir_display_override;
-      } else {
-        result.reservoir.display = result.reservoir.value.toPrecision(3) + 'U';
-      }
+      result.reservoir.display = result.reservoir.value.toPrecision(3) + 'U';
       if (result.reservoir.value < prefs.urgentRes) {
         result.reservoir.level = levels.URGENT;
         result.reservoir.message = 'URGENT: Pump Reservoir Low';
@@ -254,6 +250,12 @@ function init (ctx) {
       result.reservoir = {
         label: 'Reservoir', display: '50+ U'
       }
+    }
+    if (result.reservoir_display_override) {
+      result.reservoir.display = result.reservoir_display_override;
+    }
+    if (result.reservoir_level_override) {
+      result.reservoir.level = result.reservoir_level_override;
     }
   }
 

--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -257,7 +257,6 @@ function init (ctx) {
     if (result.reservoir_level_override) {
       result.reservoir.level = result.reservoir_level_override;
     }
-    console.log("pump result = ", result);
   }
 
   function updateBattery (type, prefs, result, batteryWarn) {

--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -257,6 +257,7 @@ function init (ctx) {
     if (result.reservoir_level_override) {
       result.reservoir.level = result.reservoir_level_override;
     }
+    console.log("pump result = ", result);
   }
 
   function updateBattery (type, prefs, result, batteryWarn) {

--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -322,6 +322,7 @@ function init (ctx) {
       , clock: pump.clock ? { value: moment(pump.clock) } : null
       , reservoir: pump.reservoir || pump.reservoir === 0 ? { value: pump.reservoir } : null
       , reservoir_display_override: pump.reservoir_display_override || null
+      , reservoir_level_override: pump.reservoir_level_override || null
       , manufacturer: pump.manufacturer
       , model: pump.model
       , extended: pump.extended || null

--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -91,7 +91,7 @@ function init (ctx) {
     var prefs = pump.getPrefs(sbx);
 
     if (!prefs.enableAlerts) { return; }
-    
+
     pump.warnOnSuspend = prefs.warnOnSuspend;
 
     var data = prepareData(sbx.properties.pump, prefs, sbx);
@@ -130,7 +130,7 @@ function init (ctx) {
         }
       }
     });
-    
+
     if (result.extended) {
       info.push({label: '------------', value: ''});
       _.forOwn(result.extended, function(value, key) {
@@ -250,7 +250,7 @@ function init (ctx) {
       } else {
         result.reservoir.level = levels.NONE;
       }
-    } else if (result.manufacturer === 'Insulet' &&  result.model === 'Eros') {
+    } else if (result.manufacturer === 'Insulet') {
       result.reservoir = {
         label: 'Reservoir', display: '50+ U'
       }


### PR DESCRIPTION
This patch has two updates:
* Special handling of reservoir for Eros pods extended to all Insulet pods. 
* Allow uploaders to set urgency reservoir_level_override, when reservoir_display_override