### PR TITLE
Support automatic bolus volumes in the enacted field for loop status.

### DIFF
--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -231,7 +231,7 @@ function init (ctx) {
         , split: false
         , targets: false
         , reasons: reasonconf
-        , otp: true 
+        , otp: true
         , submitHook: postLoopNotification
       },
       {
@@ -252,16 +252,16 @@ function init (ctx) {
       {
         val: 'Remote Carbs Entry'
         , name: 'Remote Carbs Entry'
-        , remoteCarbs: true 
-        , remoteAbsorption: true 
-        , otp: true 
+        , remoteCarbs: true
+        , remoteAbsorption: true
+        , otp: true
         , submitHook: postLoopNotification
       },
       {
         val: 'Remote Bolus Entry'
         , name: 'Remote Bolus Entry'
-        , remoteBolus: true 
-        , otp: true 
+        , remoteBolus: true
+        , otp: true
         , submitHook: postLoopNotification
       }
     ];
@@ -269,7 +269,7 @@ function init (ctx) {
 
   // TODO: Add event listener to customize labels
 
- 
+
   loop.updateVisualisation = function updateVisualisation (sbx) {
     var prop = sbx.properties.loop;
 
@@ -356,13 +356,22 @@ function init (ctx) {
 
     function addLastEnacted () {
       if (prop.lastEnacted) {
-        var canceled = prop.lastEnacted.rate === 0 && prop.lastEnacted.duration === 0;
+        var canceled = ;
 
-        var valueParts = [
-          '<b>Temp Basal' + (canceled ? ' Canceled' : ' Started') + '</b>'
-          , canceled ? '' : ' ' + prop.lastEnacted.rate.toFixed(2) + 'U/hour for ' + prop.lastEnacted.duration + 'm'
-          , valueString(', ', prop.lastEnacted.reason)
-        ];
+        var valueParts = []
+
+        if (prop.lastEnacted.rate === 0 && prop.lastEnacted.duration === 0) {
+          valueParts.push('<b>Temp Basal Canceled</b>')
+        }
+        if (prop.lastEnacted.rate != null) {
+          valueParts.push('<b>Temp Basal Started</b>')
+          valueParts.push(' ' + prop.lastEnacted.rate.toFixed(2) + 'U/hour for ' + prop.lastEnacted.duration + 'm')
+        }
+        if (prop.lastEnacted.bolusVolume) {
+          valueParts.push('<b>Automatic Bolus</b>')
+          valueParts.push(' ' + prop.lastEnacted.bolusVolume + 'U')
+        }
+        valueParts.push(valueString(', ', prop.lastEnacted.reason))
 
         valueParts = concatIOB(valueParts);
         valueParts = concatCOB(valueParts);

--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -356,8 +356,6 @@ function init (ctx) {
 
     function addLastEnacted () {
       if (prop.lastEnacted) {
-        var canceled = ;
-
         var valueParts = []
 
         if (prop.lastEnacted.rate === 0 && prop.lastEnacted.duration === 0) {


### PR DESCRIPTION
With automatic bolusing in Loop, the last temp basal adjustment might be quite old. The current loop plugin only shows last temp basal adjustment. This change updates the plugin to show automatic bolus enactments in the loop pill as well, so the user has a clearer understanding of the time that Loop last adjusted dosing.

This must be merged before https://github.com/ps2/NightscoutService/pull/17 can land in Loop. 