### PR TITLE
Fix incorrect appending for loop enacted status

### DIFF
--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -358,16 +358,17 @@ function init (ctx) {
       if (prop.lastEnacted) {
         var valueParts = []
 
-        if (prop.lastEnacted.rate === 0 && prop.lastEnacted.duration === 0) {
-          valueParts.push('<b>Temp Basal Canceled</b>')
-        }
-        if (prop.lastEnacted.rate != null) {
-          valueParts.push('<b>Temp Basal Started</b>')
-          valueParts.push(' ' + prop.lastEnacted.rate.toFixed(2) + 'U/hour for ' + prop.lastEnacted.duration + 'm')
-        }
         if (prop.lastEnacted.bolusVolume) {
           valueParts.push('<b>Automatic Bolus</b>')
           valueParts.push(' ' + prop.lastEnacted.bolusVolume + 'U')
+          if (prop.lastEnacted.rate === 0 && prop.lastEnacted.duration === 0) {
+            valueParts.push(' (Temp Basal Canceled)')
+          }
+        } else if (prop.lastEnacted.rate === 0 && prop.lastEnacted.duration === 0) {
+          valueParts.push('<b>Temp Basal Canceled</b>')
+        } else if (prop.lastEnacted.rate != null) {
+          valueParts.push('<b>Temp Basal Started</b>')
+          valueParts.push(' ' + prop.lastEnacted.rate.toFixed(2) + 'U/hour for ' + prop.lastEnacted.duration + 'm')
         }
         valueParts.push(valueString(', ', prop.lastEnacted.reason))
 


### PR DESCRIPTION
When Loop was canceling a temp basal, the enacted status was showing conflicting information; it showed `<b>Temp Basal Canceled</b><b>Temp Basal Started</b> 0 U/hour for 0m`, which is confusing.

