### PR TITLE
fix webpack 5 polyfills

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -161,6 +161,10 @@ module.exports = {
     rules
   },
   resolve: {
+    fallback: {
+      'process/browser': require.resolve('process/browser'),
+      events: require.resolve('events/')
+    },
     alias: {
       stream: 'stream-browserify',
       crypto: 'crypto-browserify',


### PR DESCRIPTION
When using cgm-remote-monitor as part of monorepo I got errors because incorrect module resolution. The problem is explained here https://gist.github.com/ef4/d2cf5672a93cf241fd47c020b9b3066a. 

I tested that it has no impact on size of the result, it only provides more proper way to resolve the `process/browser` and `events` modules.