### PR TITLE
Fix empty import config

### DIFF
--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -23,7 +23,7 @@ function boot (env, language) {
 
   //////////////////////////////////////////////////
   // Check Node version.
-  // Latest Node LTS releases are recommended and supported. 
+  // Latest Node LTS releases are recommended and supported.
   // Current Node releases MAY work, but are not recommended. Will be tested in CI
   // Older Node versions or Node versions with known security issues will not work.
   ///////////////////////////////////////////////////
@@ -35,7 +35,7 @@ function boot (env, language) {
     var nodeVersion = process.version;
 
     const isLTS = process.release.lts ? true : false;
-  
+
     if (isLTS && (semver.satisfies(nodeVersion, '^16.0.0') || semver.satisfies(nodeVersion, '^14.0.0'))) {
       //Latest Node 14 LTS and Node 16 LTS are recommended and supported.
       //Require at least Node 14 without known security issues
@@ -267,7 +267,7 @@ function boot (env, language) {
   function setupListeners (ctx, next) {
 
     console.log('Executing setupListeners');
-    
+
     if (hasBootErrors(ctx)) {
       return next();
     }

--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -72,11 +72,15 @@ function boot (env, language) {
     var configURL = env.IMPORT_CONFIG || null;
     var url = require('url');
     var href = null;
-    try {
-      href = url.parse(configURL).href;
-    } catch (e) {
-      console.error('Parsing config URL from IMPORT_CONFIG failed');
+
+    if (configURL) {
+      try {
+        href = url.parse(configURL).href;
+      } catch (e) {
+        console.error('Parsing config URL from IMPORT_CONFIG failed');
+      }
     }
+
     if(configURL && href) {
       var request = require('request');
       console.log('Getting settings from', href);

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -161,6 +161,10 @@ module.exports = {
     rules
   },
   resolve: {
+    fallback: {
+      'process/browser': require.resolve('process/browser'),
+      events: require.resolve('events/')
+    },
     alias: {
       stream: 'stream-browserify',
       crypto: 'crypto-browserify',


### PR DESCRIPTION
If `env.IMPORT_CONFIG` is not provided and is null we try to `url.parse` and print error `console.error('Parsing config URL from IMPORT_CONFIG failed');`.