### PR TITLE
Add charging state to the uploader battery pill 

### DIFF
--- a/lib/plugins/upbat.js
+++ b/lib/plugins/upbat.js
@@ -72,6 +72,7 @@ function init(ctx) {
 
       var battery = uploaderStatus.battery;
       var voltage = uploaderStatus.batteryVoltage;
+      var charging = status.isCharging ? status.isCharging : false;
       var voltageDisplay;
 
       if (voltage) {
@@ -93,7 +94,7 @@ function init(ctx) {
           uploaderStatus.voltageDisplay = voltageDisplay;
         }
 
-        uploaderStatus.display = battery ? battery + '%' : voltageDisplay;
+        uploaderStatus.display = (battery ? battery + '%' : voltageDisplay) + (charging ? "⚡" : "");
 
         if (battery >= 95) {
           uploaderStatus.level = 100;


### PR DESCRIPTION
AAPSClientV3 now uploads the charging state on a dev build. This change will display the charging state in the pill when the field is set. 

See commit: https://github.com/nightscout/AndroidAPS/commit/ba58fb5ff7772966b728ecbfbca9090d6360ed72 

![msedge_V9SpdXecOD](https://user-images.githubusercontent.com/5643940/216604096-c2786603-4182-47f8-96b8-d31e504e8f75.png)
