### PR TITLE
Fixed pushover callbacks not being processed

### DIFF
--- a/lib/api/notifications-api.js
+++ b/lib/api/notifications-api.js
@@ -1,11 +1,15 @@
 'use strict';
 
 var consts = require('../constants');
+var bodyParser = require('body-parser');
 
 function configure (app, wares, ctx) {
   var express = require('express')
     , api = express.Router( )
     ;
+
+  app.use(bodyParser.urlencoded({extended : true}));
+  app.use(bodyParser.json());
 
   api.post('/notifications/pushovercallback', function (req, res) {
     if (ctx.pushnotify.pushoverAck(req.body)) {


### PR DESCRIPTION
This is a fix for: https://github.com/nightscout/cgm-remote-monitor/issues/7170

The problem was that the body of the put request wasn't parsed and was undefined. After trying a lot of things, this was what worked for me. I can now once more silence an alarm by acknowledging the push over notification. 