### PR TITLE
Add logging limits to docker-compose.yml for all services (mongo, nightscout and traefik)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,18 @@
 version: '3'
 
+x-logging:
+  &default-logging
+  options:
+    max-size: '10m'
+    max-file: '5'
+  driver: json-file
+
 services:
   mongo:
     image: mongo:4.4
     volumes:
       - ${NS_MONGO_DATA_DIR:-./mongo-data}:/data/db:cached
+    logging: *default-logging
 
   nightscout:
     image: nightscout/cgm-remote-monitor:latest
@@ -19,6 +27,7 @@ services:
       - 'traefik.http.routers.nightscout.rule=Host(`localhost`)'
       - 'traefik.http.routers.nightscout.entrypoints=websecure'
       - 'traefik.http.routers.nightscout.tls.certresolver=le'
+    logging: *default-logging
     environment:
       ### Variables for the container
       NODE_ENV: production
@@ -74,3 +83,4 @@ services:
     volumes:
       - './letsencrypt:/letsencrypt'
       - '/var/run/docker.sock:/var/run/docker.sock:ro'
+    logging: *default-logging


### PR DESCRIPTION
Common log limit parameters for json-file driver defined in x-logging extension field with options:
    max-size: '10m'
    max-file: '5'
