### PR TITLE
Add event type to event on treatment notify if it's missing

### DIFF
--- a/lib/plugins/treatmentnotify.js
+++ b/lib/plugins/treatmentnotify.js
@@ -123,6 +123,11 @@ function init(ctx) {
         message = '...';
       }
 
+      if (!eventType && lastTreatment.carbs && lastTreatment.insulin) eventType = "Meal Bolus";
+      if (!eventType && lastTreatment.carbs) eventType = "Carb Correction";
+      if (!eventType && lastTreatment.insulin) eventType = "Correcton Bolus";
+      if (!eventType) eventType = "Note";      
+
       const hash = crypto.createHash('sha1');
       const info = JSON.stringify({ eventType, timestamp});
       hash.update(info);


### PR DESCRIPTION
Fixes treatment notification not creating a notify if user doesn't select an event in Care Portal or a client uploading data with no treatment event type