### PR TITLE
Fix loading JWT when auth subject has no permissions

### DIFF
--- a/lib/authorization/index.js
+++ b/lib/authorization/index.js
@@ -298,7 +298,7 @@ function init (env, ctx) {
       const token = env.enclave.signJWT({ accessToken: subject.accessToken });
       const decoded = env.enclave.verifyJWT(token);
 
-      var roles = _.uniq(subject.roles.concat(defaultRoles));
+      var roles = subject.roles ? _.uniq(subject.roles.concat(defaultRoles)) : defaultRoles;
 
       authorized = {
         token

--- a/tests/api.security.test.js
+++ b/tests/api.security.test.js
@@ -71,6 +71,20 @@ describe('Security of REST API V1', function() {
       });
   });
 
+  it('Should return a JWT with default roles on broken role token', function(done) {
+    const now = Math.round(Date.now() / 1000) - 1;
+    request(self.app)
+      .get('/api/v2/authorization/request/' + self.token.noneSubject)
+      .expect(200)
+      .end(function(err, res) {
+        const decodedToken = jwt.decode(res.body.token);
+        decodedToken.accessToken.should.equal(self.token.noneSubject);
+        decodedToken.iat.should.be.aboveOrEqual(now);
+        decodedToken.exp.should.be.above(decodedToken.iat);
+        done();
+      });
+  });
+
   it('Data load should succeed with API SECRET', function(done) {
     request(self.app)
       .get('/api/v1/entries.json')

--- a/tests/fixtures/api3/authSubject.js
+++ b/tests/fixtures/api3/authSubject.js
@@ -67,6 +67,7 @@ async function authSubject (authStorage) {
   await createRole(authStorage, 'apiRead', 'api:*:read');
   await createRole(authStorage, 'apiUpdate', 'api:*:update');
   await createRole(authStorage, 'apiDelete', 'api:*:delete');
+  await createRole(authStorage, 'noneRole', '');
 
   const subject = {
     apiAll: await createTestSubject(authStorage, 'apiAll', ['apiAll']),
@@ -77,7 +78,9 @@ async function authSubject (authStorage) {
     apiDelete: await createTestSubject(authStorage, 'apiDelete', ['apiDelete']),
     admin: await createTestSubject(authStorage, 'admin', ['admin']),
     readable: await createTestSubject(authStorage, 'readable', ['readable']),
-    denied: await createTestSubject(authStorage, 'denied', ['denied'])
+    denied: await createTestSubject(authStorage, 'denied', ['denied']),
+    noneSubject: await createTestSubject(authStorage, 'noneSubject', null),
+    noneRole: await createTestSubject(authStorage, 'noneRole', ['noneRole'])
   };
 
   const token = {
@@ -89,7 +92,9 @@ async function authSubject (authStorage) {
     delete: subject.apiDelete.accessToken,
     denied: subject.denied.accessToken,
     adminAll: subject.admin.accessToken,
-    readable: subject.readable.accessToken
+    readable: subject.readable.accessToken,
+    noneSubject: subject.noneSubject.accessToken,
+    noneRole: subject.noneRole.accessToken
   };
 
   return {subject, token};


### PR DESCRIPTION
Fix an issue reported by Milos, when a JWT is loaded with a subject that has no permissions