### PR TITLE
Fixes #7910

### DIFF
--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -472,11 +472,6 @@ function configure (app, wares, ctx, env) {
       });
     } else {
       inMemoryCollection = ctx.cache.getData('entries');
-
-      inMemoryCollection = _.sortBy(inMemoryCollection, function(item) {
-        const age = item.mills | item.date;
-        return age;
-      }).reverse();
     }
 
     if (inMemoryPossible && query.count <= inMemoryCollection.length) {

--- a/lib/server/entries.js
+++ b/lib/server/entries.js
@@ -99,8 +99,11 @@ function storage (env, ctx) {
 
       // Normalize dates to be in UTC, store offset in utcOffset
 
-      var _sysTime = moment(doc.dateString).isValid() ? moment.parseZone(doc.dateString) : moment(doc.date);
-      _sysTime = _sysTime.isValid() ? _sysTime : moment();
+      var _sysTime;
+
+      if (doc.dateString) { _sysTime = moment.parseZone(doc.dateString); }
+      if (!_sysTime && doc.date) { _sysTime = moment(doc.date); }
+      if (!_sysTime) _sysTime = moment();
 
       doc.utcOffset = _sysTime.utcOffset();
       doc.sysTime = _sysTime.toISOString();
@@ -163,17 +166,11 @@ function storage (env, ctx) {
   api.aggregate = require('./aggregate')({}, api);
   api.indexedFields = [
     'date'
-    
     , 'type'
-    
     , 'sgv'
-    
     , 'mbg'
-    
     , 'sysTime'
-    
     , 'dateString'
-    
     , { 'type': 1, 'date': -1, 'dateString': 1 }
  ];
   return api;


### PR DESCRIPTION
As reported on #7910, the entries API call without the type specifier was returning data from the runtime state in wrong order, resulting in 48 hour old entries being returned first. Expected behaviour was to return latest entries first.

The PR additionally fixes insertion of CGM entries to /entries using the moment of insertion for entries that sent a numeric date moment for the record, rather than a dateString.