### PR TITLE
emoji clock

### DIFF
--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -118,6 +118,8 @@ client.render = function render () {
   // Insert the delta value text.
   $('.dt').html(deltaDisplayValue);
 
+  let bgNum = parseFloat(rec.mgdl);
+
   // Color background
   if (bgColor) {
 
@@ -132,8 +134,6 @@ client.render = function render () {
     let bgLow = client.settings.thresholds.bgLow;
     let bgTargetBottom = client.settings.thresholds.bgTargetBottom;
     let bgTargetTop = client.settings.thresholds.bgTargetTop;
-
-    let bgNum = parseFloat(rec.mgdl);
 
     // Threshold background coloring.
     if (bgNum < bgLow) {
@@ -165,6 +165,56 @@ client.render = function render () {
 
   // Insert the BG value text, toggle stale if necessary.
   $('.sg').toggleClass('stale', thresholdReached).html(displayValue);
+
+  var em;  
+  if (thresholdReached) {
+    em='🤷';
+  } else if (bgNum <= 40) { //2,2
+    em='❌';
+  } else if (bgNum <= 54) { //3
+    em='🥶';
+  } else if (bgNum <= 72) { //4
+    em='😱';
+  } else if (bgNum <= 97) {  //5,4
+    em='😊';
+  } else if (displayValue == '100' || displayValue == '5.5') { //5,5
+    em='🦄';
+  } else if (bgNum <= 101) { //5,6 
+    em='🥇';
+  } else if (bgNum <= 108) { //6
+    em='😎';
+  } else if (bgNum <= 126) { //7
+    em='🥳';
+  } else if (bgNum <= 144) { //8
+    em='🤔';
+  } else if (bgNum <= 162) { //9
+    em='😳';
+  } else if (bgNum <= 180) { //10
+    em='😵‍💫';
+  } else if (bgNum <= 198) { //11
+    em='🎃';
+  } else if (bgNum <= 216) { //12
+    em='🙀';
+  } else if (bgNum <= 234) { //13
+    em='🔥';
+  } else if (bgNum <= 252) { //14
+    em='😬';
+  } else if (bgNum <= 270) { //15
+    em='😡';
+  } else if (bgNum <= 288) { //16
+    em='🤬';
+  } else if (bgNum <= 306) { //17
+    em='🥵';
+  } else if (bgNum <= 324) { //18
+    em='🫣';
+  } else if (bgNum <= 342) { //19
+    em='😩';
+  } else if (bgNum <= 360) { //20
+    em='🤯';
+  } else {
+    em='👿';
+  }
+  $('.em').html(em);
 
   if (thresholdReached || alwaysShowTime) {
     let staleTimeText;

--- a/views/clockviews/clock-config.html
+++ b/views/clockviews/clock-config.html
@@ -22,6 +22,7 @@
         <p><input type="button" class="elmt" id="cfg_dt" name="dt" value="Add SGV delta"> Size: <input type="number" class="size" id="cfg_dt_size" name="cfg_dt_size" min="1" max="99" value="14"></p>
         <p><input type="button" class="elmt" id="cfg_ar" name="ar" value="Add trend arrow"> Size: <input type="number" class="size" id="cfg_ar_size" name="cfg_ar_size" min="1" max="99" value="30"></p>
         <p><input type="button" class="elmt" id="cfg_tm" name="tm" value="Add time"> Size: <input type="number" class="size" id="cfg_tm_size" name="cfg_tm_size" min="1" max="99" value="10"></p>
+        <p><input type="button" class="elmt" id="cfg_em" name="em" value="Add emoji"> Size: <input type="number" class="size" id="cfg_em_size" name="cfg_em_size" min="1" max="99" value="40"></p>
         <p><input type="button" class="undo" id="cfg_undo" name="undo" value="Remove last element"></p>
         <a id="clocklink" target=”_blank” href="/clock/cy10">Open my clock view!</a>
         <div id="facename">cy10</div>

--- a/views/clockviews/clock.html
+++ b/views/clockviews/clock.html
@@ -19,7 +19,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon-180x180.png">
 
   <style type="text/css">
-    @import url("//fonts.googleapis.com/css?family=Open+Sans:700");
+    @import url("//fonts.googleapis.com/css?family=Open+Sans:700|Noto+Color+Emoji");
     <%- include('clock-shared.css', {}); %>
     <%if (face === 'config') { %>
     <%- include('clock-config.css', {}); %>


### PR DESCRIPTION
After being inspired by Jon Faucet's SugarPixel, I decided to enhance the custom clock view by adding the ability to display an emoji that corresponds to the current blood sugar value. My 9-year-old child with type 1 diabetes helped me choose the emojis. We are using a custom clock view with svg, emoji and time on a raspberry with a small screen in kiosk mode. I have thoroughly tested the implementation in different environments, including dev, master, and units of measurement (mmol/L and mg/dL). Overall, I're thrilled with the outcome and hope it can benefit others as well.

Examples:
<img width="683" alt="image" src="https://user-images.githubusercontent.com/12718238/224536302-f953a9be-e197-4801-a707-f5453380b04d.png">
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/12718238/224536317-afd5fce1-fb53-475e-b12f-b0fe61a9e3e4.png">

