### PR TITLE
Deprecate update tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ The data being uploaded from the server to the client is from a MongoDB server s
 
 ## Updating my version?
 
-The easiest way to update your version of cgm-remote-monitor to the latest version is to use the [update tool][update-fork]. A step-by-step guide is available [here][http://www.nightscout.info/wiki/welcome/how-to-update-to-latest-cgm-remote-monitor-aka-cookie].
-To downgrade to an older version, follow [this guide][http://www.nightscout.info/wiki/welcome/how-to-deploy-an-older-version-of-nightscout].
+A step-by-step guide is available [here][https://nightscout.github.io/update/update/].
+To deploy another version (or downgrade), follow [this guide][[https://nightscout.github.io/update/dev_branch/].
 
 ## Configure my uploader to match
 


### PR DESCRIPTION
Since GitHub implement Sync Fork, using the update tool is not necessary. Many ended-up trying to PR into the main repo with this method. Sync Fork will be easier, and for those failing, redeploy (delete and fork) is the most efficient way to update. As for downgrade, it follows the same logic than deploying dev IMHO.