### PR TITLE
Less frequent Mongo updates

### DIFF
--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const UPDATE_THROTTLE = 5000;
+const UPDATE_THROTTLE = 15000;
 
 function boot (env, language) {
 
@@ -292,6 +292,7 @@ function boot (env, language) {
 
     ctx.bus.on('data-received', function forceReloadData ( ) {
       console.info('got data-received event, requesting reload');
+      ctx.bus.emit('data-loaded'); // Since we update local sandbox instantly, process data-loaded right away in case this gets debounced
       updateData();
     });
 


### PR DESCRIPTION
Increase debounce for data loads to 15 seconds and trigger a data-loaded event to process local data updates even if the call is debounced

Maybe fixes #8024