### PR TITLE
Fix label's `for` attribute for plugin-specific settings

### DIFF
--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -142,7 +142,7 @@ function init (client, serverSettings, $) {
             const id = e.plugin.name + "-" + p.id;
             const label = p.label;
             if (p.type == 'boolean') {
-              const html = $(`<dd><input type="checkbox" id="${id}" value="true" /><label for="${id}r">` + translate(label) + `</label></dd>`);
+              const html = $(`<dd><input type="checkbox" id="${id}" value="true" /><label for="${id}">` + translate(label) + `</label></dd>`);
               dl.append(html);
               if (storage.get(id) == true) {
                 toggleCheckboxes.push(id);


### PR DESCRIPTION
Fixes a minor issue with the label for the "Color prediction lines" checkbox not being clickable.