### PR TITLE
Fix default value of the checkbox in plugin-specific settings

### DIFF
--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -144,7 +144,8 @@ function init (client, serverSettings, $) {
             if (p.type == 'boolean') {
               const html = $(`<dd><input type="checkbox" id="${id}" value="true" /><label for="${id}r">` + translate(label) + `</label></dd>`);
               dl.append(html);
-              if (storage.get(id) == true) {
+              const settingsBase = settings.extendedSettings[e.plugin.name];
+              if (settingsBase[p.id] == true) {
                 toggleCheckboxes.push(id);
               }
             }


### PR DESCRIPTION
When `OPENAPS_COLOR_PREDICTION_LINES` is set to `true`, the "Color prediction lines" checkbox in settings is incorrectly unchecked when opening Nightscout on a browser without any site data. This means that when you first change any settings, you'll override the current value of "Color prediction lines" to be false if you don't notice that the checkbox was unchecked despite the feature being enabled. This should fix that issue by using the proper setting value from `settings.extendedSettings` rather than only checking the value in browser storage.

There's actually one other problem that I noticed which I'm not sure what the best way to fix it is - "Reset, and use defaults" does not reset the plugin-specific settings. This happens because nothing in that link's on-click function touches `extendedSettings` (`settings.eachSetting()` only lists direct attributes of `settings` and `settings.thresholds`).