### PR TITLE
Create render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,84 @@
+# Easily deploy NightScout CGM Remote Monitor (https://github.com/nightscout/cgm-remote-monitor) 
+# to Render (https://render.com)
+# ------------------------------
+# 1. Fork https://github.com/nightscout/cgm-remote-monitor to your own GitHub account.
+# 2. Add a render.yaml file to the root of your forked repo, copy/paste the contents below
+# 3. Commit the new file (and push to GitHub)
+# 4. In Render, click "New +" > "Blueprint"
+# 5. Connect your own, forked cgm-remote-monitor repo
+# 6. Fill in required environment variables
+# 7. Click "Apply" and wait for the deploy to complete.
+# mongodb+srv://mkerimsag:m00451400@cluster0.ll9egev.mongodb.net/?retryWrites=true&w=majority
+# nitghscoutk1 n00451400451400
+# mongodb+srv://mkerimsay:m00451400@kerimdepo.lkh93yd.mongodb.net/?retryWrites=true&w=majority
+# mongodb+srv://mkerimsay:@kerimdepo.lkh93yd.mongodb.net/Gmsay ?retryWrites=true&w=majority
+# mongodb+srv://mkerimsay:m00451400@kerimdepo.lkh93yd.mongodb.net/Gmsay ?retryWrites=true&w=majority
+
+services:
+  - type: web
+    name: nightscout
+    env: node
+    region: oregon # optional (defaults to oregon. Other regions: ohio, frankfurt, singapore)
+    plan: free # optional (defaults to free - this a FREE PLAN, maybe... https://render.com/pricing)
+    buildCommand: npm install
+    startCommand: npm start
+    healthCheckPath: /
+    envVars:
+      - key: INSECURE_USE_HTTP # TLS is terminated before reaching the app, so only needs to respond to HTTP.
+        value: true
+      - key: HOSTNAME # bind app to any internal IP
+        value: "0.0.0.0"
+      - key: MONGODB_URI # The MongoDB Connection String to connect to your MongoDB cluster. If you don't have this from MongoDB Atlas, please re-read installation instructions at http://nightscout.github.io/nightscout/new_user/ before continuing
+        sync: false # will be requested when Blueprint is created
+      - key: ALARM_HIGH # Default setting for new browser views, for the High alarm (triggered when BG crosses BG_TARGET_TOP). ('on' or 'off')
+        value: "on"
+      - key: ALARM_LOW # Default setting for new browser views, for the Low alarm (triggered when BG crosses BG_TARGET_BOTTOM). ('on' or 'off')
+        value: "on"
+      - key: ALARM_TIMEAGO_URGENT # Default setting for new browser views, for an urgent alarm when CGM data hasn't been received in the number of minutes set in ALARM_TIMEAGO_URGENT_MINS. ('on' or 'off')
+        value: "on"
+      - key: ALARM_TIMEAGO_URGENT_MINS # Default setting for new browser views, for the number of minutes since the last CGM reading to trigger an ALARM_TIMEAGO_URGENT alarm.
+        value: "30"
+      - key: ALARM_TIMEAGO_WARN # Default setting for new browser views, for a warning alarm when CGM data hasn't been received in the number of minutes set in ALARM_TIMEAGO_WARN_MINS. ('on' or 'off')
+        value: "on"
+      - key: ALARM_TIMEAGO_WARN_MINS # Default setting for new browser views, for the number of minutes since the last CGM reading to trigger an ALARM_TIMEAGO_WARN alarm.
+        value: "15"
+      - key: ALARM_TYPES # 'simple' and/or 'predict'. Simple alarms trigger when BG crosses the various thresholds set below. Predict alarms use a formula that forecasts where the BG is going based on its trend. You will *not* get warnings when crossing the BG thresholds set below when using the predict type.
+        value: "simple"
+      - key: ALARM_URGENT_HIGH # Default setting for new browser views, for the Urgent High alarm (triggered when BG crosses BG_HIGH). ('on' or 'off')
+        value: "on"
+      - key: ALARM_URGENT_LOW # Default setting for new browser views, for the Urgent Low alarm (triggered when BG crosses BG_LOW). ('on' or 'off')
+        value: "on"
+      - key: API_SECRET # A passphrase that must be at least 12 characters long. Avoid 'special' characters, which can cause problems in some cases.
+        sync: false # will be requested when Blueprint is created
+      - key: BG_HIGH # Urgent High BG threshold, triggers the ALARM_URGENT_HIGH alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.
+        value: "260"
+      - key: BG_LOW # Urgent Low BG threshold, triggers the ALARM_URGENT_LOW alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.
+        value: "55"
+      - key: BG_TARGET_BOTTOM # Low BG threshold, triggers the ALARM_LOW alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.
+        value: "80"
+      - key: BG_TARGET_TOP # High BG threshold, triggers the ALARM_HIGH alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.
+        value: "180"
+      - key: BOLUS_RENDER_OVER # U value over which the bolus values are rendered on the chart if the 'x U and Over' option is selected.
+        value: "1"
+      - key: BRIDGE_PASSWORD # Your Dexcom account password, to receive CGM data from the Dexcom Share service. Also make sure to include 'bridge' in your ENABLE line.
+        value: "password"
+      - key: BRIDGE_SERVER # If you are bridging from the Dexcom Share service, and are anywhere *outside* the US, change this to EU. ('US' or 'EU')
+        value: "EU"
+      - key: BRIDGE_USER_NAME # Your Dexcom account username, to receive CGM data from the Dexcom Share service. Also make sure to include 'bridge' in your ENABLE line.
+        value: "username"
+      - key: CUSTOM_TITLE # The display name for the Nightscout site. Appears in the upper left of the main view. Often set to the name of the CGM wearer.
+        value: ""
+      - key: DISPLAY_UNITS # Preferred BG units for the site: 'mg/dl' or 'mmol/L' (or just 'mmol').
+        sync: false # will be requested when Blueprint is created
+      - key: ENABLE # Plugins to enable for your site. Must be a space-delimited, lower-case list. Include the word 'bridge' here if you are receiving data from the Dexcom Share service. Include 'mmconnect' if you are bridging from the MiniMed CareLink service.
+        value: "careportal basal dbsize rawbg iob maker cob bwp cage iage sage boluscalc pushover treatmentnotify loop pump profile food openaps bage alexa override speech cors"
+      - key: NIGHT_MODE # Default setting for new browser views, for whether Night Mode should be enabled. ('on' or 'off')
+        value: "off"
+      - key: SHOW_PLUGINS # Default setting for whether or not these plugins are checked (active) by default, not merely enabled. Include plugins here as in the ENABLE line; space-separated and lower-case.
+        value: "careportal dbize"
+      - key: SHOW_RAWBG # Default setting for new browser views, for the display of raw CGM data (if available). ('always', 'never', or 'noise')
+        value: "never"
+      - key: THEME # Default setting for new browser views, for the color theme of the CGM graph. ('default', 'colors', or 'colorblindfriendly')
+        value: "colors"
+      - key: TIME_FORMAT # Default setting for new browser views, for the time mode. ('12' or '24')
+        value: "24"


### PR DESCRIPTION
# Easily deploy NightScout CGM Remote Monitor (https://github.com/nightscout/cgm-remote-monitor) 
# to Render (https://render.com)
# ------------------------------
# 1. Fork https://github.com/nightscout/cgm-remote-monitor to your own GitHub account.
# 2. Add a render.yaml file to the root of your forked repo, copy/paste the contents below
# 3. Commit the new file (and push to GitHub)
# 4. In Render, click "New +" > "Blueprint"
# 5. Connect your own, forked cgm-remote-monitor repo
# 6. Fill in required environment variables
# 7. Click "Apply" and wait for the deploy to complete.
# mongodb+srv://mkerimsag:m00451400@cluster0.ll9egev.mongodb.net/?retryWrites=true&w=majority
# nitghscoutk1 n00451400451400
# mongodb+srv://mkerimsay:m00451400@kerimdepo.lkh93yd.mongodb.net/?retryWrites=true&w=majority
# mongodb+srv://mkerimsay:@kerimdepo.lkh93yd.mongodb.net/Gmsay ?retryWrites=true&w=majority
# mongodb+srv://mkerimsay:m00451400@kerimdepo.lkh93yd.mongodb.net/Gmsay ?retryWrites=true&w=majority

services:
  - type: web
    name: nightscout
    env: node
    region: oregon # optional (defaults to oregon. Other regions: ohio, frankfurt, singapore)
    plan: free # optional (defaults to free - this a FREE PLAN, maybe... https://render.com/pricing)
    buildCommand: npm install
    startCommand: npm start
    healthCheckPath: /
    envVars:
      - key: INSECURE_USE_HTTP # TLS is terminated before reaching the app, so only needs to respond to HTTP.
        value: true
      - key: HOSTNAME # bind app to any internal IP
        value: "0.0.0.0"
      - key: MONGODB_URI # The MongoDB Connection String to connect to your MongoDB cluster. If you don't have this from MongoDB Atlas, please re-read installation instructions at http://nightscout.github.io/nightscout/new_user/ before continuing
        sync: false # will be requested when Blueprint is created
      - key: ALARM_HIGH # Default setting for new browser views, for the High alarm (triggered when BG crosses BG_TARGET_TOP). ('on' or 'off')
        value: "on"
      - key: ALARM_LOW # Default setting for new browser views, for the Low alarm (triggered when BG crosses BG_TARGET_BOTTOM). ('on' or 'off')
        value: "on"
      - key: ALARM_TIMEAGO_URGENT # Default setting for new browser views, for an urgent alarm when CGM data hasn't been received in the number of minutes set in ALARM_TIMEAGO_URGENT_MINS. ('on' or 'off')
        value: "on"
      - key: ALARM_TIMEAGO_URGENT_MINS # Default setting for new browser views, for the number of minutes since the last CGM reading to trigger an ALARM_TIMEAGO_URGENT alarm.
        value: "30"
      - key: ALARM_TIMEAGO_WARN # Default setting for new browser views, for a warning alarm when CGM data hasn't been received in the number of minutes set in ALARM_TIMEAGO_WARN_MINS. ('on' or 'off')
        value: "on"
      - key: ALARM_TIMEAGO_WARN_MINS # Default setting for new browser views, for the number of minutes since the last CGM reading to trigger an ALARM_TIMEAGO_WARN alarm.
        value: "15"
      - key: ALARM_TYPES # 'simple' and/or 'predict'. Simple alarms trigger when BG crosses the various thresholds set below. Predict alarms use a formula that forecasts where the BG is going based on its trend. You will *not* get warnings when crossing the BG thresholds set below when using the predict type.
        value: "simple"
      - key: ALARM_URGENT_HIGH # Default setting for new browser views, for the Urgent High alarm (triggered when BG crosses BG_HIGH). ('on' or 'off')
        value: "on"
      - key: ALARM_URGENT_LOW # Default setting for new browser views, for the Urgent Low alarm (triggered when BG crosses BG_LOW). ('on' or 'off')
        value: "on"
      - key: API_SECRET # A passphrase that must be at least 12 characters long. Avoid 'special' characters, which can cause problems in some cases.
        sync: false # will be requested when Blueprint is created
      - key: BG_HIGH # Urgent High BG threshold, triggers the ALARM_URGENT_HIGH alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.
        value: "260"
      - key: BG_LOW # Urgent Low BG threshold, triggers the ALARM_URGENT_LOW alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.
        value: "55"
      - key: BG_TARGET_BOTTOM # Low BG threshold, triggers the ALARM_LOW alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.
        value: "80"
      - key: BG_TARGET_TOP # High BG threshold, triggers the ALARM_HIGH alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.
        value: "180"
      - key: BOLUS_RENDER_OVER # U value over which the bolus values are rendered on the chart if the 'x U and Over' option is selected.
        value: "1"
      - key: BRIDGE_PASSWORD # Your Dexcom account password, to receive CGM data from the Dexcom Share service. Also make sure to include 'bridge' in your ENABLE line.
        value: "password"
      - key: BRIDGE_SERVER # If you are bridging from the Dexcom Share service, and are anywhere *outside* the US, change this to EU. ('US' or 'EU')
        value: "EU"
      - key: BRIDGE_USER_NAME # Your Dexcom account username, to receive CGM data from the Dexcom Share service. Also make sure to include 'bridge' in your ENABLE line.
        value: "username"
      - key: CUSTOM_TITLE # The display name for the Nightscout site. Appears in the upper left of the main view. Often set to the name of the CGM wearer.
        value: ""
      - key: DISPLAY_UNITS # Preferred BG units for the site: 'mg/dl' or 'mmol/L' (or just 'mmol').
        sync: false # will be requested when Blueprint is created
      - key: ENABLE # Plugins to enable for your site. Must be a space-delimited, lower-case list. Include the word 'bridge' here if you are receiving data from the Dexcom Share service. Include 'mmconnect' if you are bridging from the MiniMed CareLink service.
        value: "careportal basal dbsize rawbg iob maker cob bwp cage iage sage boluscalc pushover treatmentnotify loop pump profile food openaps bage alexa override speech cors"
      - key: NIGHT_MODE # Default setting for new browser views, for whether Night Mode should be enabled. ('on' or 'off')
        value: "off"
      - key: SHOW_PLUGINS # Default setting for whether or not these plugins are checked (active) by default, not merely enabled. Include plugins here as in the ENABLE line; space-separated and lower-case.
        value: "careportal dbize"
      - key: SHOW_RAWBG # Default setting for new browser views, for the display of raw CGM data (if available). ('always', 'never', or 'noise')
        value: "never"
      - key: THEME # Default setting for new browser views, for the color theme of the CGM graph. ('default', 'colors', or 'colorblindfriendly')
        value: "colors"
      - key: TIME_FORMAT # Default setting for new browser views, for the time mode. ('12' or '24')
        value: "24"

# 