### PR TITLE
Fix to display historic COB-value (from OpenAps) when scolling back in time

### DIFF
--- a/lib/plugins/cob.js
+++ b/lib/plugins/cob.js
@@ -282,9 +282,10 @@ function init (ctx) {
       var when = new Date(lastCarbs.mills).toLocaleString();
       var amount = lastCarbs.carbs + 'g';
       info.push({ label: translate('Last Carbs'), value: amount + ' @ ' + when });
+      displayCob = Math.round(sbx.properties.openaps.lastSuggested.COB);
     }
 
-    sbx.pluginBase.updatePillText(sbx, {
+    sbx.pluginBase.updatePillText(cob, {
       value: displayCob + 'g'
       , label: translate('COB')
       , info: info


### PR DESCRIPTION
Copied from https://github.com/nightscout/cgm-remote-monitor/commit/7aa606ddac735fce821119e5bb674c08bc8441f0 by @klalle / @maja-lofgren

Please see https://github.com/nightscout/cgm-remote-monitor/issues/6916 and https://github.com/nightscout/cgm-remote-monitor/issues/5241 for details.