### PR TITLE
restore compat with socket.io v2 client

### DIFF
--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -75,7 +75,9 @@ function init (env, ctx, server) {
       'log level': 0
     }).listen(server, {
       //these only effect the socket.io.js file that is sent to the client, but better than nothing
-      'browser client minification': true
+      // compat with v2 client
+      allowEIO3: true
+      , 'browser client minification': true
       , 'browser client etag': true
       , 'browser client gzip': false
       , 'perMessageDeflate': {


### PR DESCRIPTION
socket.io v4 won't talk to a socket.io v2 client unless you enable a compatibility flag 

https://socket.io/docs/v4/server-options/#alloweio3

tested directly in prod, version screenshot

<img width="406" alt="image" src="https://github.com/nightscout/cgm-remote-monitor/assets/165080/1df5c777-36e6-4b5c-b7c2-a2e0515f3113">
