### PR TITLE
socket.io: enable legacy v2 connections

### DIFF
--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -76,7 +76,9 @@ function init (env, ctx, server) {
       'log level': 0
     }).listen(server, {
       //these only effect the socket.io.js file that is sent to the client, but better than nothing
-      'browser client minification': true
+      // compat with v2 client
+      allowEIO3: true
+      , 'browser client minification': true
       , 'browser client etag': true
       , 'browser client gzip': false
       , 'perMessageDeflate': {

--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -72,6 +72,7 @@ function init (env, ctx, server) {
 
   function start () {
     io = require('socket.io')({
+      allowEIO3: true,
       'log level': 0
     }).listen(server, {
       //these only effect the socket.io.js file that is sent to the client, but better than nothing

--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -72,7 +72,6 @@ function init (env, ctx, server) {
 
   function start () {
     io = require('socket.io')({
-      allowEIO3: true,
       'log level': 0
     }).listen(server, {
       //these only effect the socket.io.js file that is sent to the client, but better than nothing


### PR DESCRIPTION
The allowEIO3, when set to true allows v2 clients to connect while the default is false. This patch should allow versions of AndroidAPS older than 3.2 to connect to NS15 and above.
Thanks to Dave Carlson for researching and experimenting with this option!
https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#how-to-upgrade-an-existing-production-deployment https://socket.io/docs/v4/server-options/#alloweio3