### PR TITLE
Fix nightscout crashes after failed APNs delivery

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,0 +1,26 @@
+name: Build Docker Image
+on:
+  push:
+    branches:
+      - upstream/wip/nspro/dev
+jobs:
+    build:
+      name: push docker image to docker hub
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: login to docker hub
+          id: docker-hub
+          env:
+            username: ${{secrets.DOCKERHUB_USERNAME}}
+            password: ${{secrets.DOCKERHUB_PASSWORD}}
+          run: |
+            docker login -u $username -p $password 
+        - name: build the docker image
+          id: build-docker-image
+          run: |
+            ls -la 
+            docker build . -f Dockerfile -t nightscoutpro/cgm-remote-monitor:dev
+        - name: push the docker image
+          id: push-docker-image
+          run: docker push ${{secrets.DOCKERHUB_USERNAME}}/cgm-remote-monitor:dev

--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -130,14 +130,36 @@ function init (env, ctx) {
     notification.payload = payload;
     notification.interruptionLevel = "time-sensitive"
 
-    provider.send(notification, [loopSettings.deviceToken]).then( (response) => {
+    provider.send(notification, [loopSettings.deviceToken]).then((response) => {
       if (response.sent && response.sent.length > 0) {
         completion();
       } else {
-        console.log("APNs delivery failed:", response.failed)
-        completion("APNs delivery failed: " + response.failed[0].response.reason);
+        console.log("APNs delivery failed:", response.failed);
+    
+        // Check if response.failed and response.failed[0] are defined
+        if (response.failed && response.failed.length > 0) {
+          const failedResponse = response.failed[0];
+          const reason = failedResponse.response && failedResponse.response.reason
+            ? failedResponse.response.reason
+            : 'Unknown reason';
+    
+          // Provide detailed debugging information
+          const errorMessage = `APNs delivery failed: ${reason}`;
+          console.error(errorMessage, failedResponse);
+          completion(errorMessage);
+        } else {
+          // Handle the case where response.failed is undefined or empty
+          const errorMessage = 'APNs delivery failed: No failure details available.';
+          console.error(errorMessage, response);
+          completion(errorMessage);
+        }
       }
+    }).catch((error) => {
+      // Catch any other unexpected errors
+      console.error('Unexpected error during APNs delivery:', error);
+      completion(`APNs delivery failed: ${error.message || 'Unknown error'}`);
     });
+    
   };
 
   return loop();


### PR DESCRIPTION
Updated the loop.js file to handle the error more gracefully and display an error message to the user rather than crashing the Nightscout instance.