### PR TITLE
return generic '500' status on bootError page

### DIFF
--- a/lib/server/booterror.js
+++ b/lib/server/booterror.js
@@ -29,7 +29,7 @@ function bootError(env, ctx) {
       return '<dt><b>' + obj.desc + '</b></dt><dd>' + message.replace(/\\n/g, '<br/>') + '</dd>';
     }).join(' ');
 
-    res.render('error.html', {
+    res.status(500).render('error.html', {
       errors,
       locals
     });


### PR DESCRIPTION
Currently Nightscout Web Monitor does not return a HTTP error status code when displaying the `bootError` page. 

This means that while users can see there is a problem with the application, platforms it may be deployed on cannot.

Returning a 500 status error in this case will at least enable health checks to be performed and deployments to be restarted when there's an issue with the application.