### PR TITLE
Use local timezone date in careportal. Fixes nightscout#8304

### DIFF
--- a/lib/client/boluscalc.js
+++ b/lib/client/boluscalc.js
@@ -45,9 +45,9 @@ function init (client, $) {
   }
 
   function setDateAndTime (time) {
-    time = time || new Date();
-    eventTime.val(time.getHours() + ":" + time.getMinutes());
-    eventDate.val(time.toISOString().split('T')[0]);
+    time = time ? (time.format ? time : client.ctx.moment(time)) : client.ctx.moment();
+    eventDate.val(time.format('YYYY-MM-DD'));
+    eventTime.val(time.format('HH:mm'));
   }
 
   function mergeDateAndTime () {
@@ -585,7 +585,7 @@ function init (client, $) {
     maybePrevent(event);
   }
 
-  function quickpickHideFood () {
+  function quickpickHideFood (event) {
     var qpiselected = $('#bc_quickpick').val();
 
     if (qpiselected >= 0) {

--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -18,8 +18,8 @@ function init (client, $) {
 
   function setDateAndTime (time) {
     time = time || client.ctx.moment();
-    eventTime.val(time.hours() + ":" + time.minutes());
-    eventDate.val(time.toISOString().split('T')[0]);
+    eventDate.val(time.format('YYYY-MM-DD'));
+    eventTime.val(time.format('HH:mm'));
   }
 
   function mergeDateAndTime () {

--- a/tests/careportal.test.js
+++ b/tests/careportal.test.js
@@ -2,6 +2,7 @@
 
 require('should');
 var benv = require('benv');
+const moment = require("moment/moment");
 
 var nowData = {
   sgvs: [
@@ -96,6 +97,19 @@ describe('careportal', function ( ) {
 
     client.careportal.save();
 
+  });
+
+  it('uses local timezone date, not UTC (8304) ', async () =>{
+    const client = window.Nightscout.client;
+    client.init();
+    // sleep(50);
+
+    const fakeNow = moment.parseZone('2024-10-25T23:00:00-05:00');
+    client.ctx.moment = () => (fakeNow);
+
+    client.careportal.prepare();
+
+    $('#eventDateValue').val().should.equal('2024-10-25');
   });
 
 });

--- a/tests/careportal.test.js
+++ b/tests/careportal.test.js
@@ -11,6 +11,31 @@ var nowData = {
   , treatments: []
 };
 
+var profileData = {
+  defaultProfile: 'Default'
+  , units: 'mg/dl'
+  , store: {
+    Default: {
+      dia: 3
+      , units: 'mg/dl'
+      , basal: [{time: '00:00', timeAsSeconds: 0, value: 1}]
+      , carbratio: [{time: '00:00', timeAsSeconds: 0, value: 10}]
+      , sens: [{time: '00:00', timeAsSeconds: 0, value: 50}]
+      , target_low: [{time: '00:00', timeAsSeconds: 0, value: 100}]
+      , target_high: [{time: '00:00', timeAsSeconds: 0, value: 120}]
+    }
+  }
+};
+
+var boluscalcData = {
+  sgvs: [
+    { mgdl: 100, mills: Date.now(), direction: 'Flat', type: 'sgv' }
+  ]
+  , treatments: []
+  , devicestatus: []
+  , profiles: [profileData]
+};
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -39,12 +64,66 @@ describe('careportal', function ( ) {
     done( );
   });
 
+  function mockMomentNow (client, time) {
+    var fakeNow = moment.parseZone(time);
+
+    client.ctx.moment = function mockMoment (value) {
+      if (value === undefined) {
+        return fakeNow.clone();
+      }
+      return moment(value);
+    };
+  }
+
+  function selectRadio (nowSelector, otherSelector) {
+    $(nowSelector).removeAttr('checked').prop('checked', false);
+    $(otherSelector).attr('checked', 'checked').prop('checked', true);
+  }
+
+  function mockTreatmentPost () {
+    var mocks = {
+      ajax: $.ajax
+      , confirm: window.confirm
+      , alert: window.alert
+      , treatment: undefined
+    };
+
+    $.ajax = function mockAjax (request) {
+      mocks.treatment = request.data;
+
+      return {
+        done: function mockDone (fn) {
+          fn({message: 'OK'});
+          return this;
+        }
+        , fail: function mockFail () {
+          return this;
+        }
+      };
+    };
+
+    window.confirm = function mockConfirm () {
+      return true;
+    };
+    window.alert = function mockAlert (messages) {
+      messages.should.equal('');
+    };
+
+    return mocks;
+  }
+
+  function restoreTreatmentPost (mocks) {
+    $.ajax = mocks.ajax;
+    window.confirm = mocks.confirm;
+    window.alert = mocks.alert;
+  }
+
   it ('open careportal, and enter a treatment', async () =>{
 
     console.log('Careportal test client start');
 
-	  var client = window.Nightscout.client;
-	
+    var client = window.Nightscout.client;
+
     var hashauth = require('../lib/client/hashauth');
     hashauth.init(client,$);
     hashauth.verifyAuthentication = function mockVerifyAuthentication(next) { 
@@ -99,65 +178,82 @@ describe('careportal', function ( ) {
 
   });
 
-  it('uses local timezone date, not UTC, when saving an other-time treatment (8304)', function () {
+  [
+    {
+      time: '2024-10-25T23:00:00-05:00'
+      , expectedDate: '2024-10-25'
+      , expectedTime: '23:00'
+      , utcDate: '2024-10-26'
+    }
+    , {
+      time: '2024-10-26T01:00:00+03:00'
+      , expectedDate: '2024-10-26'
+      , expectedTime: '01:00'
+      , utcDate: '2024-10-25'
+    }
+  ].forEach(function eachCase (testCase) {
+    it('uses local timezone date, not UTC, when saving an other-time treatment (8304) ' + testCase.time, function () {
+      var client = window.Nightscout.client;
+      client.init();
+      mockMomentNow(client, testCase.time);
+
+      client.careportal.prepare();
+
+      $('#eventDateValue').val().should.equal(testCase.expectedDate);
+      $('#eventTimeValue').val().should.equal(testCase.expectedTime);
+
+      $('#eventType').val('BG Check');
+      $('#glucoseValue').val('100');
+      selectRadio('#nowtime', '#othertime');
+      client.careportal.eventTimeTypeChange();
+
+      var mocks = mockTreatmentPost();
+
+      try {
+        client.careportal.save();
+      } finally {
+        restoreTreatmentPost(mocks);
+      }
+
+      var expectedCreatedAt = client.utils.mergeInputTime(testCase.expectedTime, testCase.expectedDate).toDate().toISOString();
+
+      mocks.treatment.eventType.should.equal('BG Check');
+      mocks.treatment.created_at.should.equal(expectedCreatedAt);
+      mocks.treatment.created_at.should.not.equal(client.utils.mergeInputTime(testCase.expectedTime, testCase.utcDate).toDate().toISOString());
+    });
+  });
+
+  it('uses local timezone date, not UTC, when saving a boluscalc other-time treatment', function () {
     var client = window.Nightscout.client;
     client.init();
+    client.dataUpdate(boluscalcData, true);
+    mockMomentNow(client, '2024-10-26T01:00:00+03:00');
 
-    var fakeNow = moment.parseZone('2024-10-25T23:00:00-05:00');
-    client.ctx.moment = function mockMoment () {
-      return fakeNow.clone();
-    };
+    client.boluscalc.prepare();
 
-    client.careportal.prepare();
+    $('#bc_eventDateValue').val().should.equal('2024-10-26');
+    $('#bc_eventTimeValue').val().should.equal('01:00');
 
-    $('#eventDateValue').val().should.equal('2024-10-25');
-    $('#eventTimeValue').val().should.equal('23:00');
+    $('#bc_bg').val('100');
+    $('#bc_carbs').val('10');
+    selectRadio('#bc_nowtime', '#bc_othertime');
+    client.boluscalc.eventTimeTypeChange();
 
-    $('#eventType').val('BG Check');
-    $('#glucoseValue').val('100');
-    $('#nowtime').removeAttr('checked').prop('checked', false);
-    $('#othertime').attr('checked', 'checked').prop('checked', true);
-    client.careportal.eventTimeTypeChange();
-
-    var originalAjax = $.ajax;
-    var originalConfirm = window.confirm;
-    var originalAlert = window.alert;
-    var postedTreatment;
-
-    $.ajax = function mockAjax (request) {
-      postedTreatment = request.data;
-
-      return {
-        done: function mockDone (fn) {
-          fn({message: 'OK'});
-          return this;
-        }
-        , fail: function mockFail () {
-          return this;
-        }
-      };
-    };
-
-    window.confirm = function mockConfirm () {
-      return true;
-    };
-    window.alert = function mockAlert (messages) {
-      messages.should.equal('');
-    };
+    var mocks = mockTreatmentPost();
 
     try {
-      client.careportal.save();
+      client.boluscalc.submit();
     } finally {
-      $.ajax = originalAjax;
-      window.confirm = originalConfirm;
-      window.alert = originalAlert;
+      restoreTreatmentPost(mocks);
     }
 
-    var expectedCreatedAt = client.utils.mergeInputTime('23:00', '2024-10-25').toDate().toISOString();
+    var expectedEventTime = client.utils.mergeInputTime('01:00', '2024-10-26').toDate().toISOString();
+    var utcShiftedEventTime = client.utils.mergeInputTime('01:00', '2024-10-25').toDate().toISOString();
 
-    postedTreatment.eventType.should.equal('BG Check');
-    postedTreatment.created_at.should.equal(expectedCreatedAt);
-    postedTreatment.created_at.should.not.equal(client.utils.mergeInputTime('23:00', '2024-10-26').toDate().toISOString());
+    mocks.treatment.eventType.should.equal('Bolus Wizard');
+    mocks.treatment.eventTime.toISOString().should.equal(expectedEventTime);
+    mocks.treatment.boluscalc.eventTime.should.equal(expectedEventTime);
+    mocks.treatment.boluscalc.eventTime.should.not.equal(utcShiftedEventTime);
   });
 
 });

--- a/tests/careportal.test.js
+++ b/tests/careportal.test.js
@@ -2,7 +2,7 @@
 
 require('should');
 var benv = require('benv');
-const moment = require("moment/moment");
+var moment = require('moment');
 
 var nowData = {
   sgvs: [
@@ -99,17 +99,65 @@ describe('careportal', function ( ) {
 
   });
 
-  it('uses local timezone date, not UTC (8304) ', async () =>{
-    const client = window.Nightscout.client;
+  it('uses local timezone date, not UTC, when saving an other-time treatment (8304)', function () {
+    var client = window.Nightscout.client;
     client.init();
-    // sleep(50);
 
-    const fakeNow = moment.parseZone('2024-10-25T23:00:00-05:00');
-    client.ctx.moment = () => (fakeNow);
+    var fakeNow = moment.parseZone('2024-10-25T23:00:00-05:00');
+    client.ctx.moment = function mockMoment () {
+      return fakeNow.clone();
+    };
 
     client.careportal.prepare();
 
     $('#eventDateValue').val().should.equal('2024-10-25');
+    $('#eventTimeValue').val().should.equal('23:00');
+
+    $('#eventType').val('BG Check');
+    $('#glucoseValue').val('100');
+    $('#nowtime').removeAttr('checked').prop('checked', false);
+    $('#othertime').attr('checked', 'checked').prop('checked', true);
+    client.careportal.eventTimeTypeChange();
+
+    var originalAjax = $.ajax;
+    var originalConfirm = window.confirm;
+    var originalAlert = window.alert;
+    var postedTreatment;
+
+    $.ajax = function mockAjax (request) {
+      postedTreatment = request.data;
+
+      return {
+        done: function mockDone (fn) {
+          fn({message: 'OK'});
+          return this;
+        }
+        , fail: function mockFail () {
+          return this;
+        }
+      };
+    };
+
+    window.confirm = function mockConfirm () {
+      return true;
+    };
+    window.alert = function mockAlert (messages) {
+      messages.should.equal('');
+    };
+
+    try {
+      client.careportal.save();
+    } finally {
+      $.ajax = originalAjax;
+      window.confirm = originalConfirm;
+      window.alert = originalAlert;
+    }
+
+    var expectedCreatedAt = client.utils.mergeInputTime('23:00', '2024-10-25').toDate().toISOString();
+
+    postedTreatment.eventType.should.equal('BG Check');
+    postedTreatment.created_at.should.equal(expectedCreatedAt);
+    postedTreatment.created_at.should.not.equal(client.utils.mergeInputTime('23:00', '2024-10-26').toDate().toISOString());
   });
 
 });


### PR DESCRIPTION
Resolves #8304

Not sure what the 50ms sleep (see line 105 copied from line 61) is for - tests pass on my machine without it. Should I uncomment it or remove it?