### PR TITLE
build status badge: Travis CI -> GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 [![Coverage Status](https://coveralls.io/repos/github/nightscout/cgm-remote-monitor/badge.svg?branch=master)](https://coveralls.io/github/nightscout/cgm-remote-monitor?branch=master)
 
-[build-img]: https://img.shields.io/travis/nightscout/cgm-remote-monitor.svg
-[build-url]: https://travis-ci.org/nightscout/cgm-remote-monitor
+
+
+[build-img]: https://img.shields.io/github/actions/workflow/status/nightscout/cgm-remote-monitor/main.yml
+[build-url]: https://github.com/nightscout/cgm-remote-monitor/actions/workflows/main.yml
 [dependency-img]: https://img.shields.io/david/nightscout/cgm-remote-monitor.svg
 [dependency-url]: https://david-dm.org/nightscout/cgm-remote-monitor
 [coverage-img]: https://img.shields.io/coveralls/nightscout/cgm-remote-monitor/dev.svg


### PR DESCRIPTION
This updates the build status badge, replacing the outdated one from Travis CI with the current one from GitHub Actions.

CI builds were migrated from Travis CI to GitHub Actions in #6690.  The [old Travis CI build][1] is no longer used.  This causes the [old Travis CI badge][2] on shields.io to 404.

The new GitHub Actions build can be found under the [`main.yml`][3] workflow. [Its badge][4] is available on shields.io.

[1]: https://app.travis-ci.com/github/nightscout/cgm-remote-monitor/builds
[2]: https://img.shields.io/travis/nightscout/cgm-remote-monitor.svg
[3]: https://github.com/nightscout/cgm-remote-monitor/actions/workflows/main.yml
[4]: https://img.shields.io/github/actions/workflow/status/nightscout/cgm-remote-monitor/main.yml