### PR TITLE
Drop the deprecated Codacy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Nightscout Web Monitor (a.k.a. cgm-remote-monitor)
 [![Build Status][build-img]][build-url]
 [![Dependency Status][dependency-img]][dependency-url]
 [![Coverage Status][coverage-img]][coverage-url]
-[![Codacy Badge][codacy-img]][codacy-url]
 [![Discord chat][discord-img]][discord-url]
 
 This acts as a web-based CGM (Continuous Glucose Monitor) to allow
@@ -42,8 +41,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 [dependency-url]: https://david-dm.org/nightscout/cgm-remote-monitor
 [coverage-img]: https://img.shields.io/coveralls/nightscout/cgm-remote-monitor/dev.svg
 [coverage-url]: https://coveralls.io/github/nightscout/cgm-remote-monitor?branch=master
-[codacy-img]: https://www.codacy.com/project/badge/f79327216860472dad9afda07de39d3b
-[codacy-url]: https://www.codacy.com/app/Nightscout/cgm-remote-monitor
 [discord-img]: https://img.shields.io/discord/629952586895851530?label=discord%20chat
 [discord-url]: https://discord.gg/rTKhrqz
 [heroku-img]: https://www.herokucdn.com/deploy/button.png


### PR DESCRIPTION
This drops the Codacy badge, which was added back in [6c84eac].  Since the integration [no longer exists][1], the badge is broken and can be removed.

Fixes #8289

[6c84eac]: https://github.com/nightscout/cgm-remote-monitor/commit/6c84eac
[1]: https://www.codacy.com/project/badge/f79327216860472dad9afda07de39d3b