### PR TITLE
Add an icon to toggle wake lock of the display

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
         - [`ar2` (AR2 Forecasting)](#ar2-ar2-forecasting)
         - [`simplealarms` (Simple BG Alarms)](#simplealarms-simple-bg-alarms)
         - [`profile` (Treatment Profile)](#profile-treatment-profile)
+        - [`wake-lock` (Wake Lock)](#wake-lock-wake-lock)
       - [Advanced Plugins:](#advanced-plugins)
         - [`careportal` (Careportal)](#careportal-careportal)
         - [`boluscalc` (Bolus Wizard)](#boluscalc-bolus-wizard)
@@ -417,6 +418,10 @@ autonomy for your data:
   Add link to Profile Editor and allow to enter treatment profile settings. Also uses the extended setting:
   * `PROFILE_HISTORY` (`off`) - possible values `on` or `off`. Enable/disable NS ability to keep history of your profiles (still experimental)
   * `PROFILE_MULTIPLE` (`off`) - possible values `on` or `off`. Enable/disable NS ability to handle and switch between multiple treatment profiles
+
+##### `wake-lock` (Wake Lock)
+
+  Add an icon that, when clicked, toggles [Screen Wake Lock](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) to prevent the display from sleeping or locking.
 
 #### Advanced Plugins:
 

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1391,6 +1391,11 @@ client.load = function load (serverSettings, callback) {
       chart.updateContext();
     }
   }
+
+  if (client.settings.isEnabled('wake-lock')) {
+    require('./wake-lock')($);
+  }
+
 };
 
 module.exports = client;

--- a/lib/client/wake-lock.js
+++ b/lib/client/wake-lock.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const init = ($) => {
+
+  // whether the browser supports wake lock
+  const isWakeLockSupported = 'wakeLock' in navigator;
+
+  if (isWakeLockSupported) {
+
+    const showWakeLockEnabled = () => {
+      $('#wakeLockIcon').attr('class', 'icon-sun');
+    };
+
+    const showWakeLockDisabled = () => {
+      $('#wakeLockIcon').attr('class', 'icon-moon');
+    };
+
+    // the currently enabled wake lock, if any
+    let wakeLockSentinel = null;
+
+    // enable or reacquire wake lock
+    const enableWakeLock = () => {
+      navigator.wakeLock.request('screen')
+        .then((x) => {
+          wakeLockSentinel = x;
+          wakeLockSentinel
+            .addEventListener('release', () => {
+              showWakeLockDisabled();
+            });
+          showWakeLockEnabled();
+        })
+        .catch((e) => {
+          if (wakeLockSentinel === null || wakeLockSentinel.released) {
+            showWakeLockDisabled();
+          } else {
+            showWakeLockEnabled();
+          }
+        });
+    };
+
+    // release wake lock, if present
+    const disableWakeLock = () => {
+      if (wakeLockSentinel !== null) {
+        wakeLockSentinel.release()
+          .then(() => {
+            wakeLockSentinel = null;
+            showWakeLockDisabled();
+          })
+          .catch((e) => {
+            if (wakeLockSentinel === null || wakeLockSentinel.released) {
+              showWakeLockDisabled();
+            } else {
+              showWakeLockEnabled();
+            }
+          });
+      }
+    };
+
+    // determine whether the browser window is currently visible
+    const isBrowserVisible = () => {
+      return document.visibilityState === 'visible';
+    };
+
+    // whether the user has clicked on the wake lock icon
+    let isWakeLockRequested = false;
+
+    // enable or disable wake lock, as appropriate
+    const updateWakeLock = () => {
+      if (isWakeLockRequested && isBrowserVisible()) {
+        enableWakeLock();
+      } else {
+        disableWakeLock();
+      }
+    };
+
+    // re-setup the wake lock whenever the window visibility changes
+    document.addEventListener('visibilitychange', updateWakeLock);
+
+    // set up the click event handler for the wake lock icon
+    $('#wakeLock')
+      .click((event) => {
+        isWakeLockRequested = !isWakeLockRequested;
+        updateWakeLock();
+        event.preventDefault();
+      });
+
+    // now that everything is set up, make the wake lock icon visible
+    $('#wakeLock').show();
+  }
+};
+
+module.exports = init;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -82,6 +82,8 @@
 .icon-sort-numeric:before { content: '\f162'; }
 .icon-chart-line:before { content: '\f201'; }
 .icon-hourglass:before { content: '\f254'; }
+.icon-moon:before { content: '\263e'; }
+.icon-sun:before { content: '\2600'; }
 
 /* Plugin Icons id-s (copy from generated icon style.css) */
 .plugicon-database:before { content: "\e901"; }

--- a/views/partials/toolbar.ejs
+++ b/views/partials/toolbar.ejs
@@ -21,6 +21,7 @@
             <a id="treatmentDrawerToggle" class="tip" original-title="Care Portal" aria-label="Care Portal" href="#" style="display:none;"><i class="icon-plus"></i></a>
             <a id="lockedToggle" class="tip" original-title="Token needed for Care Portal" aria-label="Token needed for Care Portal" href="#" style="display:none;"><i class="icon-lock"></i></a>
             <a id="drawerToggle" class="tip" original-title="Settings" aria-label="Settings" href="#"><i class="icon-menu"></i></a>
+            <a id="wakeLock" class="tip" original-title="Wake Lock" aria-label="Wake Lock" href="#" style="display:none;"><i id="wakeLockIcon" class="icon-moon"></i></a>
             <a id="testAlarms" class="tip" original-title="Alarm Test / Smartphone Enable" aria-label="Alarm Test / Smartphone Enable" href="#"><i class="icon-volume"></i></a>
             <a id="editbutton" class="tip" original-title="Edit Mode" aria-label="Edit Mode" href="#" style="display:none;"><i class="icon-edit"></i></a>
             <a id="adminnotifies" class="tip" original-title="Admin ntofications" aria-label="Admin notifications" href="#" style="display:none;"><i class="plugicon-notifies" style='color: #c91515'></i></a>


### PR DESCRIPTION
This adds the Wake Lock plugin, which adds a clickable sun/moon icon to the toolbar to toggle wake lock using the [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API):

<img width="161" height="25" alt="unlocked" src="https://github.com/user-attachments/assets/2a2299ea-7150-44f0-b3d2-f237e989c4f2" />
<br>
<img width="161" height="25" alt="locked" src="https://github.com/user-attachments/assets/213e932e-d3b6-490d-9942-ef9df851bfcc" />

The plugin must be enabled by the user by setting `ENABLE=wake-lock`.