### PR TITLE
Add date params to profile query

### DIFF
--- a/lib/server/profile.js
+++ b/lib/server/profile.js
@@ -38,6 +38,11 @@ function storage (collection, ctx) {
       , dateField: 'startDate'
     };
 
+    // If user provides explicit date filters, don't enforce default date filter
+    if (opts && opts.find && opts.find.startDate) {
+      storage.queryOpts.noDateFilter = true;
+    }
+
     function limit () {
         if (opts && opts.count) {
             return this.limit(parseInt(opts.count));

--- a/lib/server/swagger.json
+++ b/lib/server/swagger.json
@@ -685,6 +685,57 @@
         }
       }
     },
+    "/profiles": {
+      "get": {
+        "summary": "Profiles",
+        "description": "The Profiles endpoint returns information about the Nightscout Treatment Profiles with support for filtering and pagination.",
+        "tags": [
+          "Profile"
+        ],
+        "parameters": [
+          {
+            "name": "find",
+            "in": "query",
+            "description": "The query used to find profiles, support nested query syntax, for example `find[startDate][$gte]=2015-08-27` or `find[startDate][$lte]=2015-08-27`. All find parameters are interpreted as strings.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of profiles to return.",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of profiles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Profile"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/status": {
       "get": {
         "summary": "Status",

--- a/lib/server/swagger.yaml
+++ b/lib/server/swagger.yaml
@@ -519,6 +519,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /profiles:
+    get:
+      summary: Profiles
+      description: >-
+        The Profiles endpoint returns information about the Nightscout Treatment
+        Profiles with support for filtering and pagination.
+      tags:
+        - Profile
+      parameters:
+        - name: find
+          in: query
+          description: >-
+            The query used to find profiles, support nested query syntax, for
+            example `find[startDate][$gte]=2015-08-27` or `find[startDate][$lte]=2015-08-27`.
+            All find parameters are interpreted as strings.
+          required: false
+          schema:
+            type: string
+        - name: count
+          in: query
+          description: Number of profiles to return.
+          required: false
+          schema:
+            type: number
+      responses:
+        '200':
+          description: An array of profiles
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /status:
     get:
       summary: Status


### PR DESCRIPTION
This PR adds date filtering support to the /profiles endpoint and updates the API documentation.
## Changes
* Date filtering support: When startDate is provided in the query, the default date filter is bypassed, allowing custom date ranges.
* API documentation: Adds Swagger/OpenAPI docs for /profiles with:
find parameter supporting nested query syntax (e.g., find[startDate][$gte]=2015-08-27 or find[startDate][$lte]=2015-08-27)
* count parameter for pagination
## Technical Details
The implementation checks if opts.find.startDate is provided and sets storage.queryOpts.noDateFilter = true to disable the default date filter, giving users full control over date range queries.
## Files Changed
* lib/server/profile.js - Added logic to handle explicit date filters
* lib/server/swagger.json - Added /profiles endpoint documentation
* lib/server/swagger.yaml - Added /profiles endpoint documentation
This enables querying profiles by custom date ranges via the API.