### PR TITLE
Add server-only webhook plugin with deduplication

### DIFF
--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -67,6 +67,7 @@ function init (ctx) {
     , require('./basalprofile')(ctx)
     , require('./dbsize')(ctx)
     , require('./runtimestate')(ctx)
+    , require('./webhook')(ctx) // NEW: Webhook plugin to send SGV updates to a local server address (e.g. Raspberry Pi)
   ];
 
   plugins.registerServerDefaults = function registerServerDefaults () {

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -43,6 +43,7 @@ function init (ctx) {
     , require('./dbsize')(ctx)
   ];
 
+  /*
   var serverDefaultPlugins = [
     require('./bgnow')(ctx)
     , require('./rawbg')(ctx)
@@ -69,12 +70,57 @@ function init (ctx) {
     , require('./runtimestate')(ctx)
     , require('./webhook')(ctx) // NEW: Webhook plugin to send SGV updates to a local server address (e.g. Raspberry Pi)
   ];
+*/
 
+  function getServerDefaultPlugins () {
+    var plugins = [
+      require('./bgnow')(ctx)
+      , require('./rawbg')(ctx)
+      , require('./direction')(ctx)
+      , require('./upbat')(ctx)
+      , require('./ar2')(ctx)
+      , require('./simplealarms')(ctx)
+      , require('./errorcodes')(ctx)
+      , require('./iob')(ctx)
+      , require('./cob')(ctx)
+      , require('./pump')(ctx)
+      , require('./openaps')(ctx)
+      , require('./xdripjs')(ctx)
+      , require('./loop')(ctx)
+      , require('./boluswizardpreview')(ctx)
+      , require('./cannulaage')(ctx)
+      , require('./sensorage')(ctx)
+      , require('./insulinage')(ctx)
+      , require('./batteryage')(ctx)
+      , require('./treatmentnotify')(ctx)
+      , require('./timeago')(ctx)
+      , require('./basalprofile')(ctx)
+      , require('./dbsize')(ctx)
+      , require('./runtimestate')(ctx)
+    ];
+
+  // Only load webhook plugin in Node/server (avoid webpack/browser bundling).
+  // NOTE: Use eval('require') so webpack won't statically include './webhook' in the client bundle.
+  if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+      var req = eval('require');
+      plugins.push(req('./webhook')(ctx));
+    }
+
+    return plugins;
+  }
+
+  /*
   plugins.registerServerDefaults = function registerServerDefaults () {
     plugins.register(serverDefaultPlugins);
     return plugins;
   };
+*/
 
+  plugins.registerServerDefaults = function registerServerDefaults () {
+    plugins.register(getServerDefaultPlugins());
+    return plugins;
+  };
+  
   plugins.registerClientDefaults = function registerClientDefaults () {
     plugins.register(clientDefaultPlugins);
     return plugins;

--- a/lib/plugins/webhook.js
+++ b/lib/plugins/webhook.js
@@ -22,7 +22,7 @@
 // - Deduplicates by timestamp so it triggers once per new SGV.
 // ==================================================================
 
-module.exports = function webhookPlugin(env) {
+module.exports = function webhookPlugin() {
   // ------------------------------------------------------------------
   // Configuration
   // ------------------------------------------------------------------

--- a/lib/plugins/webhook.js
+++ b/lib/plugins/webhook.js
@@ -7,11 +7,13 @@
 // (glucose) value is available in Nightscout.
 //
 // Configure via environment variables:
-//   WEBHOOK_HOST  (default: localhost)
-//   WEBHOOK_PORT  (default: 3000)
-//   WEBHOOK_PATH  (default: /nightscout)
+//   WEBHOOK_PROTOCOL  (default: http)
+//   WEBHOOK_HOST      (default: localhost)
+//   WEBHOOK_PORT      (default: 3000)
+//   WEBHOOK_PATH      (default: /nightscout)
 //
 // Example:
+//   WEBHOOK_PROTOCOL=https
 //   WEBHOOK_HOST=192.168.10.5
 //   WEBHOOK_PORT=33333
 //   WEBHOOK_PATH=/nightscout
@@ -20,16 +22,22 @@
 // - This is a server-side Nightscout plugin.
 // - Uses sbx helper methods (lastSGVMgdl / lastSGVMills) for stability.
 // - Deduplicates by timestamp so it triggers once per new SGV.
+// - The SGV present at startup is skipped; only readings ingested after
+//   the process starts will fire a webhook.
+// - lastSentMills is updated only after a successful (2xx) response,
+//   providing at-least-once delivery: a failed request will be retried
+//   on the next checkNotifications cycle.
 // ==================================================================
 
 module.exports = function webhookPlugin() {
   // ------------------------------------------------------------------
   // Configuration
   // ------------------------------------------------------------------
+  const WEBHOOK_PROTOCOL = process.env.WEBHOOK_PROTOCOL || 'http';
   const WEBHOOK_HOST = process.env.WEBHOOK_HOST || 'localhost';
   const WEBHOOK_PORT = process.env.WEBHOOK_PORT || '3000';
   const WEBHOOK_PATH = process.env.WEBHOOK_PATH || '/nightscout';
-  const WEBHOOK_URL = `http://${WEBHOOK_HOST}:${WEBHOOK_PORT}${WEBHOOK_PATH}`;
+  const WEBHOOK_URL = `${WEBHOOK_PROTOCOL}://${WEBHOOK_HOST}:${WEBHOOK_PORT}${WEBHOOK_PATH}`;
 
   const WEBHOOK_TIMEOUT_MS = 5000;
 
@@ -37,13 +45,18 @@ module.exports = function webhookPlugin() {
   const https = require('https');
   const url = require('url');
 
-  // Used to prevent sending duplicate webhooks for the same SGV.
+  // mills of the last SGV for which a webhook was successfully delivered.
   let lastSentMills = null;
+  // mills of a request currently in flight; prevents duplicate concurrent sends.
+  let pendingMills = null;
+  // true after the first checkNotifications call; suppresses the startup SGV.
+  let initialized = false;
 
   // ------------------------------------------------------------------
-  // Send HTTP POST JSON webhook
+  // Send HTTP/HTTPS POST JSON webhook
+  // Exposed on the returned object so tests can replace it.
   // ------------------------------------------------------------------
-  function sendWebhook(payload) {
+  function sendWebhook(payload, onSuccess, onFailure) {
     const parsed = url.parse(WEBHOOK_URL);
     const protocol = parsed.protocol === 'https:' ? https : http;
 
@@ -64,21 +77,25 @@ module.exports = function webhookPlugin() {
     const req = protocol.request(options, (res) => {
       // Drain response to avoid socket issues in some Node versions.
       res.on('data', () => {});
-      res.on('end', () => {});
-
-      // Keep logs minimal but useful for ops.
-      if (res.statusCode !== 200) {
-        console.warn('[Webhook] Non-200 response from webhook endpoint:', res.statusCode);
-      }
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          onSuccess();
+        } else {
+          console.warn('[Webhook] Non-2xx response from webhook endpoint:', res.statusCode);
+          onFailure();
+        }
+      });
     });
 
     req.on('error', (err) => {
       console.error('[Webhook] Webhook request failed:', err.message);
+      onFailure();
     });
 
     req.on('timeout', () => {
       console.error('[Webhook] Webhook request timed out after', WEBHOOK_TIMEOUT_MS, 'ms');
       req.destroy();
+      // onFailure will be called via the 'error' event that destroy() triggers.
     });
 
     req.write(body);
@@ -91,18 +108,24 @@ module.exports = function webhookPlugin() {
   function checkNotifications(sbx) {
     if (!sbx) return;
 
-    // Stable, server-side accessors for SGV and timestamp (ms).
     const mgdl = typeof sbx.lastSGVMgdl === 'function' ? sbx.lastSGVMgdl() : null;
     const mills = typeof sbx.lastSGVMills === 'function' ? sbx.lastSGVMills() : null;
 
-    // If we don't have a valid SGV yet, do nothing.
     if (!mgdl || !mills) return;
 
-    // Deduplicate by timestamp (one webhook per new SGV).
-    if (lastSentMills === mills) return;
-    lastSentMills = mills;
+    // On first call after startup, record the current SGV as already seen
+    // so we do not fire a webhook for a reading that pre-dates this process.
+    if (!initialized) {
+      lastSentMills = mills;
+      initialized = true;
+      return;
+    }
 
-    // Minimal payload; the iOS app can fetch details from Nightscout if needed.
+    // Skip if already successfully delivered or a request is in flight.
+    if (mills === lastSentMills || mills === pendingMills) return;
+
+    pendingMills = mills;
+
     const payload = {
       source: 'nightscout',
       mgdl,
@@ -110,23 +133,39 @@ module.exports = function webhookPlugin() {
       iso: new Date(mills).toISOString()
     };
 
-    sendWebhook(payload);
+    // Use plugin.sendWebhook so tests can replace it.
+    plugin.sendWebhook(
+      payload,
+      function onSuccess() {
+        lastSentMills = mills;
+        if (pendingMills === mills) pendingMills = null;
+      },
+      function onFailure() {
+        // Clear pendingMills so the next cycle can retry.
+        if (pendingMills === mills) pendingMills = null;
+      }
+    );
   }
 
   // ------------------------------------------------------------------
   // Plugin metadata
   // ------------------------------------------------------------------
-  return {
+  const plugin = {
     name: 'webhook',
     label: 'Webhook Notifier',
     pluginType: 'notification',
 
-    // Called once when plugin initializes
+    // Called once when the plugin initializes.
     init: function () {
       console.log('[Webhook] Enabled. Sending webhooks to:', WEBHOOK_URL);
     },
 
-    // Called periodically by Nightscout
+    // Replaceable in tests.
+    sendWebhook,
+
+    // Called periodically by Nightscout.
     checkNotifications
   };
+
+  return plugin;
 };

--- a/lib/plugins/webhook.js
+++ b/lib/plugins/webhook.js
@@ -1,0 +1,132 @@
+'use strict';
+
+// ==================================================================
+// NIGHTSCOUT PLUGIN: Webhook Notifier
+// ==================================================================
+// Sends an HTTP POST webhook to a local server whenever a NEW SGV
+// (glucose) value is available in Nightscout.
+//
+// Configure via environment variables:
+//   WEBHOOK_HOST  (default: localhost)
+//   WEBHOOK_PORT  (default: 3000)
+//   WEBHOOK_PATH  (default: /nightscout)
+//
+// Example:
+//   WEBHOOK_HOST=192.168.10.5
+//   WEBHOOK_PORT=33333
+//   WEBHOOK_PATH=/nightscout
+//
+// Notes:
+// - This is a server-side Nightscout plugin.
+// - Uses sbx helper methods (lastSGVMgdl / lastSGVMills) for stability.
+// - Deduplicates by timestamp so it triggers once per new SGV.
+// ==================================================================
+
+module.exports = function webhookPlugin(env) {
+  // ------------------------------------------------------------------
+  // Configuration
+  // ------------------------------------------------------------------
+  const WEBHOOK_HOST = process.env.WEBHOOK_HOST || 'localhost';
+  const WEBHOOK_PORT = process.env.WEBHOOK_PORT || '3000';
+  const WEBHOOK_PATH = process.env.WEBHOOK_PATH || '/nightscout';
+  const WEBHOOK_URL = `http://${WEBHOOK_HOST}:${WEBHOOK_PORT}${WEBHOOK_PATH}`;
+
+  const WEBHOOK_TIMEOUT_MS = 5000;
+
+  const http = require('http');
+  const https = require('https');
+  const url = require('url');
+
+  // Used to prevent sending duplicate webhooks for the same SGV.
+  let lastSentMills = null;
+
+  // ------------------------------------------------------------------
+  // Send HTTP POST JSON webhook
+  // ------------------------------------------------------------------
+  function sendWebhook(payload) {
+    const parsed = url.parse(WEBHOOK_URL);
+    const protocol = parsed.protocol === 'https:' ? https : http;
+
+    const body = JSON.stringify(payload);
+
+    const options = {
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.path,
+      method: 'POST',
+      timeout: WEBHOOK_TIMEOUT_MS,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body)
+      }
+    };
+
+    const req = protocol.request(options, (res) => {
+      // Drain response to avoid socket issues in some Node versions.
+      res.on('data', () => {});
+      res.on('end', () => {});
+
+      // Keep logs minimal but useful for ops.
+      if (res.statusCode !== 200) {
+        console.warn('[Webhook] Non-200 response from webhook endpoint:', res.statusCode);
+      }
+    });
+
+    req.on('error', (err) => {
+      console.error('[Webhook] Webhook request failed:', err.message);
+    });
+
+    req.on('timeout', () => {
+      console.error('[Webhook] Webhook request timed out after', WEBHOOK_TIMEOUT_MS, 'ms');
+      req.destroy();
+    });
+
+    req.write(body);
+    req.end();
+  }
+
+  // ------------------------------------------------------------------
+  // Nightscout lifecycle hook: called periodically
+  // ------------------------------------------------------------------
+  function checkNotifications(sbx) {
+    if (!sbx) return;
+
+    // Stable, server-side accessors for SGV and timestamp (ms).
+    const mgdl = typeof sbx.lastSGVMgdl === 'function' ? sbx.lastSGVMgdl() : null;
+    const mills = typeof sbx.lastSGVMills === 'function' ? sbx.lastSGVMills() : null;
+
+    // If we don't have a valid SGV yet, do nothing.
+    if (!mgdl || !mills) return;
+
+    // Deduplicate by timestamp (one webhook per new SGV).
+    if (lastSentMills === mills) return;
+    lastSentMills = mills;
+
+    // Minimal payload; the iOS app can fetch details from Nightscout if needed.
+    const payload = {
+      source: 'nightscout',
+      mgdl,
+      mills,
+      iso: new Date(mills).toISOString()
+    };
+
+    sendWebhook(payload);
+  }
+
+  // ------------------------------------------------------------------
+  // Plugin metadata
+  // ------------------------------------------------------------------
+  return {
+    name: 'webhook',
+    label: 'Webhook Notifier',
+    pluginType: 'notification',
+
+    // Called once when plugin initializes
+    init: function () {
+      console.log('[Webhook] Enabled. Sending webhooks to:', WEBHOOK_URL);
+    },
+
+    // Called periodically by Nightscout
+    checkNotifications
+  };
+};

--- a/tests/webhook.test.js
+++ b/tests/webhook.test.js
@@ -1,0 +1,207 @@
+'use strict';
+
+var should = require('should');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSbx(mgdl, mills) {
+  return {
+    lastSGVMgdl: function () { return mgdl; },
+    lastSGVMills: function () { return mills; }
+  };
+}
+
+// Create a fresh plugin instance for each test so internal state is isolated.
+function makePlugin() {
+  // Clear the require cache so each call returns a brand-new closure.
+  delete require.cache[require.resolve('../lib/plugins/webhook')];
+  return require('../lib/plugins/webhook')();
+}
+
+// ---------------------------------------------------------------------------
+// Startup behaviour
+// ---------------------------------------------------------------------------
+
+describe('webhook – startup behaviour', function () {
+
+  it('does not send a webhook for the SGV that is already present at startup', function () {
+    var plugin = makePlugin();
+    var sent = 0;
+    plugin.sendWebhook = function () { sent++; };
+
+    plugin.checkNotifications(makeSbx(120, 1000));
+    sent.should.equal(0);
+  });
+
+  it('sends a webhook for the first NEW SGV after startup', function (done) {
+    var plugin = makePlugin();
+
+    // First call – existing reading, should be skipped.
+    plugin.checkNotifications(makeSbx(120, 1000));
+
+    plugin.sendWebhook = function (payload, onSuccess) {
+      payload.mills.should.equal(2000);
+      onSuccess();
+      done();
+    };
+
+    // Second call – new reading.
+    plugin.checkNotifications(makeSbx(130, 2000));
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+describe('webhook – deduplication', function () {
+
+  it('sends only once for the same SGV timestamp', function () {
+    var plugin = makePlugin();
+    var sent = 0;
+
+    // Initialise (skip startup SGV).
+    plugin.checkNotifications(makeSbx(120, 1000));
+
+    plugin.sendWebhook = function (payload, onSuccess) {
+      sent++;
+      onSuccess();
+    };
+
+    plugin.checkNotifications(makeSbx(130, 2000));
+    plugin.checkNotifications(makeSbx(130, 2000));
+    plugin.checkNotifications(makeSbx(130, 2000));
+
+    sent.should.equal(1);
+  });
+
+  it('does not send a second request while one is still in flight', function () {
+    var plugin = makePlugin();
+    var sent = 0;
+
+    plugin.checkNotifications(makeSbx(120, 1000));
+
+    // Capture onSuccess but do NOT call it yet – request is in flight.
+    var pendingSuccess;
+    plugin.sendWebhook = function (payload, onSuccess) {
+      sent++;
+      pendingSuccess = onSuccess;
+    };
+
+    plugin.checkNotifications(makeSbx(130, 2000));
+    plugin.checkNotifications(makeSbx(130, 2000)); // should be a no-op
+
+    sent.should.equal(1);
+
+    // Resolve the in-flight request.
+    pendingSuccess();
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Retry on failure (at-least-once semantics)
+// ---------------------------------------------------------------------------
+
+describe('webhook – retry after failure', function () {
+
+  it('retries the same SGV after a failed request', function () {
+    var plugin = makePlugin();
+    var attempts = 0;
+
+    plugin.checkNotifications(makeSbx(120, 1000));
+
+    plugin.sendWebhook = function (payload, onSuccess, onFailure) {
+      attempts++;
+      if (attempts === 1) {
+        onFailure(); // Simulate a network error on first attempt.
+      } else {
+        onSuccess();
+      }
+    };
+
+    plugin.checkNotifications(makeSbx(130, 2000)); // attempt 1 – fails
+    plugin.checkNotifications(makeSbx(130, 2000)); // attempt 2 – succeeds
+    plugin.checkNotifications(makeSbx(130, 2000)); // attempt 3 – skipped (already sent)
+
+    attempts.should.equal(2);
+  });
+
+  it('does not retry after a successful delivery', function () {
+    var plugin = makePlugin();
+    var attempts = 0;
+
+    plugin.checkNotifications(makeSbx(120, 1000));
+
+    plugin.sendWebhook = function (payload, onSuccess) {
+      attempts++;
+      onSuccess();
+    };
+
+    plugin.checkNotifications(makeSbx(130, 2000));
+    plugin.checkNotifications(makeSbx(130, 2000));
+
+    attempts.should.equal(1);
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Payload shape
+// ---------------------------------------------------------------------------
+
+describe('webhook – payload', function () {
+
+  it('includes mgdl, mills, iso, and source fields', function (done) {
+    var plugin = makePlugin();
+
+    plugin.checkNotifications(makeSbx(120, 1000)); // initialise
+
+    plugin.sendWebhook = function (payload, onSuccess) {
+      payload.source.should.equal('nightscout');
+      payload.mgdl.should.equal(130);
+      payload.mills.should.equal(2000);
+      payload.iso.should.equal(new Date(2000).toISOString());
+      onSuccess();
+      done();
+    };
+
+    plugin.checkNotifications(makeSbx(130, 2000));
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('webhook – edge cases', function () {
+
+  it('does nothing when sbx is null', function () {
+    var plugin = makePlugin();
+    var sent = 0;
+    plugin.sendWebhook = function () { sent++; };
+    plugin.checkNotifications(null);
+    sent.should.equal(0);
+  });
+
+  it('does nothing when mgdl is missing', function () {
+    var plugin = makePlugin();
+    var sent = 0;
+    plugin.sendWebhook = function () { sent++; };
+    plugin.checkNotifications(makeSbx(null, 1000));
+    sent.should.equal(0);
+  });
+
+  it('does nothing when mills is missing', function () {
+    var plugin = makePlugin();
+    var sent = 0;
+    plugin.sendWebhook = function () { sent++; };
+    plugin.checkNotifications(makeSbx(120, null));
+    sent.should.equal(0);
+  });
+
+});


### PR DESCRIPTION
### TL;DR
This change adds an opt-in, server-only webhook plugin that emits a push-based notification when Nightscout processes a new blood glucose entry. It provides a low-latency mechanism for external services to react to new data without relying on polling, while keeping all follow-up actions outside of Nightscout’s scope. The plugin is disabled by default, runs exclusively on the server, and does not affect existing behavior or the client bundle.

### Problem

Some downstream consumers require a push-based signal when new blood glucose data is ingested by Nightscout. Nightscout does not currently expose a simple, low-latency mechanism to notify custom local services immediately when a new glucose entry is recorded.

Polling for new entries is inefficient and introduces unnecessary delay for integrations that need to react in near real time.

### Motivation

This change supports architectures where Nightscout acts as a data source and an external service reacts to new glucose data as it becomes available. A common pattern is to run such a service locally (for example, on a Raspberry Pi) and perform follow-up actions outside of Nightscout’s scope.

Providing a webhook at the point where new glucose entries are processed allows these integrations to be implemented cleanly without modifying core Nightscout behavior or relying on polling.

### Solution
Introduce a server-only webhook plugin that is invoked when Nightscout processes a new blood glucose entry. The plugin sends an HTTP request to a configurable endpoint, enabling external systems to react immediately.

The implementation:
- Uses at-least-once delivery semantics with deduplication safeguards
- Runs exclusively on the server and is excluded from the client bundle
- Is opt-in and disabled by default


### Backward compatibility
- No breaking changes
- No impact on existing installations unless explicitly enabled

### Testing
- Webpack build passes
- ESLint run on touched files (`lib/plugins/index.js`,
  `lib/plugins/webhook.js`) with no findings
- Full test suite not run locally due to missing `my.test.env`