### PR TITLE
Fix missing spacing between average values in Day to Day report

### DIFF
--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -115,8 +115,8 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
     html += '<b>' + translate('Bolus average') + ':</b> ' + bolusAveragePercent + '%&nbsp; ';
     html += '<b>' + translate('Basal average') + ':</b> ' + basalAveragePercent + '%&nbsp; ';
     html += '<b>(' + translate('Base basal average:') + '</b> ' + baseBasalAveragePercent + '%<b>)</b>&nbsp; ';
-    html += '<b>' + translate('Carbs average') + ':</b> ' + carbsAverage.toFixed(0) + 'g';
-    html += '<b>' + translate('Protein average') + ':</b> ' + proteinAverage.toFixed(0) + 'g';
+    html += '<b>' + translate('Carbs average') + ':</b> ' + carbsAverage.toFixed(0) + 'g&nbsp; ';
+    html += '<b>' + translate('Protein average') + ':</b> ' + proteinAverage.toFixed(0) + 'g&nbsp; ';
     html += '<b>' + translate('Fat average') + ':</b> ' + fatAverage.toFixed(0) + 'g';
     $('#daytodaycharts').append(html);
   }


### PR DESCRIPTION
## Summary
- Added non-breaking spaces (`&nbsp;`) between Carbs average, Protein average, and Fat average values in the insulin distribution summary section
- Previously these three values were displayed concatenated without any separation, making them difficult to read (e.g., "120gProtein average:45gFat average:30g")
- Now displays correctly with proper spacing (e.g., "Carbs average: 144g  Protein average: 0g  Fat average: 0g")

## Changes
- `lib/report_plugins/daytoday.js` lines 118-120: Added `&nbsp; ` after Carbs and Protein average values

## Test plan
- [ ] Open Nightscout Reports
- [ ] Select "Day to day" report
- [ ] Enable "Insulin distribution" checkbox
- [ ] Click SHOW to generate report
- [ ] Verify that Carbs average, Protein average, and Fat average values at the bottom are properly spaced apart

## Screenshot before
**Before:** Values are concatenated without spacing
<img width="1524" height="1006" alt="before" src="https://github.com/user-attachments/assets/c17c172e-573c-47da-98e1-f1683d5d327b" />