### PR TITLE
Fix profile save update semantics

### DIFF
--- a/lib/server/profile.js
+++ b/lib/server/profile.js
@@ -20,11 +20,16 @@ function storage (collection, ctx) {
   }
 
   function save (obj, fn) {
-    obj._id = new ObjectID(obj._id);
-    if (!obj.created_at) {
+    try {
+      obj._id = new ObjectID(obj._id);
+    } catch (err) {
+      obj._id = new ObjectID();
+    }
+    if (!Object.prototype.hasOwnProperty.call(obj, 'created_at')) {
       obj.created_at = (new Date( )).toISOString( );
     }
-    api().insertOne(obj, function (err) {
+    // Match existing profiles by _id only. The profile editor rewrites created_at on save.
+    api().replaceOne({ _id: obj._id }, obj, { upsert: true }, function (err) {
       //id should be added for new docs
       fn(err, obj);
     });

--- a/tests/storage.shape-handling.test.js
+++ b/tests/storage.shape-handling.test.js
@@ -255,6 +255,64 @@ describe('Storage Layer Shape Handling - Direct Storage Tests', function () {
         done();
       });
     });
+
+    it('save() updates an existing profile by _id', function (done) {
+      var original = {
+        defaultProfile: 'Default',
+        store: {
+          Default: {
+            dia: 3,
+            carbratio: [{ time: '00:00', value: 30 }],
+            sens: [{ time: '00:00', value: 100 }],
+            basal: [{ time: '00:00', value: 0.5 }],
+            target_low: [{ time: '00:00', value: 80 }],
+            target_high: [{ time: '00:00', value: 120 }],
+            units: 'mg/dl'
+          }
+        },
+        startDate: '2024-10-19T23:00:00.000Z',
+        created_at: '2024-10-26T20:32:49.173Z',
+        units: 'mg/dl'
+      };
+
+      self.ctx.profile.save(original, function (err, savedProfile) {
+        should.not.exist(err);
+        should.exist(savedProfile);
+        should.exist(savedProfile._id);
+
+        var savedId = savedProfile._id;
+        var updated = {
+          _id: savedId.toString(),
+          defaultProfile: 'Default',
+          store: {
+            Default: {
+              dia: 4,
+              carbratio: [{ time: '00:00', value: 30 }],
+              sens: [{ time: '00:00', value: 100 }],
+              basal: [{ time: '00:00', value: 0.5 }],
+              target_low: [{ time: '00:00', value: 80 }],
+              target_high: [{ time: '00:00', value: 120 }],
+              units: 'mg/dl'
+            }
+          },
+          startDate: '2024-10-19T23:00:00.000Z',
+          created_at: '2024-10-26T21:32:49.173Z',
+          units: 'mg/dl'
+        };
+
+        self.ctx.profile.save(updated, function (saveErr) {
+          should.not.exist(saveErr);
+
+          self.ctx.profile().find({ _id: savedId }).toArray(function (findErr, docs) {
+            should.not.exist(findErr);
+            docs.length.should.equal(1);
+            docs[0].store.Default.dia.should.equal(4);
+            docs[0].created_at.should.equal('2024-10-26T21:32:49.173Z');
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('Food Storage - lib/server/food.js', function () {


### PR DESCRIPTION
Regression found from dev branch. When saving a profile, I'm seeing:

```
MongoServerError: E11000 duplicate key error collection: thibault.profile index: _id_ dup key: { _id: ObjectId('69b926c87fd3539b8414c63f') }
at /opt/app/node_modules/mongodb/lib/operations/insert.js:50:33
at process.processTicksAndRejections (node:internal/process/task_queues:103:5) {
index: 0,
code: 11000,
keyPattern: { _id: 1 },
keyValue: { _id: new ObjectId("69b926c87fd3539b8414c63f") },
[Symbol(errorLabels)]: Set(0) {}
}
```

The change appears to have been introduced by commit `286fa07014dca75b089dd6fc923ee14e78866bf5` with message switch profile api to new mongo driver.

This change safely normalizes or generates `_id`, then uses `replaceOne({ _id }, obj, { upsert: true })` instead of `insertOne(obj)`.
