### PR TITLE
Fix 404 errors when running tests with NODE_ENV=test

### DIFF
--- a/lib/api3/index.js
+++ b/lib/api3/index.js
@@ -77,7 +77,7 @@ function configure (env, ctx) {
 
     app.get('/version', require('./specific/version')(app, ctx, env));
 
-    if (app.get('env') === 'development' || app.get('ci')) { // for development and testing purposes only
+    if (app.get('env') === 'test' || app.get('ci')) { // for development and testing purposes only
       app.get('/test', async function test (req, res) {
 
         try {


### PR DESCRIPTION
[production_safety_test.js](https://github.com/nightscout/cgm-remote-monitor/blob/dev/tests/lib/production-safety.js) requires tests to run with `NODE_ENV` set to `test`. The `/test` endpoint was previously only enabled with `NODE_ENV` set to `development` (or when running under CI) which results in the api3 security tests failing with 404 errors when running with `NODE_ENV` set to `test`.

Instead, enable the `/test` endpoint when `NODE_ENV` is set to `test`.