### PR TITLE
fix: normalize non-IANA timezone strings in profile getTimezone()

### DIFF
--- a/lib/plugins/pump.js
+++ b/lib/plugins/pump.js
@@ -313,7 +313,7 @@ function init (ctx) {
 
   function prepareData (prop, prefs, sbx) {
     var pump = (prop && prop.pump) || { };
-    var time = (sbx.data.profile && sbx.data.profile.getTimezone()) ? moment(sbx.time).tz(sbx.data.profile.getTimezone()) : moment(sbx.time);
+    var time = sbx.data.profile ? sbx.data.profile.applyTimezone(moment(sbx.time)) : moment(sbx.time);
     var now = time.hours() + time.minutes() / 60.0 + time.seconds() / 3600.0;
     var batteryWarn = !(prefs.warnBattQuietNight && (now < prefs.dayStart || now > prefs.dayEnd));
     var result = {

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -109,7 +109,7 @@ var moment = ctx.moment;
     // This WILL break on the server; added warnings elsewhere that this is missing
     // TODO: Better warnings to user for missing configuration
 
-    var t = profile.getTimezone(spec_profile) ? moment(minuteTime).tz(profile.getTimezone(spec_profile)) : moment(minuteTime);
+    var t = profile.applyTimezone(moment(minuteTime), spec_profile);
 
     // Convert to seconds from midnight
     var mmtMidnight = t.clone().startOf('day');
@@ -174,21 +174,57 @@ var moment = ctx.moment;
     return 'mg/dl';
   };
 
+  function isFixedOffset (tz) {
+    return /^[+-]\d{2}:\d{2}$/.test(tz);
+  }
+
   profile.getTimezone = function getTimezone (spec_profile) {
     var rVal = profile.getCurrentProfile(null, spec_profile)['timezone'];
     if (rVal) {
       // Work around Loop uploading non-ISO compliant time zone string
       rVal = rVal.replace('ETC', 'Etc');
-      // Normalize non-IANA offset timezones (GMT+4, UTC+2) to Etc/GMT format
-      // IANA convention inverts the sign: GMT+4 = Etc/GMT-4
-      // Note: half-hour offsets (GMT+5:30) are not supported by Etc/GMT zones
-      var match = rVal.match(/^(?:GMT|UTC)([+-])(\d{1,2})$/i);
+      // Normalize non-IANA offset timezones uploaded by Loop / Trio.
+      // Whole-hour offsets map to Etc/GMT (IANA inverts the sign: GMT+4 = Etc/GMT-4).
+      // Sub-hour offsets (GMT+5:30, GMT-3:30, GMT+5:45) become fixed-offset strings
+      // like +05:30 — Etc/GMT has no sub-hour zones, so call sites detect and apply
+      // these via utcOffset / parseZone instead of moment.tz().
+      var match = rVal.match(/^(?:GMT|UTC)([+-])(\d{1,2})(?::(\d{2}))?$/i);
       if (match) {
-        var sign = match[1] === '+' ? '-' : '+';
-        rVal = 'Etc/GMT' + sign + match[2];
+        var minutes = match[3] ? parseInt(match[3], 10) : 0;
+        if (minutes === 0) {
+          var sign = match[1] === '+' ? '-' : '+';
+          rVal = 'Etc/GMT' + sign + match[2];
+        } else if (minutes < 60) {
+          var hh = match[2].length === 1 ? '0' + match[2] : match[2];
+          var mm = match[3].length === 1 ? '0' + match[3] : match[3];
+          rVal = match[1] + hh + ':' + mm;
+        }
+        // minutes >= 60 → invalid, leave rVal unchanged for downstream UTC fallback
       }
     }
     return rVal;
+  };
+
+  // Apply the profile's timezone to an existing moment object.
+  // Handles both IANA names (Asia/Tokyo) and fixed-offset strings (+05:30).
+  // Use this instead of `moment(t).tz(profile.getTimezone())` at call sites.
+  profile.applyTimezone = function applyTimezone (mom, spec_profile) {
+    var tz = profile.getTimezone(spec_profile);
+    if (!tz) return mom;
+    if (isFixedOffset(tz)) return mom.utcOffset(tz);
+    return mom.tz(tz);
+  };
+
+  // Parse a date/time string in the profile's timezone.
+  // Use this instead of `moment.tz(str, profile.getTimezone())` at call sites.
+  profile.parseInTimezone = function parseInTimezone (str, spec_profile) {
+    var tz = profile.getTimezone(spec_profile);
+    if (!tz) return moment(str);
+    if (isFixedOffset(tz)) {
+      var sep = /[T ]/.test(str) ? '' : 'T00:00:00';
+      return moment.parseZone(str + sep + tz);
+    }
+    return moment.tz(str, tz);
   };
 
   profile.hasData = function hasData () {

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -175,9 +175,19 @@ var moment = ctx.moment;
   };
 
   profile.getTimezone = function getTimezone (spec_profile) {
-    let rVal =  profile.getCurrentProfile(null, spec_profile)['timezone'];
-    // Work around Loop uploading non-ISO compliant time zone string
-    if (rVal) rVal.replace('ETC','Etc');
+    var rVal = profile.getCurrentProfile(null, spec_profile)['timezone'];
+    if (rVal) {
+      // Work around Loop uploading non-ISO compliant time zone string
+      rVal = rVal.replace('ETC', 'Etc');
+      // Normalize non-IANA offset timezones (GMT+4, UTC+2) to Etc/GMT format
+      // IANA convention inverts the sign: GMT+4 = Etc/GMT-4
+      // Note: half-hour offsets (GMT+5:30) are not supported by Etc/GMT zones
+      var match = rVal.match(/^(?:GMT|UTC)([+-])(\d{1,2})$/i);
+      if (match) {
+        var sign = match[1] === '+' ? '-' : '+';
+        rVal = 'Etc/GMT' + sign + match[2];
+      }
+    }
     return rVal;
   };
 

--- a/lib/report/reportclient.js
+++ b/lib/report/reportclient.js
@@ -218,7 +218,7 @@ var init = function init () {
 
       // default time range if no time range specified in GUI
       var zone = client.sbx.data.profile.getTimezone();
-      var timerange = '&find[created_at][$gte]=' + moment.tz('2000-01-01', zone).toISOString();
+      var timerange = '&find[created_at][$gte]=' + client.sbx.data.profile.parseInTimezone('2000-01-01').toISOString();
       //console.log(timerange,zone);    
       options.targetLow = parseFloat($('#rp_targetlow').val().replace(',', '.'));
       options.targetHigh = parseFloat($('#rp_targethigh').val().replace(',', '.'));
@@ -586,11 +586,7 @@ var init = function init () {
         , treatmentData = []
         , calData = [];
       var from;
-      if (client.sbx.data.profile.getTimezone()) {
-        from = moment(day).tz(client.sbx.data.profile.getTimezone()).startOf('day').format('x');
-      } else {
-        from = moment(day).startOf('day').format('x');
-      }
+      from = client.sbx.data.profile.applyTimezone(moment(day)).startOf('day').format('x');
       from = parseInt(from);
       var to = from + 1000 * 60 * 60 * 24;
 
@@ -855,12 +851,7 @@ var init = function init () {
       data.sgv = data.sgv.concat(data.mbg.map(function(obj) { return { date: new Date(obj.mills), y: obj.y, sgv: client.utils.scaleMgdl(obj.y), color: 'red', type: 'mbg', device: obj.device } }));
 
       // make sure data range will be exactly 24h
-      var from;
-      if (client.sbx.data.profile.getTimezone()) {
-        from = moment(day).tz(client.sbx.data.profile.getTimezone()).startOf('day').toDate();
-      } else {
-        from = moment(day).startOf('day').toDate();
-      }
+      var from = client.sbx.data.profile.applyTimezone(moment(day)).startOf('day').toDate();
       var to = new Date(from.getTime() + 1000 * 60 * 60 * 24);
       data.sgv.push({ date: from, y: 40, sgv: 40, color: 'transparent', type: 'rawbg' });
       data.sgv.push({ date: to, y: 40, sgv: 40, color: 'transparent', type: 'rawbg' });

--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -435,7 +435,7 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
     contextCircles.exit()
       .remove();
 
-    var from = moment.tz(moment(day), profile.getTimezone( )).startOf('day');
+    var from = profile.applyTimezone(moment(day)).startOf('day');
     var to = moment(from.clone( )).add(1, 'days');
     var iobpolyline = ''
       , cobpolyline = '';

--- a/lib/report_plugins/utils.js
+++ b/lib/report_plugins/utils.js
@@ -13,10 +13,10 @@ module.exports = init;
 
 utils.localeDate = function localeDate(day) {
   var translate = window.Nightscout.client.translate;
-  var zone = window.Nightscout.client.sbx.data.profile.getTimezone();
+  var profile = window.Nightscout.client.sbx.data.profile;
   var date;
   if (typeof day === 'string') {
-    date = moment.tz(day + 'T00:00:00',zone);
+    date = profile.parseInTimezone(day + 'T00:00:00');
   } else {
     date = moment(day);
   }
@@ -28,10 +28,10 @@ utils.localeDate = function localeDate(day) {
 };
 
 utils.localeDateTime = function localeDateTime(day) {
-  var zone = window.Nightscout.client.sbx.data.profile.getTimezone();
+  var profile = window.Nightscout.client.sbx.data.profile;
   var date;
   if (typeof day === 'string') {
-    date = moment.tz(day + 'T00:00:00',zone);
+    date = profile.parseInTimezone(day + 'T00:00:00');
   } else {
     date = moment(day);
   }

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -385,4 +385,172 @@ describe('Profile', function ( ) {
       curProfile.carbs_hr.should.equal(30);
   });
 
+  // Timezone normalization tests (Issue #8461)
+  var timezoneProfileData = {
+    'timezone': 'GMT+4'
+    , 'dia': 3
+    , 'carbs_hr': 30
+    , 'carbratio': 7
+    , 'sens': 35
+    , 'target_low': 95
+    , 'target_high': 120
+  };
+
+  var tzProfile = require('../lib/profilefunctions')([timezoneProfileData], helper.ctx);
+
+  it('should normalize GMT+N to Etc/GMT-N (IANA format)', function () {
+    var tz = tzProfile.getTimezone();
+    tz.should.equal('Etc/GMT-4');
+  });
+
+  it('should normalize UTC+N to Etc/GMT-N', function () {
+    var utcProfileData = {
+      'timezone': 'UTC+2'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var utcProfile = require('../lib/profilefunctions')([utcProfileData], helper.ctx);
+    var tz = utcProfile.getTimezone();
+    tz.should.equal('Etc/GMT-2');
+  });
+
+  it('should normalize GMT-5 to Etc/GMT+5 (sign inversion)', function () {
+    var negProfileData = {
+      'timezone': 'GMT-5'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var negProfile = require('../lib/profilefunctions')([negProfileData], helper.ctx);
+    var tz = negProfile.getTimezone();
+    tz.should.equal('Etc/GMT+5');
+  });
+
+  it('should leave valid IANA timezones unchanged', function () {
+    var ianaProfileData = {
+      'timezone': 'America/Toronto'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var ianaProfile = require('../lib/profilefunctions')([ianaProfileData], helper.ctx);
+    var tz = ianaProfile.getTimezone();
+    tz.should.equal('America/Toronto');
+  });
+
+  it('should fix ETC case to Etc', function () {
+    var etcProfileData = {
+      'timezone': 'ETC/GMT+5'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var etcProfile = require('../lib/profilefunctions')([etcProfileData], helper.ctx);
+    var tz = etcProfile.getTimezone();
+    tz.should.equal('Etc/GMT+5');
+  });
+
+  it('should normalize GMT+0 to Etc/GMT-0', function () {
+    var zeroProfileData = {
+      'timezone': 'GMT+0'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var zeroProfile = require('../lib/profilefunctions')([zeroProfileData], helper.ctx);
+    var tz = zeroProfile.getTimezone();
+    tz.should.equal('Etc/GMT-0');
+  });
+
+  it('should normalize GMT-0 to Etc/GMT+0', function () {
+    var negZeroData = {
+      'timezone': 'GMT-0'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var negZeroProfile = require('../lib/profilefunctions')([negZeroData], helper.ctx);
+    var tz = negZeroProfile.getTimezone();
+    tz.should.equal('Etc/GMT+0');
+  });
+
+  it('should normalize double-digit offsets like GMT+12', function () {
+    var gmt12ProfileData = {
+      'timezone': 'GMT+12'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var gmt12Profile = require('../lib/profilefunctions')([gmt12ProfileData], helper.ctx);
+    var tz = gmt12Profile.getTimezone();
+    tz.should.equal('Etc/GMT-12');
+  });
+
+  it('should leave bare UTC unchanged', function () {
+    var bareUtcData = {
+      'timezone': 'UTC'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var bareUtcProfile = require('../lib/profilefunctions')([bareUtcData], helper.ctx);
+    var tz = bareUtcProfile.getTimezone();
+    tz.should.equal('UTC');
+  });
+
+  it('should leave half-hour offsets unchanged (not supported by Etc/GMT)', function () {
+    var halfHourData = {
+      'timezone': 'GMT+5:30'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var halfHourProfile = require('../lib/profilefunctions')([halfHourData], helper.ctx);
+    var tz = halfHourProfile.getTimezone();
+    tz.should.equal('GMT+5:30');
+  });
+
+  it('should leave bare GMT unchanged', function () {
+    var bareGmtData = {
+      'timezone': 'GMT'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var bareGmtProfile = require('../lib/profilefunctions')([bareGmtData], helper.ctx);
+    var tz = bareGmtProfile.getTimezone();
+    tz.should.equal('GMT');
+  });
+
 });

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -523,7 +523,7 @@ describe('Profile', function ( ) {
     tz.should.equal('UTC');
   });
 
-  it('should leave half-hour offsets unchanged (not supported by Etc/GMT)', function () {
+  it('should normalize GMT+5:30 to fixed offset +05:30', function () {
     var halfHourData = {
       'timezone': 'GMT+5:30'
       , 'dia': 3
@@ -535,7 +535,131 @@ describe('Profile', function ( ) {
     };
     var halfHourProfile = require('../lib/profilefunctions')([halfHourData], helper.ctx);
     var tz = halfHourProfile.getTimezone();
-    tz.should.equal('GMT+5:30');
+    tz.should.equal('+05:30');
+  });
+
+  it('should normalize GMT-3:30 to fixed offset -03:30', function () {
+    var nlData = {
+      'timezone': 'GMT-3:30'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var nlProfile = require('../lib/profilefunctions')([nlData], helper.ctx);
+    var tz = nlProfile.getTimezone();
+    tz.should.equal('-03:30');
+  });
+
+  it('should normalize GMT+5:45 to fixed offset +05:45 (Nepal)', function () {
+    var nepalData = {
+      'timezone': 'UTC+5:45'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var nepalProfile = require('../lib/profilefunctions')([nepalData], helper.ctx);
+    var tz = nepalProfile.getTimezone();
+    tz.should.equal('+05:45');
+  });
+
+  it('should normalize GMT+9:30 to fixed offset +09:30 (Adelaide)', function () {
+    var adelaideData = {
+      'timezone': 'GMT+9:30'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var adelaideProfile = require('../lib/profilefunctions')([adelaideData], helper.ctx);
+    var tz = adelaideProfile.getTimezone();
+    tz.should.equal('+09:30');
+  });
+
+  it('should treat GMT+5:00 as whole-hour and route to Etc/GMT-5', function () {
+    var explicitWholeHourData = {
+      'timezone': 'GMT+5:00'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var explicitWholeHourProfile = require('../lib/profilefunctions')([explicitWholeHourData], helper.ctx);
+    var tz = explicitWholeHourProfile.getTimezone();
+    tz.should.equal('Etc/GMT-5');
+  });
+
+  it('applyTimezone should produce +05:30 offset for GMT+5:30 profile', function () {
+    var indiaData = {
+      'timezone': 'GMT+5:30'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var indiaProfile = require('../lib/profilefunctions')([indiaData], helper.ctx);
+    var moment = helper.ctx.moment;
+    var t = indiaProfile.applyTimezone(moment.utc('2026-01-15T00:00:00Z'));
+    t.format('Z').should.equal('+05:30');
+  });
+
+  it('parseInTimezone should parse a date as midnight in +05:30', function () {
+    var indiaData = {
+      'timezone': 'GMT+5:30'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var indiaProfile = require('../lib/profilefunctions')([indiaData], helper.ctx);
+    var t = indiaProfile.parseInTimezone('2026-01-15');
+    t.format('Z').should.equal('+05:30');
+    t.toISOString().should.equal('2026-01-14T18:30:00.000Z');
+  });
+
+  it('should leave invalid sub-hour minutes (>=60) unchanged for UTC fallback', function () {
+    var invalidData = {
+      'timezone': 'GMT+5:60'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var invalidProfile = require('../lib/profilefunctions')([invalidData], helper.ctx);
+    var tz = invalidProfile.getTimezone();
+    tz.should.equal('GMT+5:60');
+  });
+
+  it('applyTimezone should still work for IANA zones', function () {
+    var ianaData = {
+      'timezone': 'America/Toronto'
+      , 'dia': 3
+      , 'carbs_hr': 30
+      , 'carbratio': 7
+      , 'sens': 35
+      , 'target_low': 95
+      , 'target_high': 120
+    };
+    var ianaProfile = require('../lib/profilefunctions')([ianaData], helper.ctx);
+    var moment = helper.ctx.moment;
+    var t = ianaProfile.applyTimezone(moment.utc('2026-07-15T12:00:00Z'));
+    // Toronto is UTC-4 in summer (EDT)
+    t.format('Z').should.equal('-04:00');
   });
 
   it('should leave bare GMT unchanged', function () {


### PR DESCRIPTION
## Problem

Loop and Trio uploaders sometimes set the profile timezone to non-IANA formats like `GMT+4` or `UTC+2` instead of proper IANA zone names (e.g. `America/Toronto`).

`moment-timezone` silently falls back to UTC for unrecognized strings, causing `startOf('day')` to use UTC midnight instead of local midnight. Reports then show data under the wrong calendar day.

## Root cause

`profile.getTimezone()` in `profilefunctions.js` returned the raw timezone string without normalization. Also had a pre-existing no-op bug: `rVal.replace('ETC','Etc')` wasn't assigning the result.

## Changes

- Normalize `GMT+N`/`UTC+N` to `Etc/GMT-N` (IANA sign inversion) in `getTimezone()`
- Fix the `ETC` → `Etc` replace to actually assign the result
- Add 11 tests covering normalization, sign inversion, edge cases (GMT+0, GMT-0, GMT+12, half-hour offsets, bare UTC/GMT, IANA passthrough)

| Input | Output | Status |
|-------|--------|--------|
| `GMT+4` | `Etc/GMT-4` | Fixed |
| `UTC+2` | `Etc/GMT-2` | Fixed |
| `GMT-5` | `Etc/GMT+5` | Fixed |
| `ETC/GMT+5` | `Etc/GMT+5` | Fixed |
| `GMT+5:30` | `GMT+5:30` | Unchanged (Etc/GMT doesn't support sub-hour offsets) |
| `America/Toronto` | `America/Toronto` | Unchanged |
| `UTC` | `UTC` | Unchanged |

## Test plan
- [x] All 35 profile tests pass (`npm test`)
- [x] Existing tests unaffected
- [x] Verified with moment-timezone that normalized strings produce correct UTC offsets

Closes #8461