### PR TITLE
Add compound indexes covering v3 parseSort tiebreaker columns

### DIFF
--- a/lib/server/devicestatus.js
+++ b/lib/server/devicestatus.js
@@ -156,6 +156,7 @@ function storage (env, ctx) {
 
   
     , 'NSCLIENT_ID'
+    , { 'created_at': -1, 'identifier': -1, 'date': -1 }
   ];
   return api;
 }

--- a/lib/server/entries.js
+++ b/lib/server/entries.js
@@ -208,6 +208,7 @@ function storage (env, ctx) {
     , 'dateString'
     , 'identifier'  // REQ-SYNC-072: Client sync identity (Trio/Loop syncIdentifier)
     , { 'type': 1, 'date': -1, 'dateString': 1 }
+    , { 'date': -1, 'identifier': -1, 'created_at': -1 }
  ];
  
   /**

--- a/lib/server/treatments.js
+++ b/lib/server/treatments.js
@@ -396,6 +396,7 @@ function storage (env, ctx) {
     , 'duration'
     , 'identifier'  // REQ-SYNC-072: Client sync identity (UUID from _id field)
     , { 'eventType' : 1, 'duration' : 1, 'created_at' : 1 }
+    , { 'eventType' : 1, 'created_at' : -1, 'identifier' : -1, 'date' : -1 }
   ];
 
   api.remove = remove;


### PR DESCRIPTION
Fixes #8477.

## TL;DR

Three new compound indexes (`treatments`, `entries`, `devicestatus`) so that the common API v3 "latest N matching filter" query pattern doesn't trigger an in-memory SORT over the whole collection.

## Root cause

`lib/api3/generic/search/input.js#parseSort` (lines 108–110) unconditionally appends three tiebreakers to every v3 sort spec:

```js
sort.identifier = sortDirection;
sort.created_at = sortDirection;
sort.date = sortDirection;
```

So the actual Mongo sort document is never `{created_at: -1}` — it's always `{<primary>: dir, <tiebreaker>: dir, <tiebreaker>: dir}`. Existing single-field indexes on `date` / `created_at` (and even the existing `{eventType, duration, created_at}` compound on treatments) cannot cover these sorts, and Mongo falls back to COLLSCAN + in-memory SORT.

## Measured impact

Verified on Nightscout 15.0.6 against a real production dataset. `explain("executionStats")` before and after each new index:

| Collection | Docs | Query (Mongo form) | Before | After |
|---|---|---|---|---|
| treatments | 574 k | `{eventType:"Pump Battery Change"}.sort({created_at:-1, identifier:-1, date:-1}).limit(1)` | `IXSCAN(eventType_1)` + **SORT**, 214 keys, ~2000 ms | `IXSCAN(new)` + LIMIT, 1 key, ~1 ms |
| entries | 961 k | `{}.sort({date:-1, identifier:-1, created_at:-1}).limit(1)` | **COLLSCAN + SORT**, 961 k docs examined, ~5800 ms | `IXSCAN(new)` + LIMIT, 1 key, <1 ms |
| devicestatus | 1.9 M | `{}.sort({created_at:-1, identifier:-1, date:-1}).limit(1)` | **COLLSCAN + SORT**, 1.9 M docs examined, ~28 000 ms | `IXSCAN(new)` + LIMIT, 1 key, <1 ms |

The devicestatus case is particularly painful: a one-document lookup walks 1.9 million documents and spends 28 seconds on in-memory sort, which on a small-RAM host can easily push Mongo into OOM territory.

## What the PR adds

Three lines — one new entry in each collection's `indexedFields` array:

- `lib/server/treatments.js`: `{eventType: 1, created_at: -1, identifier: -1, date: -1}`
- `lib/server/entries.js`: `{date: -1, identifier: -1, created_at: -1}`
- `lib/server/devicestatus.js`: `{created_at: -1, identifier: -1, date: -1}`

## Safety / compatibility

- Existing indexes are left untouched.
- All tiebreaker columns are populated by Nightscout (identifier is the v3 sync UUID; created_at / date come from the entry/treatment writer).
- Sort direction: `parseSort` applies a single direction to all three fields (all `+1` or all `-1`). Mongo can walk a `-1/-1/-1` index backwards for ascending sorts, so each new index serves both `sort$desc=X` and `sort=X` query shapes.
- Indexes ship with `{background: true}` via the standard `ensureIndexes` path (`lib/storage/mongo-storage.js`).
- Index build on ~2 M documents completes within a few seconds; the indexes are single-key-per-side and compact.

## Related

- #5463 — original mLab index review (2020). The existing `{eventType, duration, created_at}` compound followed Mongo's equality-sort-range guidance but at the time v3's parseSort tiebreakers didn't exist in the code path.
- #7898 — open report that `sort$desc=created_at` on `/api/v3/treatments?eventType$eq=…` "doesn't work". Documents happened to come back in ascending order because the real sort shape does not match any existing index. This PR should resolve both the perf and the correctness symptoms.
- #8167 — CosmosDB users manually added comparable indexes as a workaround.