### PR TITLE
Don't enforce exact database name in connection string test.

### DIFF
--- a/tests/mongo-storage.test.js
+++ b/tests/mongo-storage.test.js
@@ -3,6 +3,8 @@
 var should = require('should');
 var assert = require('assert');
 
+var productionSafety = require('./lib/production-safety');
+
 describe('mongo storage', function () {
   var env = require('../lib/server/env')();
 
@@ -38,7 +40,7 @@ describe('mongo storage', function () {
       should.exist(db.client);
 
       db.client.db().databaseName.should.equal(db.db.databaseName);
-      db.db.databaseName.should.equal('testdb');
+      productionSafety.isTestDatabaseName(db.db.databaseName).should.be.true();
       done();
     });
   });


### PR DESCRIPTION
The preflight checks suggest 'nightscout_test' as the database name, not 'testdb'. Using 'nightscout_test' would cause this test to fail. Using 'testdb' would pass the preflight check and the connection string test, but if we aren't going to enforce an exact database name, this test shouldn't either.