### PR TITLE
Build Docker arm64 images on native runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,51 +44,96 @@ jobs:
       - name: Send Coverage
         run: npm run-script coverage
 
-  publish:
-    name: Publish to Docker Hub
+  docker-build:
+    name: Build Docker image (${{ matrix.arch }})
     needs: test
-    runs-on: ubuntu-latest
     if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') && github.repository_owner == 'nightscout'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     env:
       DOCKER_IMAGE: nightscout/cgm-remote-monitor
-      PLATFORMS: linux/amd64,linux/arm64
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
       - name: Clean git Checkout
         if: success()
-        uses: actions/checkout@v3
-      - name: Build, tag and push the dev Docker image
-        if: success() && github.ref == 'refs/heads/dev'
-        uses: docker/build-push-action@v2
+        uses: actions/checkout@v4
+      - name: Prepare Docker tags
+        id: docker-tags
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/dev" ]]; then
+            echo "version_tag=${DOCKER_IMAGE}:dev_${GITHUB_SHA}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+            echo "latest_tag=${DOCKER_IMAGE}:latest_dev-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+          else
+            version="$(node -p "require('./package.json').version")"
+            echo "version_tag=${DOCKER_IMAGE}:${version}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+            echo "latest_tag=${DOCKER_IMAGE}:latest-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build, tag and push Docker image
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           no-cache: true
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ matrix.platform }}
           tags: |
-            ${{ env.DOCKER_IMAGE }}:dev_${{ github.sha }}
-            ${{ env.DOCKER_IMAGE }}:latest_dev
+            ${{ steps.docker-tags.outputs.version_tag }}
+            ${{ steps.docker-tags.outputs.latest_tag }}
 
-      - name: Get Nightscout release version
-        if: success() && github.ref == 'refs/heads/master'
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
-      - name: Build, tag and push the master Docker image
-        if: success() && github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v2
+  publish:
+    name: Publish to Docker Hub
+    needs: docker-build
+    runs-on: ubuntu-latest
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') && github.repository_owner == 'nightscout'
+    env:
+      DOCKER_IMAGE: nightscout/cgm-remote-monitor
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          context: .
-          push: true
-          no-cache: true
-          platforms: ${{ env.PLATFORMS }}
-          tags: |
-            ${{ env.DOCKER_IMAGE }}:${{ steps.package-version.outputs.current-version }}
-            ${{ env.DOCKER_IMAGE }}:latest
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Clean git Checkout
+        uses: actions/checkout@v4
+      - name: Prepare Docker manifest tags
+        id: docker-tags
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/dev" ]]; then
+            echo "version_tag=${DOCKER_IMAGE}:dev_${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo "version_sources=${DOCKER_IMAGE}:dev_${GITHUB_SHA}-amd64 ${DOCKER_IMAGE}:dev_${GITHUB_SHA}-arm64" >> "$GITHUB_OUTPUT"
+            echo "latest_tag=${DOCKER_IMAGE}:latest_dev" >> "$GITHUB_OUTPUT"
+            echo "latest_sources=${DOCKER_IMAGE}:latest_dev-amd64 ${DOCKER_IMAGE}:latest_dev-arm64" >> "$GITHUB_OUTPUT"
+          else
+            version="$(node -p "require('./package.json').version")"
+            echo "version_tag=${DOCKER_IMAGE}:${version}" >> "$GITHUB_OUTPUT"
+            echo "version_sources=${DOCKER_IMAGE}:${version}-amd64 ${DOCKER_IMAGE}:${version}-arm64" >> "$GITHUB_OUTPUT"
+            echo "latest_tag=${DOCKER_IMAGE}:latest" >> "$GITHUB_OUTPUT"
+            echo "latest_sources=${DOCKER_IMAGE}:latest-amd64 ${DOCKER_IMAGE}:latest-arm64" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish Docker manifests
+        shell: bash
+        run: |
+          docker buildx imagetools create \
+            -t "${{ steps.docker-tags.outputs.version_tag }}" \
+            ${{ steps.docker-tags.outputs.version_sources }}
+          docker buildx imagetools create \
+            -t "${{ steps.docker-tags.outputs.latest_tag }}" \
+            ${{ steps.docker-tags.outputs.latest_sources }}


### PR DESCRIPTION
## Summary

- Split Docker image publishing into separate native amd64 and arm64 builds
- Use the GitHub-hosted `ubuntu-24.04-arm` runner for arm64 instead of QEMU emulation
- Publish the existing Docker Hub tags as multi-arch manifests after both architecture images are pushed
- Update Docker actions used by the publish path to current major versions

## Why

The current Docker publish job fails while emulating arm64 with QEMU during `npm ci`:

```
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
Illegal instruction (core dumped)
exit code: 132
```

Building arm64 on a native arm64 runner avoids that emulation failure while preserving multi-arch Docker tags.

## Validation

- Parsed `.github/workflows/main.yml` locally with Ruby YAML
- `git diff --check` passed
- Local direct push to `dev` was blocked by branch protection, so this PR is the protected-branch path for the same commit
