### PR TITLE
Guard API v3 filter parameter parsing

### DIFF
--- a/lib/api3/generic/search/input.js
+++ b/lib/api3/generic/search/input.js
@@ -63,7 +63,11 @@ function isFilterParameterStart(filterValue, index, operators) {
 
 
 function parseFilterParameterString(value, operators) {
-  const filterValue = value.toString();
+  if (!['boolean', 'number', 'string'].includes(typeof value)) {
+    return [];
+  }
+
+  const filterValue = String(value);
   const starts = [];
 
   for (let index = 0; index < filterValue.length; index++) {

--- a/tests/api3.search.test.js
+++ b/tests/api3.search.test.js
@@ -64,6 +64,28 @@ function containsMembers(requiredMembers, arrayToCheck, propertiesToCompare) {
 }
 
 
+describe('API3 SEARCH INPUT', function() {
+  const input = require('../lib/api3/generic/search/input');
+
+  it('should ignore non-scalar filter_parameters values without string coercion', function() {
+    const maliciousValue = {
+      length: 1e100
+      , toString: function toString () {
+        throw new Error('filter_parameters object should not be coerced');
+      }
+    };
+
+    const filter = input.parseFilter({
+      query: {
+        filter_parameters: maliciousValue
+      }
+    }, {});
+
+    filter.should.eql([]);
+  });
+});
+
+
 describe('API3 SEARCH', function() {
   const self = this
     , testConst = require('./fixtures/api3/const.json')


### PR DESCRIPTION
## Summary

Fixes the CodeQL `js/loop-bound-injection` alert for API v3 `filter_parameters` parsing.

The parser previously called `value.toString()` before scanning `filterValue.length`. If a query parser produced an object-shaped value such as `filter_parameters[length]=...`, CodeQL correctly flagged that path as potentially attacker-controlled.

This change only accepts scalar `filter_parameters` values (`string`, `number`, `boolean`) before converting to a primitive string. Non-scalar values are ignored and are not coerced, so object-controlled `length` and `toString()` cannot influence the loop.

## Validation

```text
./node_modules/.bin/eslint lib/api3/generic/search/input.js tests/api3.search.test.js

./node_modules/.bin/env-cmd -f ./tests/ci.test.env ./node_modules/.bin/mocha --timeout 5000 --require ./tests/hooks.js --exit ./tests/api3.search.test.js

147 passing
```
