### PR TITLE
Fix Admin Tools delete count display

### DIFF
--- a/lib/admin_plugins/cleanentriesdb.js
+++ b/lib/admin_plugins/cleanentriesdb.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var getDeletedCount = require('./delete-count');
 var moment;
 
 var cleanentriesdb = {
@@ -67,7 +68,7 @@ cleanentriesdb.actions[0].code =  function deleteOldRecords(client, callback) {
       method: 'DELETE'
     , headers: client.headers()
     , success: function (retVal) {
-      $status.hide().text(translate('%1 records deleted',{ params: [retVal.n] })).fadeIn('slow');
+      $status.hide().text(translate('%1 records deleted',{ params: [getDeletedCount(retVal)] })).fadeIn('slow');
     }
     , error: function () {
       $status.hide().text(translate('Error')).fadeIn('slow');

--- a/lib/admin_plugins/cleanstatusdb.js
+++ b/lib/admin_plugins/cleanstatusdb.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var getDeletedCount = require('./delete-count');
 var moment;
 
 var cleanstatusdb = {
@@ -121,7 +122,7 @@ cleanstatusdb.actions[1].code = function deleteOldRecords (client, callback) {
     method: 'DELETE'
     , headers: client.headers()
     , success: function(retVal) {
-      $status.text(translate('%1 records deleted', { params: [retVal.n] }));
+      $status.text(translate('%1 records deleted', { params: [getDeletedCount(retVal)] }));
     }
     , error: function() {
       $status.hide().text(translate('Error')).fadeIn('slow');

--- a/lib/admin_plugins/cleantreatmentsdb.js
+++ b/lib/admin_plugins/cleantreatmentsdb.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var getDeletedCount = require('./delete-count');
 var moment;
 
 var cleantreatmentsdb = {
@@ -68,7 +69,7 @@ cleantreatmentsdb.actions[0].code =  function deleteOldRecords(client, callback)
       method: 'DELETE'
     , headers: client.headers()
     , success: function (retVal) {
-      $status.hide().text(translate('%1 records deleted',{ params: [retVal.n] })).fadeIn('slow');
+      $status.hide().text(translate('%1 records deleted',{ params: [getDeletedCount(retVal)] })).fadeIn('slow');
     }
     , error: function () {
       $status.hide().text(translate('Error')).fadeIn('slow');

--- a/lib/admin_plugins/delete-count.js
+++ b/lib/admin_plugins/delete-count.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function getDeletedCount(retVal) {
+  if (!retVal) {
+    return 0;
+  }
+
+  if (retVal.n !== undefined) {
+    return retVal.n;
+  }
+
+  if (retVal.deletedCount !== undefined) {
+    return retVal.deletedCount;
+  }
+
+  return 0;
+}
+
+module.exports = getDeletedCount;

--- a/lib/api/devicestatus/index.js
+++ b/lib/api/devicestatus/index.js
@@ -2,10 +2,10 @@
 
 const consts = require('../../constants');
 const moment = require('moment');
-const { query } = require('express');
 const _take = require('lodash/take');
 const _ = require('lodash');
 const objectIdValidation = require('../shared/objectid-validation');
+const normalizeDeleteStatus = require('../shared/delete-status');
 
 function configure (app, wares, ctx, env) {
   var express = require('express')
@@ -118,7 +118,7 @@ function configure (app, wares, ctx, env) {
           return next(err);
         }
         // yield some information about success of operation
-        res.json(stat);
+        res.json(normalizeDeleteStatus(stat));
 
         console.log('devicestatus records deleted');
 

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -8,6 +8,7 @@ const _ = require('lodash');
 const moment = require('moment');
 
 const consts = require('../../constants');
+const normalizeDeleteStatus = require('../shared/delete-status');
 const es = require('event-stream');
 const braces = require('braces');
 const expand = braces.expand;
@@ -550,7 +551,7 @@ function configure (app, wares, ctx, env) {
         return next(err);
       }
       // yield some information about success of operation
-      res.json(stat);
+      res.json(normalizeDeleteStatus(stat));
       return next();
     });
   }

--- a/lib/api/shared/delete-status.js
+++ b/lib/api/shared/delete-status.js
@@ -1,0 +1,21 @@
+'use strict';
+
+function normalizeDeleteStatus(stat) {
+  if (!stat || typeof stat !== 'object') {
+    return stat;
+  }
+
+  var response = Object.assign({}, stat);
+
+  if (response.n === undefined && response.deletedCount !== undefined) {
+    response.n = response.deletedCount;
+  }
+
+  if (response.deletedCount === undefined && response.n !== undefined) {
+    response.deletedCount = response.n;
+  }
+
+  return response;
+}
+
+module.exports = normalizeDeleteStatus;

--- a/lib/api/treatments/index.js
+++ b/lib/api/treatments/index.js
@@ -7,6 +7,7 @@ const _take = require('lodash/take');
 
 const constants = require('../../constants');
 const moment = require('moment');
+const normalizeDeleteStatus = require('../shared/delete-status');
 
 function configure (app, wares, ctx, env) {
   var express = require('express')
@@ -165,7 +166,7 @@ function configure (app, wares, ctx, env) {
         }
 
         // yield some information about success of operation
-        res.json(stat);
+        res.json(normalizeDeleteStatus(stat));
 
         return next();
       });

--- a/lib/server/swagger.json
+++ b/lib/server/swagger.json
@@ -1408,7 +1408,12 @@
           "n": {
             "type": "integer",
             "format": "int32",
-            "description": "Number of records deleted"
+            "description": "Number of records deleted. Legacy alias of deletedCount."
+          },
+          "deletedCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of records deleted."
           },
           "optime": {
             "$ref": "#/components/schemas/optime"

--- a/lib/server/swagger.yaml
+++ b/lib/server/swagger.yaml
@@ -1057,7 +1057,11 @@ components:
         'n':
           type: integer
           format: int32
-          description: Number of records deleted
+          description: Number of records deleted. Legacy alias of deletedCount.
+        deletedCount:
+          type: integer
+          format: int32
+          description: Number of records deleted.
         optime:
           $ref: '#/components/schemas/optime'
         electionId:

--- a/tests/admintools.test.js
+++ b/tests/admintools.test.js
@@ -30,7 +30,7 @@ var someData = {
     }
   ],
   '/api/v1/devicestatus/?find[created_at][$lte]=': {
-    n: 1
+    deletedCount: 1
   },
   '/api/v1/treatments.json?&find[created_at][$gte]=': [
       {
@@ -42,7 +42,7 @@ var someData = {
       }
     ],
   '/api/v1/treatments/?find[created_at][$lte]=': {
-    n: 1
+    deletedCount: 1
   },
   '/api/v1/entries.json?&find[date][$gte]=': [
       {
@@ -59,9 +59,28 @@ var someData = {
       }
     ],
   '/api/v1/entries/?find[date][$lte]=': {
-    n: 1
+    deletedCount: 1
   },
 };
+
+
+describe('delete status compatibility', function () {
+  var normalizeDeleteStatus = require('../lib/api/shared/delete-status');
+
+  it('should preserve legacy n count for MongoDB deletedCount results', function () {
+    normalizeDeleteStatus({deletedCount: 1}).should.eql({
+      deletedCount: 1
+      , n: 1
+    });
+  });
+
+  it('should preserve deletedCount for legacy n results', function () {
+    normalizeDeleteStatus({n: 1}).should.eql({
+      n: 1
+      , deletedCount: 1
+    });
+  });
+});
 
 
 describe('admintools', function ( ) {
@@ -70,8 +89,8 @@ describe('admintools', function ( ) {
   before(function (done) {
     benv.setup(function() {
 
-	  benv.require(__dirname + '/../node_modules/.cache/_ns_cache/public/js/bundle.app.js');
-          
+      benv.require(__dirname + '/../node_modules/.cache/_ns_cache/public/js/bundle.app.js');
+
       self.$ = $;
       
       self.localCookieStorage = self.localStorage = self.$.localStorage = require('./fixtures/localstorage');
@@ -157,8 +176,6 @@ describe('admintools', function ( ) {
       let timer = d3.timer(function mockTimer() { });
       timer.stop();
       
-      var cookieStorageType = self.localStorage._type
-
       benv.expose({
         $: self.$
         , jQuery: self.$
@@ -166,7 +183,7 @@ describe('admintools', function ( ) {
         , serverSettings: serverSettings
         , localCookieStorage: self.localStorage
         , cookieStorageType: self.localStorage
-		, localStorage: self.localStorage
+        , localStorage: self.localStorage
         , io: {
           connect: function mockConnect ( ) {
             return {


### PR DESCRIPTION
## Summary

Fixes #8483.

Admin Tools still expected legacy Mongo delete responses to expose the deleted document count as `n`. After the MongoDB driver compatibility changes, delete operations now return `deletedCount`, so the old-documents cleanup buttons succeeded but displayed `undefined records deleted`.

This PR keeps both sides compatible:

- v1 DELETE responses for entries, treatments, and devicestatus now include both `deletedCount` and legacy `n`
- Admin Tools reads either `n` or `deletedCount`
- Admin Tools regression fixtures now return `deletedCount` only, matching the current MongoDB result shape
- v1 delete response docs now describe `deletedCount` and the legacy `n` alias

## Validation

```text
npm run bundle

./node_modules/.bin/env-cmd -f ./tests/ci.test.env ./node_modules/.bin/mocha --timeout 5000 --require ./tests/hooks.js --exit ./tests/admintools.test.js

3 passing

./node_modules/.bin/eslint lib/api/shared/delete-status.js lib/admin_plugins/delete-count.js lib/admin_plugins/cleanentriesdb.js lib/admin_plugins/cleantreatmentsdb.js lib/admin_plugins/cleanstatusdb.js lib/api/entries/index.js lib/api/treatments/index.js lib/api/devicestatus/index.js tests/admintools.test.js

No errors; one pre-existing warning in lib/api/entries/index.js.

git diff --check
```
