### PR TITLE
Add profile cleanup admin tool and indexes

### DIFF
--- a/lib/admin_plugins/cleanprofiledb.js
+++ b/lib/admin_plugins/cleanprofiledb.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var getDeletedCount = require('./delete-count');
+
+var cleanprofiledb = {
+  name: 'cleanprofiledb'
+  , label: 'Clean Mongo profile database'
+  , pluginType: 'admin'
+};
+
+function init() {
+  return cleanprofiledb;
+}
+
+module.exports = init;
+
+cleanprofiledb.actions = [
+    {
+        name: 'Delete old profile documents'
+      , description: 'This task removes older documents from the profile collection while keeping the newest profile records.'
+      , buttonLabel: 'Delete old profile records'
+      , confirmText: 'Delete old profile records from profile collection?'
+      , preventClose: true
+    }
+  ];
+
+cleanprofiledb.actions[0].init = function init(client, callback) {
+  var translate = client.translate;
+  var $status = $('#admin_' + cleanprofiledb.name + '_0_status');
+
+  $status.hide();
+
+  var keepRecords = '<br/>'
+      + '<label for="admin_profile_records_keep">'
+      + translate('Profile Records to Keep:')
+      + '  <input id="admin_profile_records_keep" value="100" size="3" min="10" max="10000"/>'
+      + '</label>';
+
+  $('#admin_' + cleanprofiledb.name + '_0_html').html(keepRecords);
+
+  if (callback) { callback(); }
+};
+
+cleanprofiledb.actions[0].code = function deleteOldProfileRecords(client, callback) {
+  var translate = client.translate;
+  var $status = $('#admin_' + cleanprofiledb.name + '_0_status');
+  var keepRecords = Number($('#admin_profile_records_keep').val());
+
+  if (isNaN(keepRecords) || keepRecords < 10 || keepRecords > 10000 || Math.floor(keepRecords) !== keepRecords) {
+    alert(translate('%1 is not a valid number - must be a whole number between 10 and 10000', { params: [$('#admin_profile_records_keep').val()] }));
+    if (callback) { callback(); }
+    return;
+  }
+
+  if (!client.hashauth.isAuthenticated()) {
+    alert(translate('Your device is not authenticated yet'));
+    if (callback) {
+      callback();
+    }
+    return;
+  }
+
+  $status.hide().text(translate('Deleting records ...')).fadeIn('slow');
+  $.ajax('/api/v1/profile/?keep=' + keepRecords, {
+      method: 'DELETE'
+    , headers: client.headers()
+    , success: function (retVal) {
+      $status.hide().text(translate('%1 records deleted', { params: [getDeletedCount(retVal)] })).fadeIn('slow');
+    }
+    , error: function () {
+      $status.hide().text(translate('Error')).fadeIn('slow');
+    }
+  }).done(function success () {
+    if (callback) { callback(); }
+  }).fail(function fail() {
+    if (callback) { callback(); }
+  });
+};

--- a/lib/admin_plugins/index.js
+++ b/lib/admin_plugins/index.js
@@ -10,6 +10,7 @@ function init(ctx) {
       , require('./cleanstatusdb')(ctx)
       , require('./cleantreatmentsdb')(ctx)
       , require('./cleanentriesdb')(ctx)
+      , require('./cleanprofiledb')(ctx)
       , require('./futureitems')(ctx)
     ];
 

--- a/lib/api/profile/index.js
+++ b/lib/api/profile/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var consts = require('../../constants');
+var normalizeDeleteStatus = require('../shared/delete-status');
 var objectIdValidation = require('../shared/objectid-validation');
 
 function configure (app, wares, ctx) {
@@ -59,6 +60,16 @@ function configure (app, wares, ctx) {
     });
 
     function config_authed (app, api, wares, ctx) {
+        function parseKeepCount (req) {
+            var rawKeep = req.query && req.query.keep !== undefined ? req.query.keep : '100';
+            var keep = Number(rawKeep);
+
+            if (!Number.isSafeInteger(keep) || keep < 10 || keep > 10000) {
+                return null;
+            }
+
+            return keep;
+        }
 
         // create new record(s)
         // Supports both single object and array inputs (NightscoutKit sends arrays)
@@ -114,6 +125,25 @@ function configure (app, wares, ctx) {
                     console.log('Profile saved', created);
                 }
 
+            });
+        });
+
+        api.delete('/profile/', ctx.authorization.isPermitted('api:profile:delete'), function(req, res) {
+            var keepCount = parseKeepCount(req);
+
+            if (keepCount === null) {
+                return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+                    'Invalid keep count', 'Must be a whole number between 10 and 10000.');
+            }
+
+            ctx.profile.prune(keepCount, function (err, stat) {
+                if (err) {
+                    res.sendJSONStatus(res, consts.HTTP_INTERNAL_ERROR, 'Mongo Error', err);
+                    console.log('Error pruning profiles');
+                    console.log(err);
+                } else {
+                    res.json(normalizeDeleteStatus(stat));
+                }
             });
         });
 

--- a/lib/server/profile.js
+++ b/lib/server/profile.js
@@ -6,6 +6,7 @@ var runWithCallback = require('../storage/run-with-callback');
 
 function storage (collection, ctx) {
    var ObjectID = require('mongodb').ObjectId;
+   var profileSort = { startDate: -1, _id: -1 };
 
   function create (objOrArray, fn) {
     // Normalize to array (supports both single object and array inputs)
@@ -69,7 +70,7 @@ function storage (collection, ctx) {
   function list (fn, count) {
     const limit = count !== null ? count : Number(consts.PROFILES_DEFAULT_COUNT);
     return runWithCallback(function () {
-      return api().find({ }).limit(limit).sort({startDate: -1}).toArray();
+      return api().find({ }).limit(limit).sort(profileSort).toArray();
     }, fn);
   }
 
@@ -90,7 +91,7 @@ function storage (collection, ctx) {
     return runWithCallback(function () {
       return limit.call(api()
         .find(query_for(opts))
-        .sort(opts && opts.sort && query_sort(opts) || { startDate: -1 }), opts)
+        .sort(opts && opts.sort && query_sort(opts) || profileSort), opts)
         .toArray();
     }, fn);
   }
@@ -119,7 +120,7 @@ function storage (collection, ctx) {
 
   function last (fn) {
     return runWithCallback(function () {
-      return api().find().sort({startDate: -1, _id: -1}).limit(1).toArray();
+      return api().find().sort(profileSort).limit(1).toArray();
     }, fn);
   }
 
@@ -133,6 +134,51 @@ function storage (collection, ctx) {
     return promise;
   }
 
+  function prune (keepCount, fn) {
+    return runWithCallback(async function () {
+      var oldProfileBoundary = await api()
+        .find({}, { projection: { _id: 1, startDate: 1 } })
+        .sort(profileSort)
+        .skip(keepCount)
+        .limit(1)
+        .toArray();
+
+      if (oldProfileBoundary.length === 0) {
+        return { deletedCount: 0 };
+      }
+
+      var pruneFilter = pruneFilterForBoundary(oldProfileBoundary[0]);
+
+      var stat = await api().deleteMany(pruneFilter);
+      ctx.bus.emit('data-update', {
+        type: 'profile'
+        , op: 'remove'
+        , count: stat.deletedCount
+        , changes: pruneFilter
+      });
+      ctx.bus.emit('data-received');
+
+      return stat;
+    }, fn);
+  }
+
+  function pruneFilterForBoundary (boundary) {
+    if (Object.prototype.hasOwnProperty.call(boundary, 'startDate') && boundary.startDate !== null) {
+      return {
+        $or: [
+          { startDate: { $lt: boundary.startDate } }
+          , { startDate: boundary.startDate, _id: { $lte: boundary._id } }
+          , { startDate: null }
+        ]
+      };
+    }
+
+    return {
+      startDate: null
+      , _id: { $lte: boundary._id }
+    };
+  }
+
   function api () {
     return ctx.store.collection(collection);
   }
@@ -142,8 +188,14 @@ function storage (collection, ctx) {
   api.create = create;
   api.save = save;
   api.remove = remove;
+  api.prune = prune;
   api.last = last;
-  api.indexedFields = ['startDate'];
+  api.indexedFields = [
+    'startDate'
+    , 'created_at'
+    , 'NSCLIENT_ID'
+    , { startDate: -1, _id: -1 }
+  ];
   return api;
 }
 

--- a/lib/storage/mongo-storage.js
+++ b/lib/storage/mongo-storage.js
@@ -210,7 +210,8 @@ function init(env, cb, forceNewConnection) {
 
   mongo.ensureIndexes = function ensureIndexes(collection, fields) {
     fields.forEach(function (field) {
-      const name = collection.collectionName + "." + field;
+      const fieldName = typeof field === 'string' ? field : JSON.stringify(field);
+      const name = collection.collectionName + "." + fieldName;
       console.info('ensuring index for: ' + name);
       collection.createIndex(field).catch(function (err) {
         console.error('unable to ensureIndex for: ' + name + ' - ' + err);

--- a/tests/admintools.test.js
+++ b/tests/admintools.test.js
@@ -61,6 +61,9 @@ var someData = {
   '/api/v1/entries/?find[date][$lte]=': {
     deletedCount: 1
   },
+  '/api/v1/profile/?keep=': {
+    deletedCount: 2
+  },
 };
 
 
@@ -134,6 +137,8 @@ describe('admintools', function ( ) {
             url = '/api/v1/treatments/?find[created_at][$lte]=';
           } else if (url.indexOf('/api/v1/entries/?find[date][$lte]=')===0) {
             url = '/api/v1/entries/?find[date][$lte]=';
+          } else if (url.indexOf('/api/v1/profile/?keep=')===0) {
+            url = '/api/v1/profile/?keep=';
           }
           return {
             done: function mockDone (fn) {
@@ -281,6 +286,12 @@ describe('admintools', function ( ) {
 
     $('#admin_cleanentriesdb_0_html + button').click();
     $('#admin_cleanentriesdb_0_status').text().should.equal('1 records deleted'); // entries code result
+
+    $('#admin_cleanprofiledb_0_html + button').text().should.equal('Delete old profile records'); // profile button
+    $('#admin_cleanprofiledb_0_status').text().should.equal(''); // profile init result
+
+    $('#admin_cleanprofiledb_0_html + button').click();
+    $('#admin_cleanprofiledb_0_status').text().should.equal('2 records deleted'); // profile code result
 
     done();
   });

--- a/tests/api.profiles.test.js
+++ b/tests/api.profiles.test.js
@@ -298,4 +298,83 @@ describe('Profiles API', function ( ) {
         .end(done);
     });
   });
+
+  describe('profile pruning', function() {
+    beforeEach(async function () {
+      await self.ctx.profile().deleteMany({});
+    });
+
+    afterEach(async function () {
+      await self.ctx.profile().deleteMany({});
+    });
+
+    function profileForIndex (index) {
+      return {
+        "defaultProfile": "PruneTest" + index,
+        "store": { "Default": { "dia": 3 } },
+        "startDate": new Date(Date.UTC(2025, 0, index + 1)).toISOString()
+      };
+    }
+
+    it('should delete older profile records and keep the newest records', function(done) {
+      var profiles = [];
+
+      for (var i = 0; i < 12; i++) {
+        profiles.push(profileForIndex(i));
+      }
+
+      self.ctx.profile.create(profiles, function (err) {
+        if (err) {
+          return done(err);
+        }
+
+        request(self.app)
+          .delete('/api/profile/?keep=10')
+          .set('api-secret', known || '')
+          .expect(200)
+          .expect(function(response) {
+            response.body.deletedCount.should.equal(2);
+            response.body.n.should.equal(2);
+          })
+          .end(function (deleteErr) {
+            if (deleteErr) {
+              return done(deleteErr);
+            }
+
+            self.ctx.profile.list(function (listErr, docs) {
+              if (listErr) {
+                return done(listErr);
+              }
+
+              docs.length.should.equal(10);
+              docs[0].defaultProfile.should.equal('PruneTest11');
+              docs[9].defaultProfile.should.equal('PruneTest2');
+              done();
+            }, 20);
+          });
+      });
+    });
+
+    it('should reject unsafe profile keep counts', function(done) {
+      request(self.app)
+        .delete('/api/profile/?keep=9')
+        .set('api-secret', known || '')
+        .expect(400)
+        .expect(function(response) {
+          response.body.message.should.match(/Invalid keep count/i);
+        })
+        .end(done);
+    });
+
+    it('should reject unbounded profile keep counts', function(done) {
+      request(self.app)
+        .delete('/api/profile/?keep=10001')
+        .set('api-secret', known || '')
+        .expect(400)
+        .expect(function(response) {
+          response.body.message.should.match(/Invalid keep count/i);
+        })
+        .end(done);
+    });
+  });
 });

--- a/tests/mongo-storage.test.js
+++ b/tests/mongo-storage.test.js
@@ -66,6 +66,30 @@ describe('mongo storage', function () {
     });
   });
 
+  it('ensureIndexes accepts compound index definitions', function (done) {
+    var store = require('../lib/storage/mongo-storage');
+    var calls = [];
+    var profileLatestIndex = { startDate: -1, _id: -1 };
+
+    store(env, function (err, db) {
+      should.not.exist(err);
+
+      db.ensureIndexes({
+        collectionName: 'profile',
+        createIndex: function (field, options) {
+          calls.push({ field: field, options: options });
+          return Promise.resolve();
+        }
+      }, [profileLatestIndex]);
+
+      calls.length.should.equal(1);
+      calls[0].field.should.eql(profileLatestIndex);
+      should.not.exist(calls[0].options);
+
+      done();
+    });
+  });
+
   it('When no connection-string is given the storage-class should throw an error.', function (done) {
     delete env.storageURI;
     should.not.exist(env.storageURI);

--- a/tests/storage.shape-handling.test.js
+++ b/tests/storage.shape-handling.test.js
@@ -440,6 +440,136 @@ describe('Storage Layer Shape Handling - Direct Storage Tests', function () {
           .catch(done);
       });
     });
+
+    it('prune() deletes older profiles while keeping the newest records', function (done) {
+      var profiles = [];
+
+      for (var i = 0; i < 12; i++) {
+        profiles.push({
+          defaultProfile: 'Profile' + i,
+          store: {
+            Default: {
+              dia: 3,
+              carbratio: [{ time: '00:00', value: 30 }],
+              sens: [{ time: '00:00', value: 100 }],
+              basal: [{ time: '00:00', value: 0.5 }],
+              target_low: [{ time: '00:00', value: 80 }],
+              target_high: [{ time: '00:00', value: 120 }],
+              units: 'mg/dl'
+            }
+          },
+          startDate: new Date(Date.UTC(2025, 0, i + 1)).toISOString(),
+          units: 'mg/dl'
+        });
+      }
+
+      self.ctx.profile.create(profiles, function (err) {
+        should.not.exist(err);
+
+        self.ctx.profile.prune(10, function (pruneErr, stat) {
+          should.not.exist(pruneErr);
+          stat.deletedCount.should.equal(2);
+
+          self.ctx.profile.list(function (listErr, docs) {
+            should.not.exist(listErr);
+            docs.length.should.equal(10);
+            docs[0].defaultProfile.should.equal('Profile11');
+            docs[9].defaultProfile.should.equal('Profile2');
+            done();
+          }, 20);
+        });
+      });
+    });
+
+    it('prune() uses _id as a tie-breaker when profile startDate values match', function (done) {
+      var profiles = [];
+
+      for (var i = 0; i < 3; i++) {
+        profiles.push({
+          defaultProfile: 'TieProfile' + i,
+          store: {
+            Default: {
+              dia: 3,
+              carbratio: [{ time: '00:00', value: 30 }],
+              sens: [{ time: '00:00', value: 100 }],
+              basal: [{ time: '00:00', value: 0.5 }],
+              target_low: [{ time: '00:00', value: 80 }],
+              target_high: [{ time: '00:00', value: 120 }],
+              units: 'mg/dl'
+            }
+          },
+          startDate: '2025-01-01T00:00:00.000Z',
+          units: 'mg/dl'
+        });
+      }
+
+      self.ctx.profile.create(profiles, function (err) {
+        should.not.exist(err);
+
+        self.ctx.profile.prune(1, function (pruneErr, stat) {
+          should.not.exist(pruneErr);
+          stat.deletedCount.should.equal(2);
+
+          self.ctx.profile.list(function (listErr, docs) {
+            should.not.exist(listErr);
+            docs.length.should.equal(1);
+            docs[0].defaultProfile.should.equal('TieProfile2');
+            done();
+          }, 10);
+        });
+      });
+    });
+
+    it('prune() removes profiles missing startDate after dated profiles', function (done) {
+      var profiles = [
+        {
+          defaultProfile: 'MissingStartDate',
+          store: { Default: { dia: 3 } },
+          units: 'mg/dl'
+        },
+        {
+          defaultProfile: 'NullStartDate',
+          store: { Default: { dia: 3 } },
+          startDate: null,
+          units: 'mg/dl'
+        },
+        {
+          defaultProfile: 'OldProfile',
+          store: { Default: { dia: 3 } },
+          startDate: '2024-01-01T00:00:00.000Z',
+          units: 'mg/dl'
+        },
+        {
+          defaultProfile: 'NewProfile',
+          store: { Default: { dia: 3 } },
+          startDate: '2025-01-01T00:00:00.000Z',
+          units: 'mg/dl'
+        }
+      ];
+
+      self.ctx.profile.create(profiles, function (err) {
+        should.not.exist(err);
+
+        self.ctx.profile.prune(1, function (pruneErr, stat) {
+          should.not.exist(pruneErr);
+          stat.deletedCount.should.equal(3);
+
+          self.ctx.profile.list(function (listErr, docs) {
+            should.not.exist(listErr);
+            docs.length.should.equal(1);
+            docs[0].defaultProfile.should.equal('NewProfile');
+            done();
+          }, 10);
+        });
+      });
+    });
+
+    it('declares indexes used by profile loading and websocket deduplication', function () {
+      self.ctx.profile.indexedFields.should.containEql('startDate');
+      self.ctx.profile.indexedFields.should.containEql('created_at');
+      self.ctx.profile.indexedFields.should.containEql('NSCLIENT_ID');
+      self.ctx.profile.indexedFields.should.containEql({ startDate: -1, _id: -1 });
+    });
   });
 
   describe('Food Storage - lib/server/food.js', function () {


### PR DESCRIPTION
## Summary
- add an Admin Tools action to prune old profile documents while keeping the newest N records
- add a protected profile prune endpoint and deterministic storage prune path based on `startDate` and `_id`
- add non-unique profile indexes for profile loading, websocket dedupe, and upgrade-safe large-collection handling

## Why
Addresses #8144. The admin prune action gives maintainers a recovery path for oversized `profile` collections, while the new non-unique indexes address the underlying slow query paths without rejecting existing duplicate profile data during upgrades.

## Validation
- `./node_modules/.bin/env-cmd -f ./tests/ci.test.env ./node_modules/.bin/mocha --timeout 15000 --require ./tests/hooks.js --exit tests/mongo-storage.test.js tests/storage.shape-handling.test.js tests/admintools.test.js tests/api.profiles.test.js`
- `git diff --check`
