### PR TITLE
Fix historical COB display when scrolling back

### DIFF
--- a/lib/plugins/cob.js
+++ b/lib/plugins/cob.js
@@ -45,7 +45,7 @@ function init (ctx) {
 
     const TEN_MINUTES = 10 * 60 * 1000;
 
-    if (_.isEmpty(result) || _.isNil(result.cob) || (Date.now() - result.mills) > TEN_MINUTES) {
+    if (_.isEmpty(result) || _.isNil(result.cob) || !Number.isFinite(result.mills) || (time - result.mills) > TEN_MINUTES) {
 
       var treatmentCOB = (treatments !== undefined && treatments.length) ? cob.fromTreatments(treatments, devicestatus, profile, time, spec_profile) : {};
 
@@ -284,7 +284,7 @@ function init (ctx) {
       info.push({ label: translate('Last Carbs'), value: amount + ' @ ' + when });
     }
 
-    sbx.pluginBase.updatePillText(sbx, {
+    sbx.pluginBase.updatePillText(cob, {
       value: displayCob + 'g'
       , label: translate('COB')
       , info: info

--- a/tests/cob.test.js
+++ b/tests/cob.test.js
@@ -84,6 +84,8 @@ describe('COB', function ( ) {
 
     ctx.pluginBase = {
         updatePillText: function mockedUpdatePillText (plugin, options) {
+          plugin.name.should.equal('cob');
+          plugin.pluginType.should.equal('pill-minor');
           options.value.should.equal('8g');
           done();
         }
@@ -170,6 +172,52 @@ describe('COB', function ( ) {
       });
     });
 
+    it('should return historical OpenAPS COB data when viewing retro time', function () {
+      var viewTime = time - (60 * 60 * 1000);
+      var cobTime = viewTime - 1;
+      var devicestatus = [{
+        device: 'openaps://pi1',
+        mills: cobTime,
+        openaps: {
+          enacted: {
+            COB: 6,
+            timestamp: cobTime
+          }
+        }
+      }];
+
+      cob.cobTotal([], devicestatus, profile, viewTime).should.containEql({
+        cob: 6,
+        source: 'OpenAPS',
+        device: 'openaps://pi1'
+      });
+    });
+
+    it('should fall back to treatments when historical OpenAPS COB is stale for retro time', function() {
+      var viewTime = time - (60 * 60 * 1000);
+      var staleCobTime = viewTime - (11 * 60 * 1000);
+      var retroTreatments = [{
+        mills: viewTime - 1,
+        carbs: '20'
+      }];
+      var retroTreatmentCOB = cob.fromTreatments(retroTreatments, [], profile, viewTime).cob;
+      var devicestatus = [{
+        device: 'openaps://pi1',
+        mills: staleCobTime,
+        openaps: {
+          enacted: {
+            COB: 6,
+            timestamp: staleCobTime
+          }
+        }
+      }];
+
+      cob.cobTotal(retroTreatments, devicestatus, profile, viewTime).should.containEql({
+        source: 'Care Portal',
+        cob: retroTreatmentCOB
+      });
+    });
+
     it('should return COB data from Loop', function () {
 
       var LOOP_DEVICESTATUS = {
@@ -184,6 +232,27 @@ describe('COB', function ( ) {
       var devicestatus = [_.merge(LOOP_DEVICESTATUS, { mills: time - 1, loop: {cob: {timestamp: time - 1} } })];
       cob.cobTotal(treatments, devicestatus, profile, time).should.containEql({
         cob: 5,
+        source: 'Loop',
+        device: 'loop://iPhone'
+      });
+    });
+
+    it('should return historical Loop COB data when viewing retro time', function () {
+      var viewTime = time - (60 * 60 * 1000);
+      var cobTime = viewTime - 1;
+      var devicestatus = [{
+        device: 'loop://iPhone',
+        mills: cobTime,
+        loop: {
+          cob: {
+            cob: 7,
+            timestamp: cobTime
+          }
+        }
+      }];
+
+      cob.cobTotal([], devicestatus, profile, viewTime).should.containEql({
+        cob: 7,
         source: 'Loop',
         device: 'loop://iPhone'
       });


### PR DESCRIPTION
## Summary
- use the viewed timeline time when checking whether controller-reported COB is fresh
- keep historical OpenAPS/iAPS/AAPS-style and Loop-style COB available while scrolling back
- fix the COB pill update to target the COB plugin object
- add regression tests for historical OpenAPS and Loop COB paths

## Why
Fixes #5241. The COB plugin could find a historical devicestatus COB value, then discard it because the freshness check compared that timestamp to real current time instead of the time being viewed. That made the pill fall back to treatment-derived COB, which could be zero or slightly different from the controller-reported COB.

PR #8081 was useful prior art, but this takes the broader path by using the existing device-status COB parser for both OpenAPS-style and Loop-style data instead of adding an OpenAPS-only special case.

## Validation
- `./node_modules/.bin/env-cmd -f ./tests/ci.test.env ./node_modules/.bin/mocha --timeout 5000 --require ./tests/hooks.js --exit tests/cob.test.js`
- `npm run bundle`
- `git diff --check`
