### PR TITLE
Add tests for weektoweek report date displays.

### DIFF
--- a/tests/reportplugins.weektoweek.test.js
+++ b/tests/reportplugins.weektoweek.test.js
@@ -1,0 +1,592 @@
+'use strict';
+
+require('should');
+var _ = require('lodash');
+var benv = require('benv');
+var serverSettings = require('./fixtures/default-server-settings');
+
+var nowData = {
+  sgvs: [
+    { mgdl: 100, mills: Date.now(), direction: 'Flat', type: 'sgv' }
+  ]
+  , treatments: []
+};
+
+function buildProfile (timezone) {
+  return [
+    {
+    //General values
+    'dia':3,
+
+    // Simple style values, 'from' are in minutes from midnight
+    'carbratio': [
+      {
+        'time': '00:00',
+        'value': 30
+      }],
+    'carbs_hr':30,
+    'delay': 20,
+    'sens': [
+      {
+        'time': '00:00',
+        'value': 100
+      }
+      , {
+        'time': '8:00',
+        'value': 80
+      }],
+    'startDate': new Date(),
+    'timezone': timezone,
+
+    //perGIvalues style values
+    'perGIvalues': false,
+    'carbs_hr_high': 30,
+    'carbs_hr_medium': 30,
+    'carbs_hr_low': 30,
+    'delay_high': 15,
+    'delay_medium': 20,
+    'delay_low': 20,
+
+    'basal':[
+      {
+        'time': '00:00',
+        'value': 0.1
+      }],
+    'target_low':[
+      {
+        'time': '00:00',
+        'value': 0
+      }],
+    'target_high':[
+      {
+        'time': '00:00',
+        'value': 0
+      }]
+    }
+  ];
+}
+
+describe('weektoweek reports', function ( ) {
+  var headless = require('./fixtures/headless')(benv, this);
+
+  before(function (done) {
+    done( );
+  });
+
+  after(function (done) {
+    done( );
+  });
+
+  beforeEach(function (done) {
+    var opts = {
+      htmlFile: __dirname + '/../views/reportindex.html'
+    , mockProfileEditor: true
+    , serverSettings: serverSettings
+    , mockSimpleAjax: {}
+    , benvRequires: [
+       __dirname + '/../static/js/reportinit.js'
+      ]
+    };
+    headless.setup(opts, done);
+  });
+
+  afterEach(function (done) {
+    // Unset the process TZ
+    delete process.env.TZ;
+
+    headless.teardown( );
+    done( );
+  });
+
+  it ('should produce week to week report', function (done) {
+    const testTimezone = 'Etc/UTC';
+
+    var client = window.Nightscout.client;
+
+    var hashauth = require('../lib/client/hashauth');
+    hashauth.init(client,$);
+    hashauth.verifyAuthentication = function mockVerifyAuthentication(next) {
+      hashauth.authenticated = true;
+      next(true);
+    };
+
+    window.confirm = function mockConfirm () {
+      return true;
+    };
+
+    window.alert = function mockAlert () {
+      return true;
+    };
+
+    window.setTimeout = function mockSetTimeout (call, timer) {
+      if (timer == 60000) return;
+      call();
+    };
+
+    window.Nightscout.reportclient();
+
+    // Because we're looking at date headings, we need to force a
+    // specific timezone
+    process.env.TZ = testTimezone;
+
+    client.init(function afterInit ( ) {
+      client.dataUpdate(nowData);
+
+      console.log('Sending profile to client');
+
+      // Load profile matching browser timezone
+      client.sbx.data.profile.loadData(buildProfile(testTimezone));
+
+      $('#weektoweek').click();
+      $('a.presetdates :first').click();
+      $('#rp_from').val('2015-08-08');
+      $('#rp_to').val('2015-09-07');
+      $('#wrp_log').prop('checked', true);
+      $('#rp_show').click();
+
+      $('#wrp_linear').prop('checked', true);
+      $('#rp_show').click();
+      $('.ui-button:contains("Save")').click();
+
+      var result = $('body').html();
+
+      // Select bold text as a child of the chart
+      var charts = $('#weektoweekcharts b');
+
+      // check the titles
+      result.indexOf('<h2>Week to week</h2>').should.be.greaterThan(-1);
+
+      charts.length.should.equal(5);
+
+      charts[0].textContent.should.equal('Tuesday 09/01/2015-Monday 09/07/2015');
+      charts[1].textContent.should.equal('Tuesday 08/25/2015-Monday 08/31/2015');
+      charts[2].textContent.should.equal('Tuesday 08/18/2015-Monday 08/24/2015');
+      charts[3].textContent.should.equal('Tuesday 08/11/2015-Monday 08/17/2015');
+      charts[4].textContent.should.equal('Saturday 08/08/2015-Monday 08/10/2015');
+
+      // Verify week-to-week report renders circles with expected day-of-week colors
+      // Note: Exact coordinates are not checked as they vary with chart dimensions
+      result.indexOf('fill="rgb(73, 22, 153)"').should.be.greaterThan(-1); // Sunday color
+      result.indexOf('fill="rgb(34, 201, 228)"').should.be.greaterThan(-1); // Monday color
+      result.indexOf('fill="rgb(0, 153, 123)"').should.be.greaterThan(-1); // Tuesday color
+      result.indexOf('fill="rgb(135, 135, 228)"').should.be.greaterThan(-1); // Wednesday color
+      result.indexOf('fill="rgb(135, 49, 204)"').should.be.greaterThan(-1); // Thursday color
+      result.indexOf('fill="rgb(36, 36, 228)"').should.be.greaterThan(-1); // Friday color
+      result.indexOf('fill="rgb(0, 234, 188)"').should.be.greaterThan(-1); // Saturday color
+
+      done();
+    });
+  });
+
+  it ('should produce week to week report in a negative offset timezone', function (done) {
+    const startDateString = '2015-08-08';
+    const endDateString = '2015-09-07';
+
+    const browserTimezone = 'Etc/GMT+6'; // Etc offsets are reversed
+    const profileTimezone = browserTimezone;
+
+    var client = window.Nightscout.client;
+    var jqueryAjax = window.$.ajax.bind({}); // Hold a reference so we can check the call args
+
+    var hashauth = require('../lib/client/hashauth');
+    hashauth.init(client,$);
+    hashauth.verifyAuthentication = function mockVerifyAuthentication(next) {
+      hashauth.authenticated = true;
+      next(true);
+    };
+
+    var requestUrls = [];
+
+    window.$.ajax = function mockAjax (url, settings) {
+        if (typeof(url) === 'string') {
+            if (url.startsWith('/api/v1/entries.json')) {
+                requestUrls.push(url);
+            }
+        }
+
+        return jqueryAjax(url, settings);
+    }
+
+    window.confirm = function mockConfirm () {
+      return true;
+    };
+
+    window.alert = function mockAlert () {
+      return true;
+    };
+
+    window.setTimeout = function mockSetTimeout (call, timer) {
+      if (timer == 60000) return;
+      call();
+    };
+
+    window.Nightscout.reportclient();
+
+    // Because we're looking at date headings, we need to force a
+    // specific timezone
+
+    // Set the process / system TZ for tests
+    process.env.TZ = browserTimezone;
+
+    client.init(function afterInit ( ) {
+      client.dataUpdate(nowData);
+
+      console.log('Sending profile to client');
+
+      // Set the profile timezone to something different from the browser timezone
+      client.sbx.data.profile.loadData(buildProfile(profileTimezone));
+
+      $('#weektoweek').click();
+      $('a.presetdates :first').click();
+      $('#rp_from').val(startDateString);
+      $('#rp_to').val(endDateString);
+      $('#wrp_log').prop('checked', true);
+      $('#rp_show').click();
+
+      $('#wrp_linear').prop('checked', true);
+      $('#rp_show').click();
+      $('.ui-button:contains("Save")').click();
+
+      // Select bold text as a child of the chart
+      var charts = $('#weektoweekcharts b');
+
+      charts.length.should.equal(5);
+
+      charts[0].textContent.should.equal('Tuesday 09/01/2015-Monday 09/07/2015');
+      charts[1].textContent.should.equal('Tuesday 08/25/2015-Monday 08/31/2015');
+      charts[2].textContent.should.equal('Tuesday 08/18/2015-Monday 08/24/2015');
+      charts[3].textContent.should.equal('Tuesday 08/11/2015-Monday 08/17/2015');
+      charts[4].textContent.should.equal('Saturday 08/08/2015-Monday 08/10/2015');
+
+      //TODO: Fix duplicate API calls
+      requestUrls = _.uniq(requestUrls);
+
+      var startMoment = window.moment(startDateString).startOf('day');
+      var endMoment = window.moment(endDateString).endOf('day');
+
+      //We need to add a day, because the results do not end at the start of
+      //the day as represented by endMoment, but the end of the day
+      var numberOfDays = endMoment.diff(startMoment, 'days') + 1;
+
+      requestUrls.length.should.equal(numberOfDays);
+
+      for (var i = 0; i < numberOfDays; i++) {
+        var requestStartMoment = window.moment.tz(window.moment.tz(startDateString, browserTimezone).startOf('day'), profileTimezone).add(i, 'days');
+        var requestEndMoment = window.moment.tz(window.moment.tz(startDateString, browserTimezone).startOf('day'), profileTimezone).add(i + 1, 'days');
+
+        requestUrls[i].should.equal('/api/v1/entries.json?find[date][$gte]=' + requestStartMoment.format('x') + '&find[date][$lt]=' + requestEndMoment.format('x') + '&count=10000');
+      }
+
+      done();
+    });
+  });
+
+  it ('should produce week to week report in a positive offset timezone', function (done) {
+    const startDateString = '2015-08-08';
+    const endDateString = '2015-09-07';
+
+    const browserTimezone = 'Etc/GMT-6'; // Etc offsets are reversed
+    const profileTimezone = browserTimezone;
+
+    var client = window.Nightscout.client;
+    var jqueryAjax = window.$.ajax.bind({}); // Hold a reference so we can check the call args
+
+    var hashauth = require('../lib/client/hashauth');
+    hashauth.init(client,$);
+    hashauth.verifyAuthentication = function mockVerifyAuthentication(next) {
+      hashauth.authenticated = true;
+      next(true);
+    };
+
+    var requestUrls = [];
+
+    window.$.ajax = function mockAjax (url, settings) {
+        if (typeof(url) === 'string') {
+            if (url.startsWith('/api/v1/entries.json')) {
+                requestUrls.push(url);
+            }
+        }
+
+        return jqueryAjax(url, settings);
+    }
+
+    window.confirm = function mockConfirm () {
+      return true;
+    };
+
+    window.alert = function mockAlert () {
+      return true;
+    };
+
+    window.setTimeout = function mockSetTimeout (call, timer) {
+      if (timer == 60000) return;
+      call();
+    };
+
+    window.Nightscout.reportclient();
+
+    // Because we're looking at date headings, we need to force a
+    // specific timezone
+
+    // Set the process / system TZ for tests
+    process.env.TZ = browserTimezone;
+
+    client.init(function afterInit ( ) {
+      client.dataUpdate(nowData);
+
+      console.log('Sending profile to client');
+
+      // Set the profile timezone to something different from the browser timezone
+      client.sbx.data.profile.loadData(buildProfile(profileTimezone));
+
+      $('#weektoweek').click();
+      $('a.presetdates :first').click();
+      $('#rp_from').val(startDateString);
+      $('#rp_to').val(endDateString);
+      $('#wrp_log').prop('checked', true);
+      $('#rp_show').click();
+
+      $('#wrp_linear').prop('checked', true);
+      $('#rp_show').click();
+      $('.ui-button:contains("Save")').click();
+
+      // Select bold text as a child of the chart
+      var charts = $('#weektoweekcharts b');
+
+      charts.length.should.equal(5);
+
+      charts[0].textContent.should.equal('Tuesday 09/01/2015-Monday 09/07/2015');
+      charts[1].textContent.should.equal('Tuesday 08/25/2015-Monday 08/31/2015');
+      charts[2].textContent.should.equal('Tuesday 08/18/2015-Monday 08/24/2015');
+      charts[3].textContent.should.equal('Tuesday 08/11/2015-Monday 08/17/2015');
+      charts[4].textContent.should.equal('Saturday 08/08/2015-Monday 08/10/2015');
+
+      //TODO: Fix duplicate API calls
+      requestUrls = _.uniq(requestUrls);
+
+      var startMoment = window.moment(startDateString).startOf('day');
+      var endMoment = window.moment(endDateString).endOf('day');
+
+      //We need to add a day, because the results do not end at the start of
+      //the day as represented by endMoment, but the end of the day
+      var numberOfDays = endMoment.diff(startMoment, 'days') + 1;
+
+      requestUrls.length.should.equal(numberOfDays);
+
+      for (var i = 0; i < numberOfDays; i++) {
+        var requestStartMoment = window.moment.tz(window.moment.tz(startDateString, browserTimezone).startOf('day'), profileTimezone).add(i, 'days');
+        var requestEndMoment = window.moment.tz(window.moment.tz(startDateString, browserTimezone).startOf('day'), profileTimezone).add(i + 1, 'days');
+
+        requestUrls[i].should.equal('/api/v1/entries.json?find[date][$gte]=' + requestStartMoment.format('x') + '&find[date][$lt]=' + requestEndMoment.format('x') + '&count=10000');
+      }
+
+      done();
+    });
+  });
+
+  it ('should produce week to week report in the requested range when the requested start date in the browser would change after profile timezone application', function (done) {
+    const startDateString = '2015-08-08';
+    const endDateString = '2015-09-07';
+
+    const browserTimezone = 'Etc/UTC';
+    const profileTimezone = 'Etc/GMT+6';
+
+    var client = window.Nightscout.client;
+    var jqueryAjax = window.$.ajax.bind({}); // Hold a reference so we can check the call args
+
+    var hashauth = require('../lib/client/hashauth');
+    hashauth.init(client,$);
+    hashauth.verifyAuthentication = function mockVerifyAuthentication(next) {
+      hashauth.authenticated = true;
+      next(true);
+    };
+
+    var requestUrls = [];
+
+    window.$.ajax = function mockAjax (url, settings) {
+        if (typeof(url) === 'string') {
+            if (url.startsWith('/api/v1/entries.json')) {
+                requestUrls.push(url);
+            }
+        }
+
+        return jqueryAjax(url, settings);
+    }
+
+    window.confirm = function mockConfirm () {
+      return true;
+    };
+
+    window.alert = function mockAlert () {
+      return true;
+    };
+
+    window.setTimeout = function mockSetTimeout (call, timer) {
+      if (timer == 60000) return;
+      call();
+    };
+
+    window.Nightscout.reportclient();
+
+    // Because we're looking at date headings, we need to force a
+    // specific timezone
+
+    // Set the process / system TZ for tests
+    process.env.TZ = browserTimezone;
+
+    client.init(function afterInit ( ) {
+      client.dataUpdate(nowData);
+
+      console.log('Sending profile to client');
+
+      // Set the profile timezone to something different from the browser timezone
+      client.sbx.data.profile.loadData(buildProfile(profileTimezone));
+
+      $('#weektoweek').click();
+      $('a.presetdates :first').click();
+      $('#rp_from').val(startDateString);
+      $('#rp_to').val(endDateString);
+      $('#wrp_log').prop('checked', true);
+      $('#rp_show').click();
+
+      $('#wrp_linear').prop('checked', true);
+      $('#rp_show').click();
+      $('.ui-button:contains("Save")').click();
+
+      // Select bold text as a child of the chart
+      var charts = $('#weektoweekcharts b');
+
+      charts.length.should.equal(5);
+
+      charts[0].textContent.should.equal('Tuesday 09/01/2015-Monday 09/07/2015');
+      charts[1].textContent.should.equal('Tuesday 08/25/2015-Monday 08/31/2015');
+      charts[2].textContent.should.equal('Tuesday 08/18/2015-Monday 08/24/2015');
+      charts[3].textContent.should.equal('Tuesday 08/11/2015-Monday 08/17/2015');
+      charts[4].textContent.should.equal('Saturday 08/08/2015-Monday 08/10/2015');
+
+      //TODO: Fix duplicate API calls
+      requestUrls = _.uniq(requestUrls);
+
+      var startMoment = window.moment(startDateString).startOf('day');
+      var endMoment = window.moment(endDateString).endOf('day');
+
+      //We need to add a day, because the results do not end at the start of
+      //the day as represented by endMoment, but the end of the day
+      var numberOfDays = endMoment.diff(startMoment, 'days') + 1;
+
+      requestUrls.length.should.equal(numberOfDays);
+
+      for (var i = 0; i < numberOfDays; i++) {
+        var requestStartMoment = window.moment.tz(window.moment.tz(startDateString, browserTimezone).startOf('day'), profileTimezone).add(i, 'days');
+        var requestEndMoment = window.moment.tz(window.moment.tz(startDateString, browserTimezone).startOf('day'), profileTimezone).add(i + 1, 'days');
+
+        requestUrls[i].should.equal('/api/v1/entries.json?find[date][$gte]=' + requestStartMoment.format('x') + '&find[date][$lt]=' + requestEndMoment.format('x') + '&count=10000');
+      }
+
+      done();
+    });
+  });
+
+  it ('should produce week to week report in the requested range when the requested end date in the browser would change after profile timezone application', function (done) {
+    const startDateString = '2015-08-08';
+    const endDateString = '2015-09-07';
+
+    const browserTimezone = 'Etc/UTC';
+    const profileTimezone = 'Etc/GMT-6';
+
+    var client = window.Nightscout.client;
+    var jqueryAjax = window.$.ajax.bind({}); // Hold a reference so we can check the call args
+
+    var hashauth = require('../lib/client/hashauth');
+    hashauth.init(client,$);
+    hashauth.verifyAuthentication = function mockVerifyAuthentication(next) {
+      hashauth.authenticated = true;
+      next(true);
+    };
+
+    var requestUrls = [];
+
+    window.$.ajax = function mockAjax (url, settings) {
+        if (typeof(url) === 'string') {
+            if (url.startsWith('/api/v1/entries.json')) {
+                requestUrls.push(url);
+            }
+        }
+
+        return jqueryAjax(url, settings);
+    }
+
+    window.confirm = function mockConfirm () {
+      return true;
+    };
+
+    window.alert = function mockAlert () {
+      return true;
+    };
+
+    window.setTimeout = function mockSetTimeout (call, timer) {
+      if (timer == 60000) return;
+      call();
+    };
+
+    window.Nightscout.reportclient();
+
+    // Because we're looking at date headings, we need to force a
+    // specific timezone
+
+    // Set the process / system TZ for tests
+    process.env.TZ = browserTimezone;
+
+    client.init(function afterInit ( ) {
+      client.dataUpdate(nowData);
+
+      console.log('Sending profile to client');
+
+      // Set the profile timezone to something different from the browser timezone
+      client.sbx.data.profile.loadData(buildProfile(profileTimezone));
+
+      $('#weektoweek').click();
+      $('a.presetdates :first').click();
+      $('#rp_from').val(startDateString);
+      $('#rp_to').val(endDateString);
+      $('#wrp_log').prop('checked', true);
+      $('#rp_show').click();
+
+      $('#wrp_linear').prop('checked', true);
+      $('#rp_show').click();
+      $('.ui-button:contains("Save")').click();
+
+      // Select bold text as a child of the chart
+      var charts = $('#weektoweekcharts b');
+
+      charts.length.should.equal(5);
+
+      charts[0].textContent.should.equal('Tuesday 09/01/2015-Monday 09/07/2015');
+      charts[1].textContent.should.equal('Tuesday 08/25/2015-Monday 08/31/2015');
+      charts[2].textContent.should.equal('Tuesday 08/18/2015-Monday 08/24/2015');
+      charts[3].textContent.should.equal('Tuesday 08/11/2015-Monday 08/17/2015');
+      charts[4].textContent.should.equal('Saturday 08/08/2015-Monday 08/10/2015');
+
+      //TODO: Fix duplicate API calls
+      requestUrls = _.uniq(requestUrls);
+
+      var startMoment = window.moment(startDateString).startOf('day');
+      var endMoment = window.moment(endDateString).endOf('day');
+
+      //We need to add a day, because the results do not end at the start of
+      //the day as represented by endMoment, but the end of the day
+      var numberOfDays = endMoment.diff(startMoment, 'days') + 1;
+
+      requestUrls.length.should.equal(numberOfDays);
+
+      for (var i = 0; i < numberOfDays; i++) {
+        var requestStartMoment = window.moment.tz(window.moment.tz(startDateString, browserTimezone).startOf('day'), profileTimezone).add(i, 'days');
+        var requestEndMoment = window.moment.tz(window.moment.tz(startDateString, browserTimezone).startOf('day'), profileTimezone).add(i + 1, 'days');
+
+        requestUrls[i].should.equal('/api/v1/entries.json?find[date][$gte]=' + requestStartMoment.format('x') + '&find[date][$lt]=' + requestEndMoment.format('x') + '&count=10000');
+      }
+
+      done();
+    });
+  });
+});

--- a/tests/reports.test.js
+++ b/tests/reports.test.js
@@ -1,9 +1,7 @@
 'use strict';
 
 require('should');
-var _ = require('lodash');
 var benv = require('benv');
-var read = require('fs').readFileSync;
 var serverSettings = require('./fixtures/default-server-settings');
 
 var nowData = {
@@ -24,7 +22,6 @@ var someData = {
   '/api/v1/treatments.json?find[created_at][$gte]=2015-08-11T00:00:00.000Z&find[created_at][$lt]=2015-08-12T00:00:00.000Z&count=1000': [{'created_at':'2015-08-11T23:37:00.000Z','eventType':'Snack Bolus','carbs':18,'_id':'55ca8644ca3c57683d19c211'},{'enteredBy':'Mom ','eventType':'Snack Bolus','glucose':203,'glucoseType':'Sensor','insulin':1,'preBolus':15,'units':'mg/dl','created_at':'2015-08-11T23:22:00.000Z','_id':'55ca8644ca3c57683d19c210'}],
   '/api/v1/entries.json?find[date][$gte]=1439337600000&find[date][$lt]=1439424000000&count=10000': [{'_id':'55cbddee38a8d88ad1b48647','unfiltered':165760,'filtered':167488,'direction':'Flat','device':'dexcom','rssi':165,'sgv':157,'dateString':'Wed Aug 12 16:58:28 PDT 2015','type':'sgv','date':1439423908000,'noise':1},{'_id':'55cbdccc38a8d88ad1b48644','unfiltered':167456,'filtered':169312,'direction':'Flat','device':'dexcom','rssi':168,'sgv':159,'dateString':'Wed Aug 12 16:53:28 PDT 2015','type':'sgv','date':1439423608000,'noise':1}],
   '/api/v1/treatments.json?find[created_at][$gte]=2015-08-12T00:00:00.000Z&find[created_at][$lt]=2015-08-14T23:59:59.999Z&count=1000': [{'enteredBy':'Dad','eventType':'Correction Bolus','insulin':0.8,'created_at':'2015-08-12T23:21:08.907Z','_id':'55cbd4e47e726599048a3f91'},{'enteredBy':'Dad','eventType':'Note','notes':'Milk now','created_at':'2015-08-12T21:23:00.000Z','_id':'55cbba4e7e726599048a3f79'}],
-  '/api/v1/treatments.json?find[created_at][$gte]=2015-08-12T00:00:00.000Z&find[created_at][$lt]=2015-08-13T00:00:00.000Z&count=1000': [{'enteredBy':'Dad','eventType':'Correction Bolus','insulin':0.8,'created_at':'2015-08-12T23:21:08.907Z','_id':'55cbd4e47e726599048a3f91'},{'enteredBy':'Dad','eventType':'Note','notes':'Milk now','created_at':'2015-08-12T21:23:00.000Z','_id':'55cbba4e7e726599048a3f79'}],
   '/api/v1/treatments.json?find[created_at][$gte]=2015-08-12T00:00:00.000Z&find[created_at][$lt]=2015-08-13T00:00:00.000Z&count=1000': [{'enteredBy':'Dad','eventType':'Correction Bolus','insulin':0.8,'created_at':'2015-08-12T23:21:08.907Z','_id':'55cbd4e47e726599048a3f91'},{'enteredBy':'Dad','eventType':'Note','notes':'Milk now','created_at':'2015-08-12T21:23:00.000Z','_id':'55cbba4e7e726599048a3f79'}],
   '/api/v1/entries.json?find[date][$gte]=1439424000000&find[date][$lt]=1439510400000&count=10000': [{'_id':'55cd2f6738a8d88ad1b48ca1','unfiltered':209792,'filtered':229344,'direction':'SingleDown','device':'dexcom','rssi':436,'sgv':205,'dateString':'Thu Aug 13 16:58:24 PDT 2015','type':'sgv','date':1439510304000,'noise':1},{'_id':'55cd2e3b38a8d88ad1b48c95','unfiltered':220928,'filtered':237472,'direction':'FortyFiveDown','device':'dexcom','rssi':418,'sgv':219,'dateString':'Thu Aug 13 16:53:24 PDT 2015','type':'sgv','date':1439510004000,'noise':1}],
   '/api/v1/treatments.json?find[created_at][$gte]=2015-08-13T00:00:00.000Z&find[created_at][$lt]=2015-08-14T00:00:00.000Z&count=1000': [{'enteredBy':'Mom ','eventType':'Correction Bolus','glucose':250,'glucoseType':'Sensor','insulin':0.75,'units':'mg/dl','created_at':'2015-08-13T23:45:56.927Z','_id':'55cd2c3497fa97ac5d8bc53b'},{'enteredBy':'Mom ','eventType':'Correction Bolus','glucose':198,'glucoseType':'Sensor','insulin':1.1,'units':'mg/dl','created_at':'2015-08-13T23:11:00.293Z','_id':'55cd240497fa97ac5d8bc535'}],
@@ -328,7 +325,7 @@ describe('reports', function ( ) {
   var self = this;
   var headless = require('./fixtures/headless')(benv, this);
   this.timeout(80000);
-  
+
   before(function (done) {
     done( );
   });
@@ -351,6 +348,9 @@ describe('reports', function ( ) {
   });
 
   afterEach(function (done) {
+    // Unset the process TZ
+    delete process.env.TZ;
+
     headless.teardown( );
     done( );
   });
@@ -366,21 +366,28 @@ describe('reports', function ( ) {
       next(true);
     };
 
-     window.confirm = function mockConfirm () {
-       return true;
-     };
+    window.confirm = function mockConfirm () {
+      return true;
+    };
 
-     window.alert = function mockAlert () {
-       return true;
-     };
-     
-     
-     window.setTimeout = function mockSetTimeout (call, timer) {
-       if (timer == 60000) return;
-       call();
-     };
+    window.alert = function mockAlert () {
+      return true;
+    };
 
-     window.Nightscout.reportclient();
+    window.setTimeout = function mockSetTimeout (call, timer) {
+      if (timer == 60000) return;
+      call();
+    };
+
+    window.Nightscout.reportclient();
+
+    // Timezone is reflected in query strings so we force one
+    function mockGetTimezone () {
+      return 'Etc/UTC';
+    }
+
+    // Set the process / system TZ for tests
+    process.env.TZ = mockGetTimezone();
 
     client.init(function afterInit ( ) {
       client.dataUpdate(nowData);
@@ -415,7 +422,6 @@ describe('reports', function ( ) {
       $('img.editTreatment:first').click();
       $('.ui-button:contains("Save")').click();
 
-      
       var result = $('body').html();
       /*
       var filesys = require('fs');
@@ -436,66 +442,4 @@ describe('reports', function ( ) {
       done();
     });
   });
-
-  it ('should produce week to week report', function (done) {
-    var client = window.Nightscout.client;
-
-    var hashauth = require('../lib/client/hashauth');
-    hashauth.init(client,$);
-    hashauth.verifyAuthentication = function mockVerifyAuthentication(next) {
-      hashauth.authenticated = true;
-      next(true);
-    };
-
-     window.confirm = function mockConfirm () {
-       return true;
-     };
-
-     window.alert = function mockAlert () {
-       return true;
-     };
-  
-     window.setTimeout = function mockSetTimeout (call, timer) {
-      if (timer == 60000) return;
-      call();
-     };
-
-     window.Nightscout.reportclient();
-
-    client.init(function afterInit ( ) {
-      client.dataUpdate(nowData);
-
-                console.log('Sending profile to client');
-
-      // Load profile, we need to operate in UTC
-      client.sbx.data.profile.loadData(exampleProfile);
-
-      $('#weektoweek').addClass('selected');
-      $('a.presetdates :first').click();
-      $('#rp_from').val('2015-08-08');
-      $('#rp_to').val('2015-09-07');
-      $('#wrp_log').prop('checked', true);
-      $('#rp_show').click();
-
-      $('#wrp_linear').prop('checked', true);
-      $('#rp_show').click();
-      $('.ui-button:contains("Save")').click();
-
-      var result = $('body').html();
-
-      // Verify week-to-week report renders circles with expected day-of-week colors
-      // Note: Exact coordinates are not checked as they vary with chart dimensions
-      result.indexOf('fill="rgb(73, 22, 153)"').should.be.greaterThan(-1); // Sunday color
-      result.indexOf('fill="rgb(34, 201, 228)"').should.be.greaterThan(-1); // Monday color
-      result.indexOf('fill="rgb(0, 153, 123)"').should.be.greaterThan(-1); // Tuesday color
-      result.indexOf('fill="rgb(135, 135, 228)"').should.be.greaterThan(-1); // Wednesday color
-      result.indexOf('fill="rgb(135, 49, 204)"').should.be.greaterThan(-1); // Thursday color
-      result.indexOf('fill="rgb(36, 36, 228)"').should.be.greaterThan(-1); // Friday color
-      result.indexOf('fill="rgb(0, 234, 188)"').should.be.greaterThan(-1); // Saturday color
-
-      done();
-    });
-    
-  });
-  
 });


### PR DESCRIPTION
With fixes for incorrect dates now landed in #8469 and #8485, add tests to verify correct date displays for the weektoweek report type.

These were written to verify the fixes from my [date fixes branch](https://github.com/bniels707/cgm-remote-monitor/tree/report_date_display_fixes) that I was siting on waiting for test suite fixes to land, now might as well merge the tests on their own to prove the related issues are fixed.

Longer term I'm hoping to add similar tests for all report types (and fix the issues with repeated API requests, and the "some html" test being slow).