### PR TITLE
Fix Docker hostname binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ autonomy for your data:
   * `MONGO_MIN_POOL_SIZE` (`0`) - Minimum pool connections to keep open.
   * `MONGO_MAX_IDLE_TIME_MS` (`30000`) - Max idle time (ms) before closing a connection.
   * `PORT` (`1337`) - The port that the node.js application will listen on.
-  * `HOSTNAME` - The hostname that the node.js application will listen on, null by default for any hostname for IPv6 you may need to use `::`.
+  * `NIGHTSCOUT_HOSTNAME` - The hostname or address that the node.js application will listen on. Leave unset to listen on all interfaces. Docker users can set this to `0.0.0.0` when Nightscout is reached through another container or reverse proxy. The older `HOSTNAME` setting is still accepted for compatibility, but should not be used for new installs because container platforms often set it automatically.
   * `SSL_KEY` - Path to your ssl key file, so that ssl(https) can be enabled directly in node.js. If using Let's Encrypt, make this variable the path to your privkey.pem file (private key).
   * `SSL_CERT` - Path to your ssl cert file, so that ssl(https) can be enabled directly in node.js. If using Let's Encrypt, make this variable the path to fullchain.pem file (cert + ca).
   * `SSL_CA` - Path to your ssl ca file, so that ssl(https) can be enabled directly in node.js. If using Let's Encrypt, make this variable the path to chain.pem file (chain).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       # The `nightscout` service can use HTTP, because we use `traefik` to serve the HTTPS
       # and manage TLS certificates
       INSECURE_USE_HTTP: 'true'
+      # Listen on all container interfaces so reverse proxies and other containers can reach Nightscout
+      NIGHTSCOUT_HOSTNAME: '0.0.0.0'
 
       # For all other settings, please refer to the Environment section of the README
       ### Required variables

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -13,6 +13,7 @@ const stringEntropy = require('fast-password-entropy')
 
 const fs = require('fs');
 const crypto = require('crypto');
+const os = require('os');
 const consts = require('../constants');
 
 const env = {
@@ -34,7 +35,7 @@ function config () {
   });
 
   env.PORT = readENV('PORT', 1337);
-  env.HOSTNAME = readENV('HOSTNAME', null);
+  env.HOSTNAME = readHostname();
   env.IMPORT_CONFIG = readENV('IMPORT_CONFIG', null);
   env.static_files = readENV('NIGHTSCOUT_STATIC_FILES', '/static');
   env.debug = {
@@ -204,10 +205,60 @@ function readENV (varName, defaultValue) {
   return value != null ? value : defaultValue;
 }
 
+function readENVRaw (varName) {
+  var keys = [
+    'CUSTOMCONNSTR_' + varName,
+    'CUSTOMCONNSTR_' + varName.toLowerCase(),
+    varName,
+    varName.toLowerCase()
+  ];
+
+  for (var i = 0; i < keys.length; i++) {
+    if (Object.prototype.hasOwnProperty.call(shadowEnv, keys[i])) {
+      return shadowEnv[keys[i]];
+    }
+  }
+}
+
 function readENVTruthy (varName, defaultValue) {
   var value = readENV(varName, defaultValue);
   if (typeof value === 'string' && (value.toLowerCase() === 'on' || value.toLowerCase() === 'true')) { value = true; } else if (typeof value === 'string' && (value.toLowerCase() === 'off' || value.toLowerCase() === 'false')) { value = false; } else { value = defaultValue }
   return value;
+}
+
+function readHostname () {
+  var nightscoutHostname = readENVRaw('NIGHTSCOUT_HOSTNAME');
+  if (nightscoutHostname !== undefined) {
+    return nightscoutHostname || null;
+  }
+
+  var legacyHostname = readENVRaw('HOSTNAME');
+  if (!legacyHostname || isContainerGeneratedHostname(legacyHostname)) {
+    return null;
+  }
+
+  return legacyHostname;
+}
+
+function isContainerGeneratedHostname (hostname) {
+  return isContainerRuntime() && hostname === os.hostname();
+}
+
+function isContainerRuntime () {
+  if (shadowEnv.container || shadowEnv.CONTAINER) {
+    return true;
+  }
+
+  if (fs.existsSync('/.dockerenv')) {
+    return true;
+  }
+
+  try {
+    var cgroup = fs.readFileSync('/proc/1/cgroup', 'utf8');
+    return /docker|kubepods|containerd|libpod|podman/.test(cgroup);
+  } catch (err) {
+    return false;
+  }
 }
 
 function findExtendedSettings (envs) {

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('should');
+var should = require('should');
+var os = require('os');
 
 describe('env', function () {
   it( 'show the right plugins', function () {
@@ -67,6 +68,77 @@ describe('env', function () {
     env = require( '../lib/server/env' )();
     env.insecureUseHttp.should.be.false(); // not defined should be false
     env.secureHstsHeader.should.be.true();
+  });
+
+  describe('HOSTNAME', function () {
+    var originalHostname;
+    var originalNightscoutHostname;
+    var originalContainer;
+
+    beforeEach(function () {
+      originalHostname = process.env.HOSTNAME;
+      originalNightscoutHostname = process.env.NIGHTSCOUT_HOSTNAME;
+      originalContainer = process.env.container;
+
+      delete process.env.HOSTNAME;
+      delete process.env.NIGHTSCOUT_HOSTNAME;
+      delete process.env.container;
+    });
+
+    afterEach(function () {
+      if (originalHostname === undefined) {
+        delete process.env.HOSTNAME;
+      } else {
+        process.env.HOSTNAME = originalHostname;
+      }
+
+      if (originalNightscoutHostname === undefined) {
+        delete process.env.NIGHTSCOUT_HOSTNAME;
+      } else {
+        process.env.NIGHTSCOUT_HOSTNAME = originalNightscoutHostname;
+      }
+
+      if (originalContainer === undefined) {
+        delete process.env.container;
+      } else {
+        process.env.container = originalContainer;
+      }
+    });
+
+    it('prefers NIGHTSCOUT_HOSTNAME over legacy HOSTNAME', function () {
+      process.env.NIGHTSCOUT_HOSTNAME = '0.0.0.0';
+      process.env.HOSTNAME = 'legacy-hostname';
+
+      var env = require('../lib/server/env')();
+
+      env.HOSTNAME.should.equal('0.0.0.0');
+    });
+
+    it('treats empty NIGHTSCOUT_HOSTNAME as all interfaces', function () {
+      process.env.NIGHTSCOUT_HOSTNAME = '';
+      process.env.HOSTNAME = 'legacy-hostname';
+
+      var env = require('../lib/server/env')();
+
+      should(env.HOSTNAME).equal(null);
+    });
+
+    it('keeps legacy HOSTNAME when explicitly configured outside Docker', function () {
+      process.env.HOSTNAME = '127.0.0.1';
+
+      var env = require('../lib/server/env')();
+
+      env.HOSTNAME.should.equal('127.0.0.1');
+    });
+
+    it('ignores Docker generated HOSTNAME', function () {
+      process.env.container = 'docker';
+      process.env.HOSTNAME = os.hostname();
+
+      var env = require('../lib/server/env')();
+
+      should(env.HOSTNAME).equal(null);
+    });
   });
 
   describe( 'DISPLAY_UNITS', function () {


### PR DESCRIPTION
## Summary

Fixes #8407.

This changes Nightscout's bind-host configuration so Docker's automatically injected `HOSTNAME` value is not accidentally treated as an intentional Nightscout setting.

## What changed

- Added `NIGHTSCOUT_HOSTNAME` as the preferred environment variable for the address/hostname passed to `server.listen()`.
- Kept legacy `HOSTNAME` support for existing non-Docker deployments that intentionally set it.
- Ignored container-generated `HOSTNAME` values, so Docker defaults back to listening on all interfaces instead of binding to the generated container hostname.
- Updated the Docker Compose example to set `NIGHTSCOUT_HOSTNAME: '0.0.0.0'` for reverse proxy/container access.
- Updated README documentation to point users at `NIGHTSCOUT_HOSTNAME` and explain why `HOSTNAME` should not be used for new installs.
- Added env tests covering the new preferred setting, legacy fallback, empty/all-interface behavior, and Docker-generated hostname handling.

## Why

Docker sets `HOSTNAME` automatically inside containers. Nightscout was reading that generic value and passing it to Node's listen call, which could make the app bind to a container-internal hostname rather than listening where reverse proxies or other containers can reach it. Users were working around this by setting `HOSTNAME=0.0.0.0`; this makes that behavior explicit and avoids the Docker naming conflict.

## Validation

- `./node_modules/.bin/env-cmd -f ./tests/ci.test.env ./node_modules/.bin/mocha --timeout 5000 --require ./tests/hooks.js --exit ./tests/env.test.js`
- `docker compose config --quiet`
- `git diff --check`
