### PR TITLE
Fix Loopalyzer localization gaps

### DIFF
--- a/lib/report_plugins/loopalyzer.js
+++ b/lib/report_plugins/loopalyzer.js
@@ -900,14 +900,14 @@ loopalyzer.generateReport = function(datastorage, daysToShow, options) {
   var client = Nightscout.client;
   var translate = client.translate;
   var profile = client.sbx.data.profile;
-  // var report_plugins = Nightscout.report_plugins;
+  var report_plugins = Nightscout.report_plugins;
   // var scaledTreatmentBG = report_plugins.utils.scaledTreatmentBG;
 
   var today = new Date();
   var todayJSON = { 'year': today.getFullYear(), 'month': today.getMonth(), 'date': today.getDate() };
 
-  var dateInfo = profile.parseInTimezone(daysToShow[0]).format('ddd MMM D'); // .split(',')[0];
-  if (daysToShow.length > 1) dateInfo += ' - ' + profile.parseInTimezone(daysToShow[daysToShow.length - 1]).format('ddd MMM D'); // .split(',')[0];
+  var dateInfo = report_plugins.utils.localeDate(daysToShow[0]);
+  if (daysToShow.length > 1) dateInfo += ' - ' + report_plugins.utils.localeDate(daysToShow[daysToShow.length - 1]);
   $("#loopalyzer-dateinfo").html(dateInfo);
 
   loopalyzer.prepareHtml();
@@ -1105,7 +1105,7 @@ loopalyzer.generateReport = function(datastorage, daysToShow, options) {
     markings.push({ xaxis: { from: timeShiftStartTime.toDate(), to: timeShiftStopTime.toDate() }, color: timeShiftBackgroundColor });
   var chartBasalData = [{
     data: basalsAvg
-    , label: translate('Basal profile')
+    , label: translate('Basal Profile')
     , id: 'basals'
     , color: basalColor
     , points: { show: false }
@@ -1127,14 +1127,14 @@ loopalyzer.generateReport = function(datastorage, daysToShow, options) {
   };
   $.plot('#loopalyzer-basal', chartBasalData, chartBasalOptions);
 
-  // Chart 2: Blood glucose
+  // Chart 2: Blood Glucose
   markings = [];
   if (doTimeShift)
     markings.push({ xaxis: { from: timeShiftStartTime.toDate(), to: timeShiftStopTime.toDate() }, color: timeShiftBackgroundColor });
   markings.push({ yaxis: { from: low, to: high }, color: glucoseRangeColor });
 
   var chartBGData = [{
-    label: translate('Blood glucose')
+    label: translate('Blood Glucose')
     , data: sgvAvg
     , id: 'glucose'
     , color: glucoseColor


### PR DESCRIPTION
## Summary

Fixes #8361.

This updates the Loopalyzer report so the remaining date and chart legend text goes through existing localization paths:

- the Loopalyzer date range header now uses the shared report `localeDate` helper instead of hard-coded `ddd MMM D` formatting
- the Basal chart legend now uses the existing `Basal Profile` translation key
- the Blood Glucose chart legend now uses the existing `Blood Glucose` translation key

This also incorporates the useful part of the older closed #6760 change, but in a fresh PR against current `dev` and with the missing date/day localization handled as well.

## Why

The affected translations already exist in Crowdin/translation files. The bug was that Loopalyzer was using source strings with different capitalization, plus a date format that bypassed the localized report date helper. This means the fix does not require new translation entries.

## Validation

- `npx eslint lib/report_plugins/loopalyzer.js`
- `node -c lib/report_plugins/loopalyzer.js`
- `npx env-cmd -f ./tests/ci.test.env mocha --timeout 5000 --require ./tests/hooks.js --exit ./tests/language.test.js`
