### PR TITLE
Normalize legacy trend arrow directions

### DIFF
--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var browserSettings = require('./browser-settings');
+var normalizeDirection = require('../direction-normalizer').normalizeDirection;
 var client = {};
 var latestProperties = {};
 
@@ -172,7 +173,8 @@ client.render = function render () {
   }
 
   // Insert the trend arrow.
-  let arrow = $('<img alt="arrow">').attr('src', '/images/' + (!rec.direction || rec.direction === 'NOT COMPUTABLE' ? 'NONE' : rec.direction) + '.svg');
+  let direction = normalizeDirection(rec.direction);
+  let arrow = $('<img alt="arrow">').attr('src', '/images/' + (!direction || direction === 'NOT COMPUTABLE' ? 'NONE' : direction) + '.svg');
 
   // Restyle body bg
   if (thresholdReached) {

--- a/lib/direction-normalizer.js
+++ b/lib/direction-normalizer.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var directionAliases = {
+  none: 'NONE'
+  , tripleup: 'TripleUp'
+  , doubleup: 'DoubleUp'
+  , singleup: 'SingleUp'
+  , fortyfiveup: 'FortyFiveUp'
+  , flat: 'Flat'
+  , fortyfivedown: 'FortyFiveDown'
+  , singledown: 'SingleDown'
+  , doubledown: 'DoubleDown'
+  , tripledown: 'TripleDown'
+  , notcomputable: 'NOT COMPUTABLE'
+  , rateoutofrange: 'RATE OUT OF RANGE'
+
+  , up: 'SingleUp'
+  , down: 'SingleDown'
+  , slideup: 'FortyFiveUp'
+  , slidedown: 'FortyFiveDown'
+  , slightup: 'FortyFiveUp'
+  , slightdown: 'FortyFiveDown'
+};
+
+function normalizeDirection(direction) {
+  if (!direction) {
+    return direction;
+  }
+
+  var key = String(direction).trim().replace(/[\s_-]+/g, '').toLowerCase();
+  return directionAliases[key] || direction;
+}
+
+module.exports = {
+  normalizeDirection: normalizeDirection
+};

--- a/lib/plugins/direction.js
+++ b/lib/plugins/direction.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var normalizeDirection = require('../direction-normalizer').normalizeDirection;
+
 function init() {
 
   var direction = {
@@ -43,7 +45,7 @@ function init() {
 
     if (!sgv) { return result; }
 
-    result.value = sgv.direction;
+    result.value = normalizeDirection(sgv.direction);
     result.label = directionToChar(result.value);
     result.entity = charToEntity(result.label);
 

--- a/tests/direction.test.js
+++ b/tests/direction.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 require('should');
+var fs = require('fs');
+var path = require('path');
+var normalizeDirection = require('../lib/direction-normalizer').normalizeDirection;
 
 describe('BG direction', function ( ) {
 
@@ -98,6 +101,29 @@ describe('BG direction', function ( ) {
 
     direction.info({mills: now, direction: 'RATE OUT OF RANGE'}).label.should.equal('⇕');
     direction.info({mills: now, direction: 'RATE OUT OF RANGE'}).entity.should.equal('&#8661;');
+  });
+
+  it('normalizes legacy direction aliases before display', function () {
+    var direction = require('../lib/plugins/direction')();
+
+    direction.info({mills: now, direction: 'Up'}).value.should.equal('SingleUp');
+    direction.info({mills: now, direction: 'Up'}).label.should.equal('↑');
+
+    direction.info({mills: now, direction: 'Down'}).value.should.equal('SingleDown');
+    direction.info({mills: now, direction: 'Down'}).label.should.equal('↓');
+
+    direction.info({mills: now, direction: 'Slide up'}).value.should.equal('FortyFiveUp');
+    direction.info({mills: now, direction: 'Slide up'}).label.should.equal('↗');
+
+    direction.info({mills: now, direction: 'Slide down'}).value.should.equal('FortyFiveDown');
+    direction.info({mills: now, direction: 'Slide down'}).label.should.equal('↘');
+  });
+
+  it('normalizes legacy direction aliases to existing clock assets', function () {
+    ['Up', 'Down', 'Slide up', 'Slide down'].forEach(function assertAssetExists(direction) {
+      var asset = path.join(__dirname, '..', 'static', 'images', normalizeDirection(direction) + '.svg');
+      fs.existsSync(asset).should.equal(true);
+    });
   });
 
 


### PR DESCRIPTION
## Summary

Fixes #8245.

This updates the direction display path so legacy or human-readable trend direction values are normalized before rendering. Values such as `Up`, `Down`, `Slide up`, and `Slide down` now map to the canonical Nightscout direction names used by the existing clock SVG assets and direction pill rendering.

## Why

The clock view was building SVG paths directly from the raw `direction` value. If an uploader stored `Slide down`, the clock tried to load `/images/Slide%20down.svg`, which does not exist. The main page direction pill had the same underlying problem and fell back to `-` for values it did not recognize.

This keeps stored SGV documents unchanged and only normalizes values at display time.

## Validation

- `env-cmd -f ./tests/ci.test.env mocha --timeout 5000 --require ./tests/hooks.js --exit ./tests/direction.test.js`
- `eslint lib/direction-normalizer.js lib/plugins/direction.js lib/client/clock-client.js`
- `npm run bundle-dev`