### PR TITLE
Handle profile helper in lastEntry

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -131,7 +131,15 @@ function init () {
     return entry && sbx.time - entry.mills <= times.mins(15).msecs;
   };
   sbx.lastEntry = function lastEntry (entries) {
-    return entries?.slice().reverse().find(function notInTheFuture (entry) {
+    if (!Array.isArray(entries) && Array.isArray(entries?.data)) {
+      entries = entries.data;
+    }
+
+    if (!Array.isArray(entries)) {
+      return;
+    }
+
+    return entries.slice().reverse().find(function notInTheFuture (entry) {
       return sbx.entryMills(entry) <= sbx.time;
     });
   };

--- a/tests/sandbox.test.js
+++ b/tests/sandbox.test.js
@@ -54,6 +54,36 @@ describe('sandbox', function ( ) {
     done();
   });
 
+  it('gets the last entry that is not in the future', function () {
+    var sbx = createServerSandbox();
+    sbx.time = now;
+
+    var older = {mgdl: 90, mills: now - 60000};
+    var latest = {mgdl: 100, mills: now};
+    var future = {mgdl: 110, mills: now + 60000};
+    var entries = [older, latest, future];
+
+    sbx.lastEntry(entries).should.equal(latest);
+    entries.should.deepEqual([older, latest, future]);
+  });
+
+  it('does not crash when lastEntry receives a non-array value', function () {
+    var sbx = createServerSandbox();
+
+    should.not.exist(sbx.lastEntry({}));
+  });
+
+  it('gets the last entry from profile helper data', function () {
+    var sbx = createServerSandbox();
+    sbx.time = now;
+
+    var older = {defaultProfile: 'Default', mills: now - 60000};
+    var latest = {defaultProfile: 'Default', mills: now};
+    var future = {defaultProfile: 'Default', mills: now + 60000};
+
+    sbx.lastEntry({data: [older, latest, future]}).should.equal(latest);
+  });
+
   it('display 39 as LOW and 401 as HIGH', function () {
     var sbx = createServerSandbox();
 


### PR DESCRIPTION
## Summary

Fix `sbx.lastEntry` so it no longer crashes when `nightscout-connect` asks for the last profile record from the server sandbox.

## Root Cause

On the server, `sbx.data.profile` is a profile helper object, not the raw profile array. `nightscout-connect` calls `sbx.lastEntry(sbx.data.profile)` while building its internal `known` watermark after `data-processed`, so `lastEntry` tried to call `.slice()` on a non-array and threw `TypeError: entries?.slice is not a function`.

## Changes

- Teach `lastEntry` to read profile helper records from `.data` when present.
- Return `undefined` for other non-array inputs instead of throwing.
- Add regression tests for normal latest-entry selection, non-array input, and profile helper data.

## Validation

- `./node_modules/.bin/env-cmd -f ./tests/ci.test.env ./node_modules/.bin/mocha --timeout 5000 --require ./tests/hooks.js --exit ./tests/sandbox.test.js`
- `./node_modules/.bin/eslint lib/sandbox.js`

Note: `npm run test-single` was not used because local `./my.test.env` is not present in this checkout; the checked-in CI env file was used for the targeted test instead.