### PR TITLE
fix(clock): respect browser unit preference in clock view

### DIFF
--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -2,6 +2,7 @@
 
 var browserSettings = require('./browser-settings');
 var normalizeDirection = require('../direction-normalizer').normalizeDirection;
+var units = require('../units')();
 var client = {};
 var latestProperties = {};
 
@@ -47,7 +48,13 @@ client.render = function render () {
   let deltaDisplayValue;
 
   if (latestProperties.delta) {
-    deltaDisplayValue = latestProperties.delta.display;
+    if (client.unitMismatch) {
+      var rawDelta = latestProperties.delta.mgdl;
+      var scaledDelta = (client.settings.units === 'mmol') ? units.mgdlToMMOL(rawDelta) : String(rawDelta);
+      deltaDisplayValue = (rawDelta >= 0 ? '+' : '') + scaledDelta;
+    } else {
+      deltaDisplayValue = latestProperties.delta.display;
+    }
   }
 
   let $errorMessage = $('#errorMessage');
@@ -104,7 +111,9 @@ client.render = function render () {
     }
   }
 
-  let displayValue = rec.scaled;
+  let displayValue = client.unitMismatch
+    ? (client.settings.units === 'mmol' ? units.mgdlToMMOL(rec.mgdl) : String(rec.mgdl))
+    : rec.scaled;
 
   // Insert the delta value text.
   $('.dt').html(deltaDisplayValue);
@@ -208,6 +217,8 @@ client.init = function init () {
 
   console.log('Initializing clock');
   client.settings = browserSettings(client, window.serverSettings, $);
+  client.unitMismatch = client.settings.units && window.serverSettings.settings.units &&
+    client.settings.units !== window.serverSettings.settings.units;
   client.query();
   setInterval(client.query, 20 * 1000); // update every 20 seconds
 

--- a/tests/clock-client.test.js
+++ b/tests/clock-client.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+var should = require('should');
+var benv = require('benv');
+
+describe('clock client units', function() {
+  var $, clockClient;
+
+  function setupClockClient(done) {
+    benv.setup(function() {
+      $ = require('jquery');
+      global.$ = $;
+
+      global.localStorage = {
+        getItem: function() {
+          return null;
+        }
+      };
+
+      $('body').html('<div id="inner" data-face="bn0-sg40-dt14-ag6-ar25"></div>');
+
+      delete require.cache[require.resolve('../lib/client/clock-client')];
+      clockClient = require('../lib/client/clock-client');
+
+      done();
+    });
+  }
+
+  function teardownClockClient(done) {
+    delete require.cache[require.resolve('../lib/client/clock-client')];
+    delete global.$;
+    delete global.localStorage;
+    clockClient = null;
+    benv.teardown(true);
+    done();
+  }
+
+  function renderProperties(serverUnits, browserUnits, properties) {
+    window.serverSettings = {
+      settings: {
+        units: serverUnits
+        , showClockDelta: true
+        , showClockLastTime: false
+      }
+    };
+
+    clockClient.settings = {
+      units: browserUnits
+      , thresholds: {
+        bgHigh: 260
+        , bgLow: 55
+        , bgTargetBottom: 80
+        , bgTargetTop: 180
+      }
+      , timeFormat: 12
+    };
+    clockClient.unitMismatch = browserUnits !== serverUnits;
+
+    $.ajax = function(url, opts) {
+      should(url).equal('/api/v2/properties');
+      opts.success(properties);
+    };
+
+    clockClient.query();
+  }
+
+  function propertiesWithUnits(scaledBg, deltaDisplay) {
+    return {
+      bgnow: {
+        sgvs: [{
+          mgdl: 100
+          , scaled: scaledBg
+          , mills: Date.now()
+          , direction: 'Flat'
+        }]
+      }
+      , delta: {
+        mgdl: 5
+        , display: deltaDisplay
+      }
+    };
+  }
+
+  beforeEach(setupClockClient);
+  afterEach(teardownClockClient);
+
+  it('should render browser mmol preference when server units are mg/dl', function() {
+    renderProperties('mg/dl', 'mmol', propertiesWithUnits(100, '+5'));
+
+    $('.sg').html().should.equal('5.6');
+    $('.dt').html().should.equal('+0.3');
+  });
+
+  it('should render browser mg/dl preference when server units are mmol', function() {
+    renderProperties('mmol', 'mg/dl', propertiesWithUnits('5.6', '+0.3'));
+
+    $('.sg').html().should.equal('100');
+    $('.dt').html().should.equal('+5');
+  });
+
+  it('should use server-scaled values when browser and server units match', function() {
+    renderProperties('mmol', 'mmol', propertiesWithUnits('5.6', '+0.3'));
+
+    $('.sg').html().should.equal('5.6');
+    $('.dt').html().should.equal('+0.3');
+  });
+});

--- a/tests/units.test.js
+++ b/tests/units.test.js
@@ -29,4 +29,16 @@ describe('units', function ( ) {
     units.mmolToMgdl(units.mgdlToMMOL(99)).should.equal(99);
   });
 
+  it('should convert negative delta -9 mgdl to mmol preserving sign', function () {
+    units.mgdlToMMOL(-9).should.equal('-0.5');
+  });
+
+  it('should convert negative delta -18 mgdl to mmol preserving sign', function () {
+    units.mgdlToMMOL(-18).should.equal('-1.0');
+  });
+
+  it('should convert 0 delta to 0.0', function () {
+    units.mgdlToMMOL(0).should.equal('0.0');
+  });
+
 });


### PR DESCRIPTION
When the browser unit preference differs from the server's configured units, the clock view was displaying the server-side pre-scaled value (`rec.scaled`, `delta.display`) rather than re-converting from the raw mgdl source. This caused incorrect BG and delta readings on the clock face for users whose browser preference did not match the server setting.

This fix reads `client.settings.units` at init and converts from `rec.mgdl` / `delta.mgdl` directly when a mismatch is detected. Both BG display value and delta are converted consistently.

Closes #8262. Replaces #8388 with a behaviour-only change — no UI toggle added, no unrelated files touched.