### PR TITLE
Add GitHub action to close accidental sync PRs

### DIFF
--- a/.github/workflows/close-accidental-sync-prs.yml
+++ b/.github/workflows/close-accidental-sync-prs.yml
@@ -1,0 +1,67 @@
+name: Auto-close Accidental Sync PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  auto-close:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-close sync PRs from forks
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const baseRepo = pr.base.repo.full_name;
+            const headRepo = pr.head.repo.full_name;
+            const isFromFork = baseRepo !== headRepo;
+
+            const syncTitlePattern = /\b(sync|merge|update|pull|new)\b/i;
+            const isLikelySync = syncTitlePattern.test(pr.title || "");
+
+            const isEmptyPR = pr.changed_files === 0 && pr.additions === 0 && pr.deletions === 0;
+
+            if (![isFromFork, isLikelySync, isEmptyPR].every(Boolean)) {
+                return;
+            }
+            const baseRepoFullName = pr.base.repo.full_name;
+            const baseBranchName = pr.base.ref;
+
+            const message = [
+              `Hi! It looks like you're trying to sync your fork's \`${baseBranchName}\` branch with the \`${baseRepoFullName}\` repository.`,
+              "",
+              "This pull request was likely opened by mistake. To sync your fork with the upstream repository using the GitHub website, please follow these steps:",
+              "",
+              `1. **Go to your fork on GitHub.** This is \`https://github.com/${pr.head.repo.full_name}\`.`,
+              `2. **Ensure you are on the \`${baseBranchName}\` branch.** You can select it from the branch dropdown menu.`,
+              "3. **Look for a \"Sync fork\" or \"Fetch upstream\" button/dropdown.**",
+              `   * On your fork's page, above the file list, you might see a section indicating if your branch is behind \`${baseRepoFullName}:${baseBranchName}\`.`,
+              "   * Next to this, or in a dropdown labeled \"Sync fork\", you should find an option called **\"Update branch\"**.",
+              "4. **Click \"Update branch\".**",
+              `   * GitHub will fetch the changes from \`${baseRepoFullName}/${baseBranchName}\` and merge them into your fork's \`${baseBranchName}\` branch.`,
+              "",
+              "If you don't see these options, your fork might already be up to date, or you might be on a different branch.",
+              "",
+              "We're automatically closing this PR to keep our queue clean.",
+              "If this was not a mistake, please feel free to reopen this pull request and clarify its purpose."
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: message
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed'
+            });

--- a/.github/workflows/close-accidental-sync-prs.yml
+++ b/.github/workflows/close-accidental-sync-prs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-close sync PRs from forks
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
This supersedes #8354 from @ryceg.

The premise and original workflow came from @ryceg's PR. I opened this replacement branch because we could not push the reviewed fixes back to `ryceg:dev`: both direct git push and the contents API returned permission errors, despite the PR reporting maintainer edits as enabled. The original PR was also based on `master`, so this reapplies the change onto current `dev`.

What changed from the original PR:
- Uses `pull_request_target` with explicit `issues: write` and `pull-requests: write` permissions so the action can comment on and close fork PRs.
- Builds the guidance comment as a JavaScript string array so the workflow YAML parses correctly.
- Tightens the auto-close predicate to avoid closing deletion-only or normally titled PRs: it now requires a fork PR, a sync-like title word, and zero changed files/additions/deletions.

Validation run locally:
- YAML parse
- wrapped JavaScript syntax check for the `github-script` block
- `actionlint`
- behavior smoke checks for empty sync PRs, same-repo PRs, deletion-only PRs, and punctuation-only titles

Co-authored-by: Rhys <36913739+ryceg@users.noreply.github.com>
