### PR TITLE
Guard null verified JWTs

### DIFF
--- a/lib/authorization/index.js
+++ b/lib/authorization/index.js
@@ -186,7 +186,7 @@ function init (env, ctx) {
     // Tokens have to be well formed JWTs
     try {
       const verified = env.enclave.verifyJWT(data.token);
-      token = verified.accessToken;
+      token = verified && verified.accessToken;
     } catch (err) {
       console.error('Error verifying JWT token:', err);
     }

--- a/tests/api.security.test.js
+++ b/tests/api.security.test.js
@@ -148,12 +148,22 @@ describe('Security of REST API V1', function() {
       });
   });
 
-  it('Data load fail succeed with a false bearer token', function(done) {
+  it('Data load should fail with a false bearer token without logging a JWT TypeError', function(done) {
+    const originalError = console.error;
+    const errors = [];
+    console.error = function captureConsoleError () {
+      errors.push(Array.prototype.slice.call(arguments).join(' '));
+      return originalError.apply(console, arguments);
+    };
+
     request(self.app)
       .get('/api/v1/entries.json')
       .set('Authorization', 'Bearer 1234567890')
       .expect(401)
-      .end(function(err, res) {
+      .end(function(err) {
+        console.error = originalError;
+        if (err) return done(err);
+        errors.join('\n').should.not.containEql('Cannot read properties of null');
         done();
       });
   });


### PR DESCRIPTION
## Summary

Invalid or expired JWTs can make `env.enclave.verifyJWT()` return `null`. `authorization.resolve()` then tried to read `verified.accessToken`, which produced a production log like:

```text
TypeError: Cannot read properties of null (reading 'accessToken')\n```\n\nThis PR guards the decoded JWT before reading `accessToken`, allowing invalid Bearer tokens to continue through the existing failed-auth path and return 401 without logging the null dereference.\n\n## Validation\n\n- `git diff --check`\n- `npx eslint lib/authorization/index.js`\n- `npx env-cmd -f ./tests/ci.test.env mocha --timeout 30000 --require ./tests/hooks.js --exit ./tests/api.security.test.js`