### PR TITLE
Harden date range delete preview rendering

### DIFF
--- a/lib/admin_plugins/daterangedelete.js
+++ b/lib/admin_plugins/daterangedelete.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var moment;
+var allowedCollections = ['entries', 'treatments', 'devicestatus'];
 
 var daterangedelete = {
   name: 'daterangedelete',
@@ -14,6 +15,14 @@ function init(ctx) {
 }
 
 module.exports = init;
+
+function isValidCollection(collection) {
+  return collection === 'all' || allowedCollections.indexOf(collection) !== -1;
+}
+
+function selectedCollections(collection) {
+  return collection === 'all' ? allowedCollections.slice() : [collection];
+}
 
 daterangedelete.actions = [
   {
@@ -80,6 +89,39 @@ daterangedelete.actions[0].init = function init(client, callback) {
     validateAndPreview(client);
   });
 
+  function appendPreviewText(text, css) {
+    $previewCount.append($('<span>').css(css).text(text));
+  }
+
+  function appendPreviewSeparator() {
+    $previewCount.append(document.createTextNode(' | '));
+  }
+
+  function setPreviewText(text, css) {
+    $previewCount.empty();
+    appendPreviewText(text, css);
+  }
+
+  function appendCollectionCount(col, count, threshold) {
+    if (count === -1) {
+      appendPreviewText(col + ': ERROR', { color: 'red' });
+      return false;
+    }
+
+    if (count >= threshold) {
+      appendPreviewText(col + ': ≥ ' + count, { color: 'orange' });
+      return true;
+    }
+
+    if (count === 0) {
+      appendPreviewText(col + ': 0', { color: 'gray' });
+      return false;
+    }
+
+    appendPreviewText(col + ': ' + count, { color: 'green', 'font-weight': 'bold' });
+    return false;
+  }
+
   function validateDates(client) {
     var translate = client.translate;
     var $info = $('#admin_daterangedelete_info');
@@ -123,12 +165,19 @@ daterangedelete.actions[0].init = function init(client, callback) {
 
   function validateAndPreview(client) {
     var translate = client.translate;
+    var $info = $('#admin_daterangedelete_info');
     var collection = $('#admin_daterange_collection').val();
     var startDateStr = $('#admin_daterange_start').val();
     var endDateStr = $('#admin_daterange_end').val();
 
     if (!collection || !startDateStr || !endDateStr) {
       $previewCount.text('');
+      return;
+    }
+
+    if (!isValidCollection(collection)) {
+      $previewCount.text('');
+      $info.text(translate('Please select a valid collection'));
       return;
     }
 
@@ -143,12 +192,7 @@ daterangedelete.actions[0].init = function init(client, callback) {
     var startDate = zone ? moment.tz(startDateStr, zone) : moment(startDateStr);
     var endDate = zone ? moment.tz(endDateStr, zone) : moment(endDateStr);
 
-    var collectionsToPreview = [];
-    if (collection === 'all') {
-      collectionsToPreview = ['entries', 'treatments', 'devicestatus'];
-    } else {
-      collectionsToPreview = [collection];
-    }
+    var collectionsToPreview = selectedCollections(collection);
 
     var queries = [];
     var totalCount = 0;
@@ -176,9 +220,9 @@ daterangedelete.actions[0].init = function init(client, callback) {
     });
 
     if (queries.length === 1) {
-      $previewCount.html('<span style="color: #666;">' + translate('Checking...') + '</span>');
+      setPreviewText(translate('Checking...'), { color: '#666' });
     } else {
-      $previewCount.html('<span style="color: #666;">' + translate('Checking collections...') + '</span>');
+      setPreviewText(translate('Checking collections...'), { color: '#666' });
     }
 
     var completed = 0;
@@ -195,7 +239,10 @@ daterangedelete.actions[0].init = function init(client, callback) {
           if (Array.isArray(data)) {
             count = data.length;
           } else if (data && data.n !== undefined) {
-            count = data.n;
+            count = Number(data.n);
+            if (isNaN(count)) {
+              count = 0;
+            }
           }
           results[query.collection] = count;
           if (count > 0) {
@@ -218,47 +265,41 @@ daterangedelete.actions[0].init = function init(client, callback) {
       }
 
       var threshold = previewLimit;
-      var summary = [];
       var hasPotentialMore = false;
 
-      collectionsToPreview.forEach(function(col) {
-        var count = results[col];
-        var colText = '';
-        if (count === -1) {
-          colText = '<span style="color: red;">' + col + ': ERROR</span>';
-        } else if (count >= threshold) {
-          colText = '<span style="color: orange;">' + col + ': ≥ ' + count + '</span>';
-          hasPotentialMore = true;
-        } else if (count === 0) {
-          colText = '<span style="color: gray;">' + col + ': 0</span>';
-        } else {
-          colText = '<span style="color: green; font-weight: bold;">' + col + ': ' + count + '</span>';
-        }
-        summary.push(colText);
-      });
+      $previewCount.empty();
 
-      var summaryLine = '';
       if (queries.length === 1) {
         var col = queries[0].collection;
         var count = results[col];
         if (count === -1) {
-          summaryLine = '<span style="color: red;">' + translate('Error checking') + '</span>';
+          appendPreviewText(translate('Error checking'), { color: 'red' });
         } else if (count >= threshold) {
-          summaryLine = '<span style="color: orange;">' + translate('At least %1 records match (limit reached)', {params: [count]}) + '</span>';
+          appendPreviewText(translate('At least %1 records match (limit reached)', {params: [count]}), { color: 'orange' });
         } else if (count === 0) {
-          summaryLine = '<span style="color: gray;">' + translate('No records found') + '</span>';
+          appendPreviewText(translate('No records found'), { color: 'gray' });
         } else {
-          summaryLine = '<span style="color: green;">' + count + ' ' + translate('record(s) will be deleted') + '</span>';
+          appendPreviewText(count + ' ' + translate('record(s) will be deleted'), { color: 'green' });
         }
       } else {
-        summaryLine = summary.join(' | ');
-        if (hasPotentialMore) {
-          summaryLine += ' | <span style="color: orange;">' + translate('some counts may be underestimated') + '</span>';
-        }
-        summaryLine += ' | <strong>' + translate('Total') + ': ' + totalCount + '</strong>';
-      }
+        collectionsToPreview.forEach(function(col, index) {
+          if (index > 0) {
+            appendPreviewSeparator();
+          }
 
-      $previewCount.html(summaryLine);
+          if (appendCollectionCount(col, results[col], threshold)) {
+            hasPotentialMore = true;
+          }
+        });
+
+        if (hasPotentialMore) {
+          appendPreviewSeparator();
+          appendPreviewText(translate('some counts may be underestimated'), { color: 'orange' });
+        }
+
+        appendPreviewSeparator();
+        $previewCount.append($('<strong>').text(translate('Total') + ': ' + totalCount));
+      }
     }
 
     if (queries.length === 0) {
@@ -287,6 +328,12 @@ daterangedelete.actions[0].code = function deleteRecordsInDateRange(client, call
     return;
   }
 
+  if (!isValidCollection(collection)) {
+    alert(translate('Please select a valid collection'));
+    if (callback) { callback(); }
+    return;
+  }
+
   // Use profile timezone if available
   var zone = (client.sbx && client.sbx.data && client.sbx.data.profile) ? client.sbx.data.profile.getTimezone() : null;
   var startDate = zone ? moment.tz(startDateStr, zone) : moment(startDateStr);
@@ -305,12 +352,7 @@ daterangedelete.actions[0].code = function deleteRecordsInDateRange(client, call
   }
 
   // Determine which collections to delete from
-  var collectionsToDelete = [];
-  if (collection === 'all') {
-    collectionsToDelete = ['entries', 'treatments', 'devicestatus'];
-  } else {
-    collectionsToDelete = [collection];
-  }
+  var collectionsToDelete = selectedCollections(collection);
 
   // Prepare confirmation message
   var confirmMsg;

--- a/tests/daterangedelete.test.js
+++ b/tests/daterangedelete.test.js
@@ -233,4 +233,47 @@ describe('daterangedelete admin plugin (TZ aware)', function() {
       global.setTimeout = originalSetTimeout;
     }
   });
+
+  it('should reject unexpected collection values', function() {
+    var originalAjax = $.ajax;
+    var originalAlert = window.alert;
+    var originalGlobalAlert = global.alert;
+    var ajaxCalled = false;
+    var alertMessage = '';
+    var callbackCalled = false;
+
+    $.ajax = function() {
+      ajaxCalled = true;
+      return originalAjax.apply(this, arguments);
+    };
+
+    window.alert = function(message) {
+      alertMessage = message;
+    };
+    global.alert = window.alert;
+
+    try {
+      $('#admin_daterange_collection').append('<option value="unknown">Unknown</option>').val('unknown');
+      $('#admin_daterange_start').val('2025-01-01');
+      $('#admin_daterange_end').val('2025-01-02');
+
+      $('.daterangePreviewButton').click();
+
+      ajaxCalled.should.equal(false);
+      $('#admin_daterangedelete_info').text().should.equal('Please select a valid collection');
+
+      daterangedelete.actions[0].code(client, function() {
+        callbackCalled = true;
+      });
+
+      callbackCalled.should.equal(true);
+      alertMessage.should.equal('Please select a valid collection');
+    } finally {
+      $.ajax = originalAjax;
+      window.alert = originalAlert;
+      global.alert = originalGlobalAlert;
+      $('#admin_daterange_collection option[value="unknown"]').remove();
+      $('#admin_daterange_collection').val('all');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the CodeQL `js/xss-through-dom` alert in the date range delete admin plugin by rendering preview output with DOM text nodes/elements instead of interpolated HTML strings.

## Details

- Whitelists the collection selector values before building preview or delete requests.
- Replaces the preview summary string passed to `.html()` with jQuery element construction using `.text()`.
- Coerces preview counts from API responses to numbers before display and total calculation.
- Adds regression coverage for an unexpected/tampered collection value.

## Root Cause

The preview summary mixed markup, translated text, collection names, and counts into one HTML string before inserting it with `$previewCount.html(summaryLine)`. CodeQL correctly flagged that pattern as DOM text being reinterpreted as HTML.

## Validation

- `./node_modules/.bin/env-cmd -f ./tests/ci.test.env ./node_modules/.bin/mocha --timeout 15000 --require ./tests/hooks.js --exit ./tests/daterangedelete.test.js`
- `./node_modules/.bin/eslint lib/admin_plugins/daterangedelete.js --quiet`
- `git diff --check`

Note: full `npm run lint -- --quiet` still fails on existing unrelated lint errors outside this patch.
