### PR TITLE
Fixies for mmol/L vs.  mg/dL battle in Bolus Wizard Preview plugin and Profile editor

### DIFF
--- a/lib/plugins/boluswizardpreview.js
+++ b/lib/plugins/boluswizardpreview.js
@@ -55,7 +55,7 @@ function init (ctx) {
         , lengthMills: settings.snoozeLength
         , debug: prop
       });
-    } else if (prop.scaledSGV > sbx.data.profile.getHighBGTarget(sbx.time) && prop.bolusEstimate > settings.warnBWP) {
+    } else if (prop.scaledSGV > sbx.scaleMgdl(sbx.data.profile.getHighBGTarget(sbx.time)) && prop.bolusEstimate > settings.warnBWP) {
       var level = prop.bolusEstimate > settings.urgentBWP ? levels.URGENT : levels.WARN;
       var levelLabel = levels.toDisplay(level);
       var sound = level === levels.URGENT ? 'updown' : 'bike';
@@ -123,7 +123,7 @@ function init (ctx) {
     var profile = sbx.data.profile;
     var iob = results.iob = sbx.properties.iob.iob || 0;
 
-    results.effect = iob * profile.getSensitivity(sbx.time);
+    results.effect = iob * sbx.scaleMgdl(profile.getSensitivity(sbx.time));
     results.outcome = scaled - results.effect;
     var delta = 0;
 
@@ -135,8 +135,8 @@ function init (ctx) {
 
     results.recentCarbs = recentCarbs;
 
-    var target_high = profile.getHighBGTarget(sbx.time);
-    var sens = profile.getSensitivity(sbx.time);
+    var target_high = sbx.scaleMgdl(profile.getHighBGTarget(sbx.time));
+    var sens = sbx.scaleMgdl(profile.getSensitivity(sbx.time));
 
     if (results.outcome > target_high) {
       delta = results.outcome - target_high;
@@ -145,7 +145,7 @@ function init (ctx) {
       results.aimTargetString = 'above high';
     }
 
-    var target_low = profile.getLowBGTarget(sbx.time);
+    var target_low = sbx.scaleMgdl(profile.getLowBGTarget(sbx.time));
 
     results.belowLowTarget = false;
     if (scaled < target_low) {
@@ -208,9 +208,9 @@ function init (ctx) {
       });
     } else if (prop) {
       info.push({label: translate('Insulin on Board'), value: prop.displayIOB + 'U'});
-      info.push({label: translate('Current target'), value: translate('Low') +': ' + sbx.data.profile.getLowBGTarget(sbx.time) + ' ' + translate('High') + ': ' + sbx.data.profile.getHighBGTarget(sbx.time)});
-      info.push({label: translate('Sensitivity'), value: '-' + sbx.data.profile.getSensitivity(sbx.time) + ' ' + sbx.settings.units + '/U'});
-      info.push({label: translate('Expected effect'), value: prop.displayIOB + ' x -' + sbx.data.profile.getSensitivity(sbx.time) + ' = -' + prop.effectDisplay + ' ' + sbx.settings.units});
+      info.push({label: translate('Current target'), value: translate('Low') +': ' + sbx.roundBGToDisplayFormat(sbx.scaleMgdl(sbx.data.profile.getLowBGTarget(sbx.time))) + ' ' + translate('High') + ': ' + sbx.roundBGToDisplayFormat(sbx.scaleMgdl(sbx.data.profile.getHighBGTarget(sbx.time)))});
+      info.push({label: translate('Sensitivity'), value: '-' + sbx.roundBGToDisplayFormat(sbx.scaleMgdl(sbx.data.profile.getSensitivity(sbx.time))) + ' ' + sbx.settings.units + '/U'});
+      info.push({label: translate('Expected effect'), value: prop.displayIOB + ' x -' + sbx.roundBGToDisplayFormat(sbx.scaleMgdl(sbx.data.profile.getSensitivity(sbx.time))) + ' = -' + prop.effectDisplay + ' ' + sbx.settings.units});
       info.push({label: translate('Expected outcome'), value: sbx.lastScaledSGV() + '-' + prop.effectDisplay + ' = ' + prop.outcomeDisplay + ' ' + sbx.settings.units});
       if (prop.bolusEstimateDisplay < 0) {
         info.unshift({label: '---------', value: ''});

--- a/lib/profile/profileeditor.js
+++ b/lib/profile/profileeditor.js
@@ -587,14 +587,15 @@ var init = function init () {
     ].forEach(function (e) {
       for (index=0; index<c_profile[e.array].length; index++) {
         $('#'+e.prefix+'_from_'+index).val(c_profile[e.array][index].time);
-        $('#'+e.prefix+'_val_'+index).val(c_profile[e.array][index].value);
+        var displayValue = (e.array === 'sens') ? client.utils.roundBGForDisplay(client.utils.scaleMgdl(c_profile[e.array][index].value)) : c_profile[e.array][index].value;
+        $('#'+e.prefix+'_val_'+index).val(displayValue);
       }
     });
 
     for (index=0; index<c_profile.target_low.length; index++) {
       $('#pe_targetbg_from_'+index).val(c_profile.target_low[index].time);
-      $('#pe_targetbg_low_'+index).val(c_profile.target_low[index].value);
-      $('#pe_targetbg_high_'+index).val(c_profile.target_high[index].value);
+      $('#pe_targetbg_low_'+index).val(client.utils.roundBGForDisplay(client.utils.scaleMgdl(c_profile.target_low[index].value)));
+      $('#pe_targetbg_high_'+index).val(client.utils.roundBGForDisplay(client.utils.scaleMgdl(c_profile.target_high[index].value)));
     }
     //console.info(JSON.stringify(c_profile));
   }
@@ -603,7 +604,7 @@ var init = function init () {
   function GUIToObject() {
     var oldProfile = _.cloneDeep(c_profile);
 
-    c_profile.units = client.settings.units;
+    c_profile.units = 'mg/dl';
 
     c_profile.dia = parseFloat($('#pe_dia').val());
     c_profile.carbs_hr = parseInt($('#pe_hr').val());
@@ -632,16 +633,17 @@ var init = function init () {
     ].forEach(function (e) {
       for (index=0; index<c_profile[e.array].length; index++) {
         c_profile[e.array][index].time = $('#'+e.prefix+'_from_'+index).val();
-        c_profile[e.array][index].value = parseFloat($('#'+e.prefix+'_val_'+index).val());
+        var rawValue = parseFloat($('#'+e.prefix+'_val_'+index).val());
+        c_profile[e.array][index].value = (e.array === 'sens') ? (client.settings.units === 'mmol' ? Nightscout.units.mmolToMgdl(rawValue) : rawValue) : rawValue;
       }
     });
 
     for (index=0; index<c_profile.target_low.length; index++) {
       var input = $('#pe_targetbg_from_' + index);
       c_profile.target_low[index].time = input.val();
-      c_profile.target_low[index].value = parseFloat($('#pe_targetbg_low_'+index).val());
+      c_profile.target_low[index].value = client.settings.units === 'mmol' ? Nightscout.units.mmolToMgdl(parseFloat($('#pe_targetbg_low_'+index).val())) : parseFloat($('#pe_targetbg_low_'+index).val());
       c_profile.target_high[index].time = input.val();
-      c_profile.target_high[index].value = parseFloat($('#pe_targetbg_high_'+index).val());
+      c_profile.target_high[index].value = client.settings.units === 'mmol' ? Nightscout.units.mmolToMgdl(parseFloat($('#pe_targetbg_high_'+index).val())) : parseFloat($('#pe_targetbg_high_'+index).val());
     }
 
 
@@ -693,7 +695,7 @@ var init = function init () {
       }
     }
     adjustedRecord.defaultProfile = currentprofile;
-    adjustedRecord.units = client.settings.units;
+    adjustedRecord.units = 'mg/dl';
 
     delete record.convertedOnTheFly;
     delete adjustedRecord.convertedOnTheFly;


### PR DESCRIPTION
## Fix mmol/L display issues in Bolus Wizard Preview and Profile Editor

### Problem

Profile values (`sensitivity`, `target_high`, `target_low`) are always stored in mg/dL in the database. Two parts of the application were not accounting for this when `DISPLAY_UNITS=mmol/L`:

1. **Bolus Wizard Preview plugin** — profile values were compared and calculated against `lastScaledSGV()`, which returns values in the user's display units. With `'mmol/L'` this caused incorrect bolus estimates, wrong target range comparisons, and raw `'mg/dL'` values shown in the pill info panel.

2. **Profile Editor** — input fields were populated with raw `'mg/dL'` values instead of converting them for display, and the `units` field was being saved as `'mmol/L'` despite values remaining in mg/dL storage format.

### Changes

- **boluswizardpreview.js** — Wrapped all profile value reads with `sbx.scaleMgdl()` in `calc()`, `checkNotifications()`, and `pushInfo()` so all arithmetic and display consistently use the configured display units.

- **profileeditor.js** — Applied `client.utils.scaleMgdl()` + `roundBGForDisplay()` when populating `target_low`, `target_high`, and `sens` (ISF) fields. Applied `Nightscout.units.mmolToMgdl()` when reading them back for storage. Always persists the `units` field as `'mg/dl'` to match actual storage format.