### PR TITLE
Fix: Outdated update and downgrade links on README.md - Issue #7441 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@
 
 ## Translations
 
-Please visit our [project in Crowdin](https://crowdin.com/project/nightscout) to translate Nigthscout. If you want to add a new language, please get in touch with the dev team in [Discord][discord-url].
+Please visit our [project in Crowdin](https://crowdin.com/project/nightscout) to translate Nightscout. If you want to add a new language, please get in touch with the dev team in [Discord][discord-url].
 
 ## Installation for development
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The data being uploaded from the server to the client is from a MongoDB server s
 
 ## Updating my version
 
-The easiest way to update your version of cgm-remote-monitor to the latest version is to use the [update tool][update-fork]. A step-by-step guide is available [here](https://nightscout.github.io/update/update/).
+The easiest way to update your version of cgm-remote-monitor to the latest version is to use the [update tool][update-fork]. A step-by-step update guide is available [here](https://nightscout.github.io/update/update/).
 To downgrade to an older version, follow [this guide](https://nightscout.github.io/update/downgrade/).
 
 ## Configure my uploader to match

--- a/README.md
+++ b/README.md
@@ -193,15 +193,15 @@ Want to help with development, or just see how Nightscout works? Great! See [CON
 
 # Usage
 
-The data being uploaded from the server to the client is from a MongoDB server such as [MongoDB Atlas][https://www.mongodb.com].
+The data being uploaded from the server to the client is from a MongoDB server such as [MongoDB Atlas](https://www.mongodb.com).
 
 [autoconfigure]: https://nightscout.github.io/pages/configure/
 [mongostring]: https://nightscout.github.io/pages/mongostring/
 
-## Updating my version?
+## Updating my version
 
-The easiest way to update your version of cgm-remote-monitor to the latest version is to use the [update tool][update-fork]. A step-by-step guide is available [here][http://www.nightscout.info/wiki/welcome/how-to-update-to-latest-cgm-remote-monitor-aka-cookie].
-To downgrade to an older version, follow [this guide][http://www.nightscout.info/wiki/welcome/how-to-deploy-an-older-version-of-nightscout].
+The easiest way to update your version of cgm-remote-monitor to the latest version is to use the [update tool][update-fork]. A step-by-step guide is available [here](https://nightscout.github.io/update/update/).
+To downgrade to an older version, follow [this guide](https://nightscout.github.io/update/downgrade/).
 
 ## Configure my uploader to match
 


### PR DESCRIPTION
Fixes #7441 

I fixed the links to upgrade and downgrade the Nightscout version in README.md.

I also fixed an incorrectly formatted Markdown link on row 196.

Additionally, I removed a "?" from the "Updating my version" header, to match the formatting of the rest of the document. 

Lastly, I found an additional typo on Contributing.md. The word "Nightscout" was misspelled. 