### PR TITLE
Add 48-hour option to focus range selector

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -154,6 +154,7 @@
         <li data-hours="6">6</li>
         <li data-hours="12">12</li>
         <li data-hours="24">24</li>
+        <li data-hours="48">48</li>
         <li>...</li>
       </ul>
     </div>


### PR DESCRIPTION
## What this adds

A 48-hour option in the focus chart's hour selector, between the existing `24` and `...` entries.

## Motivation

The selector currently tops out at 24 hours. A 48-hour view is useful for spotting overnight-into-next-day patterns and longer-running trends on the main chart, without having to drop to the smaller context chart.

## Change

One line in `views/index.html`:
```html
<li data-hours="48">48</li>
```

## Backward compatibility

Adds an option only — no defaults change, no other behavior touched.