### PR TITLE
Add optional smooth glucose line to the chart

### DIFF
--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -60,6 +60,7 @@ function init (client, serverSettings, $) {
 
     $('#nightmode-browser').prop('checked', settings.nightMode);
     $('#editmode-browser').prop('checked', settings.editMode);
+    $('#glucoseline-browser').prop('checked', settings.showGlucoseLine);
 
     if (settings.isEnabled('rawbg')) {
       $('#show-rawbg-option').show();
@@ -231,6 +232,7 @@ function init (client, serverSettings, $) {
         , alarmTimeagoUrgentMins: parseInt($('#alarm-timeagourgentmins-browser').val()) || 30
         , nightMode: $('#nightmode-browser').prop('checked')
         , editMode: $('#editmode-browser').prop('checked')
+        , showGlucoseLine: $('#glucoseline-browser').prop('checked')
         , showRawbg: $('input:radio[name=show-rawbg]:checked').val()
         , customTitle: $('input#customTitle').prop('value')
         , theme: $('input:radio[name=theme-browser]:checked').val()

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -7,6 +7,7 @@ var DEFAULT_FOCUS = times.hours(3).msecs
   , WIDTH_SMALL_DOTS = 420
   , WIDTH_BIG_DOTS = 800
   , TOOLTIP_WIDTH = 150 //min-width + padding
+  , GLUCOSE_LINE_GAP_MS = times.mins(15).msecs //break the glucose line across gaps longer than this
 ;
 
 const zeroDate = new Date(0);
@@ -99,6 +100,41 @@ function init (client, d3) {
     return segments;
   };
 
+  // Draw the optional smooth line through the SGV readings, behind the dots.
+  renderer.addFocusLine = function addFocusLine () {
+    chart().focus.selectAll('path.glucose-line').remove();
+
+    if (!client.settings.showGlucoseLine) {
+      return;
+    }
+
+    var segments = renderer.glucoseLineSegments(client.entries, GLUCOSE_LINE_GAP_MS);
+
+    var glucoseLine = d3.line()
+      .x(function(d) { return chart().xScale(getOrAddDate(d)); })
+      .y(function(d) { return chart().yScale(client.sbx.scaleEntry(d)); })
+      .defined(function(d) { return !isNaN(client.sbx.scaleEntry(d)); })
+      .curve(d3.curveMonotoneX);
+
+    var pathData = segments
+      .map(function buildSegment (segment) { return glucoseLine(segment) || ''; })
+      .join(' ');
+
+    if (!pathData.trim()) {
+      return;
+    }
+
+    chart().focus.insert('path', 'circle.entry-dot')
+      .attr('class', 'glucose-line')
+      .attr('d', pathData)
+      .attr('fill', 'none')
+      .attr('stroke', '#bbbbbb')
+      .attr('stroke-width', 2)
+      .attr('stroke-opacity', 0.65)
+      .attr('stroke-linecap', 'round')
+      .attr('stroke-linejoin', 'round');
+  };
+
   renderer.addFocusCircles = function addFocusCircles () {
 
     function updateFocusCircles (sel) {
@@ -189,6 +225,9 @@ function init (client, d3) {
     // CGM data
 
     var focusData = client.entries;
+
+    // draw the optional smooth glucose line beneath the dots
+    renderer.addFocusLine();
 
     // bind up the focus chart data to an array of circles
     // selects all our data into data and uses date function to get current max date

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -70,6 +70,35 @@ function init (client, d3) {
     return (chart().prevChartWidth < WIDTH_SMALL_DOTS ? 4 : (chart().prevChartWidth < WIDTH_BIG_DOTS ? 3 : 2)) * focusRangeAdjustment();
   };
 
+  // Split SGV readings into time-contiguous runs so the glucose line breaks
+  // across sensor gaps instead of drawing a straight diagonal over missing data.
+  renderer.glucoseLineSegments = function glucoseLineSegments (entries, maxGapMs) {
+    var sgvs = (entries || []).filter(function isPlottableSgv (d) {
+      return d && d.type === 'sgv' && typeof d.mills === 'number';
+    });
+
+    sgvs.sort(function byMills (a, b) {
+      return a.mills - b.mills;
+    });
+
+    var segments = [];
+    var current = [];
+
+    sgvs.forEach(function eachReading (d, i) {
+      if (i > 0 && d.mills - sgvs[i - 1].mills > maxGapMs) {
+        segments.push(current);
+        current = [];
+      }
+      current.push(d);
+    });
+
+    if (current.length > 0) {
+      segments.push(current);
+    }
+
+    return segments;
+  };
+
   renderer.addFocusCircles = function addFocusCircles () {
 
     function updateFocusCircles (sel) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -12,6 +12,7 @@ function init () {
     , nightMode: false
     , editMode: true
     , showRawbg: 'never'
+    , showGlucoseLine: false
     , customTitle: 'Nightscout'
     , theme: 'default'
     , alarmUrgentHigh: true
@@ -105,6 +106,7 @@ function init () {
     , deNormalizeDates: mapTruthy
     , showClockDelta: mapTruthy
     , showClockLastTime: mapTruthy
+    , showGlucoseLine: mapTruthy
     , bgHigh: mapNumber
     , bgLow: mapNumber
     , bgTargetTop: mapNumber

--- a/tests/client.renderer.test.js
+++ b/tests/client.renderer.test.js
@@ -69,4 +69,52 @@ describe('renderer', () => {
       });
     });
   });
+
+  describe('glucoseLineSegments', () => {
+    const MIN = 5 * 60 * 1000;   // 5 minutes in ms
+    const GAP = 15 * 60 * 1000;  // 15-minute split threshold in ms
+
+    function sgv (mills) {
+      return { type: 'sgv', mills: mills };
+    }
+
+    it('returns no segments for empty input', () => {
+      renderer({}, {}).glucoseLineSegments([], GAP).should.eql([]);
+    });
+
+    it('returns no segments when entries is undefined', () => {
+      renderer({}, {}).glucoseLineSegments(undefined, GAP).should.eql([]);
+    });
+
+    it('ignores entries that are not sgv readings', () => {
+      let entries = [
+        { type: 'mbg', mills: 0 }
+        , { type: 'rawbg', mills: MIN }
+        , { type: 'forecast', mills: 2 * MIN }
+      ];
+      renderer({}, {}).glucoseLineSegments(entries, GAP).should.eql([]);
+    });
+
+    it('keeps closely-spaced readings in a single segment', () => {
+      let entries = [sgv(0), sgv(MIN), sgv(2 * MIN), sgv(3 * MIN)];
+      let segments = renderer({}, {}).glucoseLineSegments(entries, GAP);
+      segments.length.should.equal(1);
+      segments[0].length.should.equal(4);
+    });
+
+    it('splits into separate segments where a gap exceeds the threshold', () => {
+      let entries = [sgv(0), sgv(MIN), sgv(MIN + 30 * 60 * 1000), sgv(MIN + 35 * 60 * 1000)];
+      let segments = renderer({}, {}).glucoseLineSegments(entries, GAP);
+      segments.length.should.equal(2);
+      segments[0].length.should.equal(2);
+      segments[1].length.should.equal(2);
+    });
+
+    it('sorts unordered readings by time before segmenting', () => {
+      let entries = [sgv(2 * MIN), sgv(0), sgv(MIN)];
+      let segments = renderer({}, {}).glucoseLineSegments(entries, GAP);
+      segments.length.should.equal(1);
+      segments[0].map(d => d.mills).should.eql([0, MIN, 2 * MIN]);
+    });
+  });
 });

--- a/views/index.html
+++ b/views/index.html
@@ -279,6 +279,10 @@
           <dd><input type="radio" name="show-rawbg" id="show-rawbg-always" value="always"><label for="show-rawbg-always" class="translate">Always</label></dd>
           <dd><input type="radio" name="show-rawbg" id="show-rawbg-noise" value="noise"><label for="show-rawbg-noise" class="translate">When there is noise</label></dd>
         </dl>
+        <dl class="toggle">
+          <dt><span class="translate">Show Glucose Line</span> <a class="tip" original-title="When enabled a smooth line connects the glucose readings on the chart"><i class="icon-help-circled"></i></a></dt>
+          <dd><input type="checkbox" name="glucoseline-browser" id="glucoseline-browser"><label for="glucoseline-browser" class="translate">Enable</label></dd>
+        </dl>
         <dl>
           <dt class="translate">Custom Title</dt>
           <dd><input type="text" id="customTitle" value="Nightscout"></dd>


### PR DESCRIPTION
## What this adds

An opt-in setting to draw a smooth line connecting the SGV points on the focus chart. Off by default; users enable it via the existing Settings drawer.

## Motivation

The chart currently shows SGV readings as discrete dots. For users who prefer a continuous trend visualization, drawing a connecting line makes patterns easier to read at a glance.

## How it works

- New `SHOW_GLUCOSE_LINE` setting and matching in-app Settings-drawer control toggles the feature.
- When enabled, the chart adds a smooth path connecting consecutive SGV points, with gap segmentation so no line is drawn across long gaps in data.

## Files changed

- `lib/settings.js` - new setting + value mapper
- `lib/client/browser-settings.js` - load/save in the Settings drawer
- `lib/client/chart.js` - renders the line on the focus chart (with the gap-segmentation helper)
- `views/index.html` - Settings-drawer control

## Backward compatibility

Off by default. Existing installs behave identically.