### PR TITLE
Fix: mg vs mmol in displaying treatments

### DIFF
--- a/lib/data/treatmenttocurve.js
+++ b/lib/data/treatmenttocurve.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var consts = require('../constants');
+var { guessUnitFromValueAndHint, guessUnitByProximity } = require('../units')();
 
 const MAX_BG_MMOL = 22;
 const MAX_BG_MGDL = MAX_BG_MMOL * consts.MMOL_TO_MGDL;
@@ -62,20 +63,27 @@ module.exports = function fitTreatmentsToBGCurve (ddata, env, ctx) {
     //to avoid checking if eventType is null everywhere, just default it here
     treatment.eventType = treatment.eventType || '';
 
+    // 1. treatment.glucose missing          → synthesize BG from nearby SGVs via mgdlByTime()
+    // 2. treatment.glucose is NaN           → warn and skip
+    // 3. treatment.units recognized         → use it directly (trusted, no guessing)
+    // 4. value >= 40                        → unambiguously mg/dL
+    // 5. value <= 25                        → unambiguously mmol/L
+    // 6. value 26-39, no unit stored        → guess via proximity to nearest interpolated SGV
     if (treatment.glucose && isNaN(treatment.glucose)) {
       console.warn('found an invalid glucose value', treatment);
-    } else if (treatment.glucose && treatment.units) {
-      if (treatment.units === 'mmol') {
-        treatment.mmol = Math.min(Number(treatment.glucose), MAX_BG_MMOL);
-      } else {
-        treatment.mgdl = Math.min(Number(treatment.glucose), MAX_BG_MGDL);
-      }
     } else if (treatment.glucose) {
-      //no units, assume everything is the same
-      //console.warn('found a glucose value without any units, maybe from an old version?', _.pick(treatment, '_id', 'created_at', 'enteredBy'));
-      var units = settings.units === 'mmol' ? 'mmol' : 'mgdl';
-
-      treatment[units] = settings.units === 'mmol' ? Math.min(Number(treatment.glucose), MAX_BG_MMOL) : Math.min(Number(treatment.glucose), MAX_BG_MGDL);
+      var value = Number(treatment.glucose);
+      var unit = guessUnitFromValueAndHint(value, treatment.units);
+      if (unit === null) {
+      // Uses mgdlByTime() as the reference — falls back to 180 mg/dL when no SGVs are available,
+      // which biases toward mg/dL in that edge case.
+        unit = guessUnitByProximity(value, mgdlByTime());
+      }
+      if (unit === 'mmol') {
+        treatment.mmol = Math.min(value, MAX_BG_MMOL);
+      } else {
+        treatment.mgdl = Math.min(value, MAX_BG_MGDL);
+      }
     } else {
       treatment.mgdl = mgdlByTime();
     }

--- a/lib/report_plugins/utils.js
+++ b/lib/report_plugins/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var consts = require('../constants');
+var { mmolToMgdl, guessUnitFromValueAndHint, guessUnitByProximity } = require('../units')();
 
 var moment = window.moment;
 var utils = { };
@@ -65,25 +66,14 @@ utils.scaledTreatmentBG = function scaledTreatmentBG(treatment,data) {
 
   if (treatment.glucose && isNaN(treatment.glucose)) {
     console.warn('found an invalid glucose value', treatment);
-  } else {
-    if (treatment.glucose && treatment.units && client.settings.units) {
-      if (treatment.units !== client.settings.units) {
-        console.info('found mismatched glucose units, converting ' + treatment.units + ' into ' + client.settings.units, treatment);
-        if (treatment.units === 'mmol') {
-          //BG is in mmol and display in mg/dl
-          treatmentGlucose = Math.round(treatment.glucose * consts.MMOL_TO_MGDL);
-        } else {
-          //BG is in mg/dl and display in mmol
-          treatmentGlucose = client.utils.scaleMgdl(treatment.glucose);
-        }
-      } else {
-        treatmentGlucose = treatment.glucose;
-      }
-    } else if (treatment.glucose) {
-      //no units, assume everything is the same
-      console.warn('found an glucose value with any units, maybe from an old version?', treatment);
-      treatmentGlucose = treatment.glucose;
+  } else if (treatment.glucose) {
+    var value = Number(treatment.glucose);
+    var unit = guessUnitFromValueAndHint(value, treatment.units);
+    if (unit === null) {
+      unit = guessUnitByProximity(value, calcBGByTime(treatment.mills));
     }
+    var mgdl = unit === 'mmol' ? mmolToMgdl(value) : value;
+    treatmentGlucose = client.utils.scaleMgdl(mgdl);
   }
 
   return treatmentGlucose || client.utils.scaleMgdl(calcBGByTime(treatment.mills));

--- a/lib/units.js
+++ b/lib/units.js
@@ -6,14 +6,40 @@ function mgdlToMMOL(mgdl) {
   return (Math.round((mgdl / consts.MMOL_TO_MGDL) * 10) / 10).toFixed(1);
 }
 
-function mmolToMgdl(mgdl) {
-  return Math.round(mgdl * consts.MMOL_TO_MGDL);
+function mmolToMgdl(mmol) {
+  return Math.round(mmol * consts.MMOL_TO_MGDL);
+}
+
+function normalizeGlucoseUnit (unit) {
+  if (!unit) return null;
+  var normalized = String(unit).toLowerCase().trim();
+  if (['mg', 'mg/dl', 'mgdl', 'mg dl'].indexOf(normalized) !== -1) return 'mgdl';
+  if (['mmol', 'mmol/l', 'mmoll', 'mmol l'].indexOf(normalized) !== -1) return 'mmol';
+  return null;
+}
+
+// Uses value and unit hint to guess the unit. Returns null if no guess can be made.
+function guessUnitFromValueAndHint(value, unitHint) {
+  if (!value || value <= 0) return null;
+  var recognized = normalizeGlucoseUnit(unitHint);
+  if (recognized) return recognized;
+  if (value >= 40) return 'mgdl';
+  if (value <= 25) return 'mmol';
+  return null;
+}
+
+// Which interpretation is numerically closer to a known mg/dL reference.
+function guessUnitByProximity(glucoseValue, refMgdl) {
+  return Math.abs(glucoseValue - refMgdl) < Math.abs(mmolToMgdl(glucoseValue) - refMgdl) ? 'mgdl' : 'mmol';
 }
 
 function configure() {
   return {
     mgdlToMMOL: mgdlToMMOL
     , mmolToMgdl: mmolToMgdl
+    , normalizeGlucoseUnit: normalizeGlucoseUnit
+    , guessUnitFromValueAndHint: guessUnitFromValueAndHint
+    , guessUnitByProximity: guessUnitByProximity
   };
 }
 

--- a/tests/data.treatmenttocurve.test.js
+++ b/tests/data.treatmenttocurve.test.js
@@ -34,4 +34,22 @@ describe('Data', function ( ) {
     ddata.treatments[4].mgdl.should.equal(90);
   });
 
+  it('resolves treatment glucose unit from value when units field is missing', function () {
+    var ddata = require('../lib/data/ddata')();
+    ddata.sgvs = [{mgdl: 90, mills: before}, {mgdl: 100, mills: now}];
+    ddata.treatments = [
+      {_id: 'no_unit_high',      mills: before, glucose: 120}   // >= 40, no units → mgdl
+      , {_id: 'no_unit_low',     mills: before, glucose: 6.5}   // <= 25, no units → mmol
+      , {_id: 'no_unit_ambig',   mills: before, glucose: 35}    // 26-39, ref ~90 mg/dL → mgdl
+      , {_id: 'invalid_glucose', mills: before, glucose: 'abc'} // isNaN → skipped
+    ];
+    fitTreatmentsToBGCurve(ddata, { settings: settings }, { language: require('../lib/language')() });
+
+    ddata.treatments[0].mgdl.should.equal(120);
+    ddata.treatments[1].mmol.should.equal(6.5);
+    ddata.treatments[2].mgdl.should.equal(35);  // proximity to ~90 mg/dL → mgdl
+    (ddata.treatments[3].mgdl === undefined).should.be.true();
+    (ddata.treatments[3].mmol === undefined).should.be.true();
+  });
+
 });

--- a/tests/units.test.js
+++ b/tests/units.test.js
@@ -30,3 +30,64 @@ describe('units', function ( ) {
   });
 
 });
+
+describe('normalizeGlucoseUnit', function () {
+  var units = require('../lib/units')();
+
+  it('should normalize mg/dl variants to mgdl', function () {
+    units.normalizeGlucoseUnit('mg/dl').should.equal('mgdl');
+    units.normalizeGlucoseUnit('mg').should.equal('mgdl');
+    units.normalizeGlucoseUnit('mgdl').should.equal('mgdl');
+    units.normalizeGlucoseUnit('MG/DL').should.equal('mgdl');
+  });
+
+  it('should normalize mmol/l variants to mmol', function () {
+    units.normalizeGlucoseUnit('mmol/l').should.equal('mmol');
+    units.normalizeGlucoseUnit('mmol').should.equal('mmol');
+    units.normalizeGlucoseUnit('MMOL/L').should.equal('mmol');
+  });
+
+  it('should return null for unrecognized or missing unit', function () {
+    (units.normalizeGlucoseUnit(null) === null).should.be.true();
+    (units.normalizeGlucoseUnit('') === null).should.be.true();
+    (units.normalizeGlucoseUnit('unknown') === null).should.be.true();
+  });
+});
+
+describe('guessUnitFromValueAndHint', function () {
+  var units = require('../lib/units')();
+
+  it('should trust a recognized unit hint', function () {
+    units.guessUnitFromValueAndHint(100, 'mg/dl').should.equal('mgdl');
+    units.guessUnitFromValueAndHint(5.5, 'mmol').should.equal('mmol');
+  });
+
+  it('should infer mgdl for value >= 40 without hint', function () {
+    units.guessUnitFromValueAndHint(40).should.equal('mgdl');
+    units.guessUnitFromValueAndHint(120).should.equal('mgdl');
+  });
+
+  it('should infer mmol for value <= 25 without hint', function () {
+    units.guessUnitFromValueAndHint(5.5).should.equal('mmol');
+    units.guessUnitFromValueAndHint(25).should.equal('mmol');
+  });
+
+  it('should return null for ambiguous values in 26-39 range without hint', function () {
+    (units.guessUnitFromValueAndHint(30) === null).should.be.true();
+    (units.guessUnitFromValueAndHint(35) === null).should.be.true();
+  });
+});
+
+describe('guessUnitByProximity', function () {
+  var units = require('../lib/units')();
+
+  it('should pick mgdl when value is closer to reference as mg/dL', function () {
+    // value=30, ref=100 → |30-100|=70 vs |mmolToMgdl(30)-100|=|540-100|=440 → mgdl
+    units.guessUnitByProximity(30, 100).should.equal('mgdl');
+  });
+
+  it('should pick mmol when mmol interpretation is closer to reference', function () {
+    // value=30, ref=540 → mmolToMgdl(30)≈540 → closer as mmol
+    units.guessUnitByProximity(30, 540).should.equal('mmol');
+  });
+});


### PR DESCRIPTION
# Fix: mg/dL vs mmol/L unit handling for displaying treatments

## Problem

Treatments with glucose values were displayed incorrectly when the stored unit didn't match
the display unit, or when no unit was stored at all.

**`treatmenttocurve.js`** — When a treatment had no `units` field, the code blindly assumed
the value was in whatever unit the *user's display preference* was set to. This caused mg/dL
values to be interpreted as mmol/L (or vice versa) for users whose stored treatments predated
unit tracking.

**`report_plugins/utils.js`** — Unit mismatch detection relied on comparing `treatment.units`
with `client.settings.units`, which only worked when both were set. When `treatment.units` was
missing, the raw value was passed through unchanged — meaning an mg/dL value like `120` could
be displayed as `120 mmol/L`.

---

## Decision logic — `treatmenttocurve.js`

```
Is treatment.glucose present?
│
├── NO  → synthesize BG from nearby SGVs via mgdlByTime()
│
└── YES
    ├── is NaN? → warn + skip (no BG set)
    │
    └── is valid number
        ├── are treatment.units set (loaded from  DB)
        │   └── YES → use it directly (always trusted, no guessing)
        │
        ├── is value >= 40 → use mg/dL
        │
        ├── is value <= 25 → use mmol/L
        │
        └── is value in 26–39 and  unit stored
            ├── is SGV available → guessUnitByProximity()
            │   └── picks whichever interpretation is numerically 
            │       closer to the nearest interpolated SGV (mg/dL)
            └── NO SGV → mgdlByTime() returns 180 mg/dL as default fallback
                └── biases toward mg/dL in this edge case
```

---

## Changes

### `lib/units.js` — three new helpers

| Function | Purpose |
|---|---|
| `normalizeGlucoseUnit(unit)` | Normalizes `"mg/dl"`, `"mgdl"`, `"mmol/l"`, `"mmol"`, etc. to canonical `'mgdl'` or `'mmol'`; returns `null` if unrecognized |
| `guessUnitFromValueAndHint(value, unitHint)` | Returns recognized unit hint if present; otherwise infers from value range (≥ 40 → `mgdl`, ≤ 25 → `mmol`, 26–39 → `null`) |
| `guessUnitByProximity(glucoseValue, refMgdl)` | For ambiguous 26–39 range: picks the interpretation numerically closest to a known mg/dL reference |

### `lib/data/treatmenttocurve.js`

Replaced the old `settings.units` fallback with the new guessing logic above.
Ambiguous values in the 26–39 range are resolved by comparing proximity to the
nearest interpolated SGV via `mgdlByTime()`.

### `lib/report_plugins/utils.js`

Replaced the `treatment.units !== client.settings.units` mismatch-comparison path.
All treatment glucose values are now normalized to mg/dL first using the same
`guessUnitFromValueAndHint` / `guessUnitByProximity` logic, then scaled for display
via `client.utils.scaleMgdl()`.

---

## Tests

### Bug fix — `lib/units.js`

`mmolToMgdl` was returning a string (`.toFixed(0)`) instead of a number, breaking
three pre-existing assertions in `units.test.js`. Fixed by removing `.toFixed(0)` so
the function returns `Math.round(...)` directly.

### `tests/units.test.js` — new describe blocks

| Suite | Cases |
|---|---|
| `normalizeGlucoseUnit` | mg/dl variants → `'mgdl'`; mmol/l variants → `'mmol'`; null / empty / unknown → `null` |
| `guessUnitFromValueAndHint` | recognized hint trusted; ≥ 40 → `mgdl`; ≤ 25 → `mmol`; 26–39 no hint → `null` |
| `guessUnitByProximity` | value closer as mg/dL → `'mgdl'`; value closer as mmol/L → `'mmol'` |

### `tests/data.treatmenttocurve.test.js` — new test case

`resolves treatment glucose unit from value when units field is missing` exercises four
treatments against SGVs around 90–100 mg/dL:

| Treatment | Input | Expected |
|---|---|---|
| `no_unit_high` | `glucose: 120`, no units | `mgdl = 120` (≥ 40 rule) |
| `no_unit_low` | `glucose: 6.5`, no units | `mmol = 6.5` (≤ 25 rule) |
| `no_unit_ambig` | `glucose: 35`, no units, SGV ~90 | `mgdl = 35` (proximity) |
| `invalid_glucose` | `glucose: 'abc'` | skipped — no `mgdl` or `mmol` set |
