### PR TITLE
fix(connect): install 0.0.13 from public tarball

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "mongo-url-parser": "^1.0.2",
         "mongodb": "^5.9.2",
         "mongomock": "^0.1.2",
-        "nightscout-connect": "github:nightscout/nightscout-connect#v0.0.13",
+        "nightscout-connect": "https://github.com/nightscout/nightscout-connect/archive/refs/tags/v0.0.13.tar.gz",
         "node-cache": "^4.2.1",
         "process": "^0.11.10",
         "pushover-notifications": "^1.2.2",
@@ -7383,7 +7383,8 @@
     },
     "node_modules/nightscout-connect": {
       "version": "0.0.13",
-      "resolved": "git+ssh://git@github.com/nightscout/nightscout-connect.git#b394411a39236b614beebffabf23ccc04f730a68",
+      "resolved": "https://github.com/nightscout/nightscout-connect/archive/refs/tags/v0.0.13.tar.gz",
+      "integrity": "sha512-ye91VY0JqPHTDfwbNIdiDa19LSfbKzurN6lkfX/Q+J3r3dofg51rMtIi1CeZteWGVrVfTIysTK8fYBFPjZYIcA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "axios": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "mongo-url-parser": "^1.0.2",
     "mongodb": "^5.9.2",
     "mongomock": "^0.1.2",
-    "nightscout-connect": "github:nightscout/nightscout-connect#v0.0.13",
+    "nightscout-connect": "https://github.com/nightscout/nightscout-connect/archive/refs/tags/v0.0.13.tar.gz",
     "node-cache": "^4.2.1",
     "process": "^0.11.10",
     "pushover-notifications": "^1.2.2",


### PR DESCRIPTION
Avoid locking the nightscout-connect GitHub dependency to git+ssh so release and deploy builds without GitHub SSH keys can install the package.