### PR TITLE
Add an icon to toggle fullscreen of the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
         - [`ar2` (AR2 Forecasting)](#ar2-ar2-forecasting)
         - [`simplealarms` (Simple BG Alarms)](#simplealarms-simple-bg-alarms)
         - [`profile` (Treatment Profile)](#profile-treatment-profile)
+        - [`fullscreen` (Fullscreen)](#fullscreen-fullscreen)
       - [Advanced Plugins:](#advanced-plugins)
         - [`careportal` (Careportal)](#careportal-careportal)
         - [`boluscalc` (Bolus Wizard)](#boluscalc-bolus-wizard)
@@ -417,6 +418,10 @@ autonomy for your data:
   Add link to Profile Editor and allow to enter treatment profile settings. Also uses the extended setting:
   * `PROFILE_HISTORY` (`off`) - possible values `on` or `off`. Enable/disable NS ability to keep history of your profiles (still experimental)
   * `PROFILE_MULTIPLE` (`off`) - possible values `on` or `off`. Enable/disable NS ability to handle and switch between multiple treatment profiles
+
+##### `fullscreen` (Fullscreen)
+
+  Add an icon that, when clicked, toggles [Fullscreen](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API).
 
 #### Advanced Plugins:
 

--- a/lib/client/fullscreen.js
+++ b/lib/client/fullscreen.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const init = ($) => {
+
+  // show expand/compress icon depending on whether fullscreen is enabled
+  const showIcon = () => {
+    if (document.fullscreenElement) {
+      // fullscreen is enabled
+      $('#fullscreenIcon').removeClass('icon-expand');
+      $('#fullscreenIcon').addClass('icon-compress');
+    } else {
+      // fullscreen is not enabled
+      $('#fullscreenIcon').removeClass('icon-compress');
+      $('#fullscreenIcon').addClass('icon-expand');
+    }
+  };
+
+  if (document.fullscreenEnabled) {
+
+    // watch for fullscreen change events
+    document
+      .body
+      .addEventListener("fullscreenchange", (event) => {
+        showIcon();
+        event.preventDefault();
+      });
+
+    // set up the click event handler for the fullscreen icon
+    $('#fullscreen')
+      .click((event) => {
+        if (!document.fullscreenElement) {
+          document
+            .body
+            .requestFullscreen()
+            .catch(err => console.error(`failed to request fullscreen: ${err.message}`));
+        } else {
+          document
+            .exitFullscreen()
+            .catch(err => console.error(`failed to exit fullscreen: ${err.message}`));
+        }
+        event.preventDefault();
+      });
+
+    // now that everything is set up, make the fullscreen icon visible
+    showIcon();
+    $('#fullscreen').show();
+  }
+};
+
+module.exports = init;

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1391,6 +1391,11 @@ client.load = function load (serverSettings, callback) {
       chart.updateContext();
     }
   }
+
+  if (client.settings.isEnabled('fullscreen')) {
+    require('./fullscreen')($);
+  }
+
 };
 
 module.exports = client;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -82,6 +82,8 @@
 .icon-sort-numeric:before { content: '\f162'; }
 .icon-chart-line:before { content: '\f201'; }
 .icon-hourglass:before { content: '\f254'; }
+.icon-expand:before { content: '\2197'; }
+.icon-compress:before { content: '\2199'; }
 
 /* Plugin Icons id-s (copy from generated icon style.css) */
 .plugicon-database:before { content: "\e901"; }

--- a/views/partials/toolbar.ejs
+++ b/views/partials/toolbar.ejs
@@ -21,6 +21,7 @@
             <a id="treatmentDrawerToggle" class="tip" original-title="Care Portal" aria-label="Care Portal" href="#" style="display:none;"><i class="icon-plus"></i></a>
             <a id="lockedToggle" class="tip" original-title="Token needed for Care Portal" aria-label="Token needed for Care Portal" href="#" style="display:none;"><i class="icon-lock"></i></a>
             <a id="drawerToggle" class="tip" original-title="Settings" aria-label="Settings" href="#"><i class="icon-menu"></i></a>
+            <a id="fullscreen" class="tip" original-title="Fullscreen" aria-label="Fullscreen" href="#" style="display:none;"><i id="fullscreenIcon" class="icon-expand"></i></a>
             <a id="testAlarms" class="tip" original-title="Alarm Test / Smartphone Enable" aria-label="Alarm Test / Smartphone Enable" href="#"><i class="icon-volume"></i></a>
             <a id="editbutton" class="tip" original-title="Edit Mode" aria-label="Edit Mode" href="#" style="display:none;"><i class="icon-edit"></i></a>
             <a id="adminnotifies" class="tip" original-title="Admin ntofications" aria-label="Admin notifications" href="#" style="display:none;"><i class="plugicon-notifies" style='color: #c91515'></i></a>


### PR DESCRIPTION
This adds the Fullscreen plugin, which adds a clickable expand/compress icon to the toolbar to toggle fullscreen using the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API):

<img width="161" height="25" alt="expand" src="https://github.com/user-attachments/assets/03cae578-e25a-48ab-be5f-2e859f54c5d2" />
<br>
<img width="161" height="25" alt="compress" src="https://github.com/user-attachments/assets/81835489-b165-4065-b05f-8e86a1fb1333" />

The plugin must be enabled by the user by setting `ENABLE=fullscreen`.