### PR TITLE
Add configurable custom notification webhooks (#5742)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
       - [Extended Settings](#extended-settings)
       - [Pushover](#pushover)
       - [IFTTT Maker](#ifttt-maker)
+      - [Custom Notification WebHooks](#custom-notification-webhooks)
     - [Treatment Profile](#treatment-profile)
   - [Setting environment variables](#setting-environment-variables)
     - [Vagrant install](#vagrant-install)
@@ -772,6 +773,55 @@ For remote overrides, the following extended settings must be configured:
   * `ns-warning` - Alarms at the warning level with cause this event to also be triggered.  It will be sent in addition to `ns-event`.
   * `ns-urgent` - Alarms at the urgent level with cause this event to also be triggered.  It will be sent in addition to `ns-event`.
   * see the [full list of events](docs/plugins/maker-setup.md#events)
+
+#### Custom Notification WebHooks
+
+ Custom notification webhooks deliver Nightscout alarms and notifications straight to an endpoint you control, instead of relaying them through IFTTT. Because the request goes directly to your endpoint, it is not subject to IFTTT's throttling, which makes this a better fit for automations that need to react immediately (a local Home Assistant instance, a Raspberry Pi, a chat webhook, or your own service).
+
+ This is completely independent of the IFTTT Maker integration described above. Custom webhooks require no `MAKER_KEY` and work whether or not Maker is configured; if you configure both, each delivers on its own and neither affects the other.
+
+ Configure up to four destinations using numbered pairs of environment variables. Each destination needs both a URL and the event name it should receive:
+
+  * `CUSTOM_WEBHOOK_URL_1` - The full `http://` or `https://` URL to send the notification to. Any other scheme is rejected.
+  * `CUSTOM_WEBHOOK_EVENT_1` - The Nightscout event name this destination should receive, for example `ns-urgent`.
+  * `CUSTOM_WEBHOOK_URL_2` / `CUSTOM_WEBHOOK_EVENT_2`, and so on up to `_4`.
+
+ For example, to send urgent alarms to your own service and use a second destination as a catch all log:
+
+ ```
+ CUSTOM_WEBHOOK_URL_1="https://my-endpoint.example.com/nightscout?token=abc123"
+ CUSTOM_WEBHOOK_EVENT_1="ns-urgent"
+ CUSTOM_WEBHOOK_URL_2="http://192.168.1.50:3000/nightscout"
+ CUSTOM_WEBHOOK_EVENT_2="ns-event"
+ ```
+
+ **Event matching.** The event names are the same ones the Maker integration uses, so `ns-event`, `ns-allclear`, `ns-info`, `ns-warning`, `ns-urgent` and the more specific `ns-<level>-<name>` form such as `ns-urgent-simplealarms` all work. For each notification Nightscout works out which names apply and delivers to every destination configured for one of them. Unlike Maker, which deliberately sends several events per notification to work around IFTTT's name-only filtering, a custom destination receives **exactly one** request per notification even if more than one of its configured event names matches.
+
+ **Request format.** Each delivery is an HTTP `POST` with a JSON body:
+
+ ```json
+ {
+   "source": "nightscout",
+   "event": "ns-urgent",
+   "name": "simplealarms",
+   "level": "urgent",
+   "title": "Urgent LOW",
+   "message": "BG 51",
+   "isAnnouncement": false,
+   "mills": 1731000000000,
+   "iso": "2024-11-07T18:40:00.000Z"
+ }
+ ```
+
+ Notes:
+
+  * Numbering does not have to be contiguous; configuring only `_1` and `_3` is fine.
+  * A pair that is missing either half, or a URL that is not a valid `http`/`https` URL, is skipped with a warning at startup rather than preventing Nightscout from starting.
+  * Requests time out after 5 seconds and any `2xx` response counts as success. A failing endpoint is logged and never blocks or breaks alarm delivery.
+  * Because a webhook URL can contain a token, these URLs are treated as secure settings: they are not published in `/api/v1/status`, and logs record only the destination host, never the full URL or the notification contents.
+  * Anyone who can set these variables can make your Nightscout server issue requests to any address it can reach, including hosts on your private network. Only point them at endpoints you trust.
+
+ This feature is separate from the SGV `webhook` plugin, which posts every new glucose reading to a single endpoint rather than routing notification events.
 
 
 ### Treatment Profile

--- a/README.md
+++ b/README.md
@@ -795,7 +795,9 @@ For remote overrides, the following extended settings must be configured:
  CUSTOM_WEBHOOK_EVENT_2="ns-event"
  ```
 
- **Event matching.** The event names are the same ones the Maker integration uses, so `ns-event`, `ns-allclear`, `ns-info`, `ns-warning`, `ns-urgent` and the more specific `ns-<level>-<name>` form such as `ns-urgent-simplealarms` all work. For each notification Nightscout works out which names apply and delivers to every destination configured for one of them. Unlike Maker, which deliberately sends several events per notification to work around IFTTT's name-only filtering, a custom destination receives **exactly one** request per notification even if more than one of its configured event names matches.
+ **Event matching.** The event names are the same ones the Maker integration uses, so `ns-event`, `ns-allclear`, `ns-info`, `ns-warning`, `ns-urgent` and the more specific `ns-<level>-<name>` form such as `ns-urgent-low` all work. For each notification Nightscout works out which names apply and delivers to every destination configured for one of them. Unlike Maker, which deliberately sends several events per notification to work around IFTTT's name-only filtering, a custom destination receives **exactly one** request per notification even if more than one of its configured event names matches.
+
+ Note that low and high BG alarms use the level qualified form, so a low alarm is `ns-urgent-low` when the `BG_LOW` threshold is crossed and `ns-warning-low` when `BG_TARGET_BOTTOM` is crossed, with `ns-urgent-high` and `ns-warning-high` as the equivalents for high alarms. There is no bare `ns-low` event. If you want a destination to receive every low alarm regardless of severity, configure one entry for each of the two names, or use `ns-event` to receive everything. See the [full list of events](docs/plugins/maker-setup.md#events) for the complete vocabulary.
 
  **Request format.** Each delivery is an HTTP `POST` with a JSON body:
 

--- a/docs/example-template.env
+++ b/docs/example-template.env
@@ -14,6 +14,14 @@ PORT=1337
 NODE_ENV=development
 AUTH_FAIL_DELAY=50
 
+# Custom notification webhooks: deliver Nightscout notifications directly to
+# your own http/https endpoint instead of relaying them through IFTTT.
+# Each destination needs both a URL and the event name it should receive.
+# Numbering does not have to be contiguous, up to 4 pairs are recognized.
+# See the "Custom Notification WebHooks" section of the README.
+# CUSTOM_WEBHOOK_URL_1="https://my-endpoint.example.com/nightscout"
+# CUSTOM_WEBHOOK_EVENT_1="ns-urgent"
+
 # UUID handling for specific client patterns that send UUID as _id field
 # Only affects cases where a UUID is sent as the _id field itself
 # (e.g., Loop overrides, Trio CGM entries)

--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -231,6 +231,7 @@ function boot (env, language) {
 
     ctx.pushover = require('../plugins/pushover')(env, ctx);
     ctx.maker = require('../plugins/maker')(env);
+    ctx.customwebhook = require('./customwebhook')(env);
     ctx.pushnotify = require('./pushnotify')(env, ctx);
     ctx.loop = require('./loop')(env, ctx);
 

--- a/lib/server/customwebhook.js
+++ b/lib/server/customwebhook.js
@@ -1,0 +1,239 @@
+'use strict';
+
+var http = require('http');
+var https = require('https');
+
+//how many CUSTOM_WEBHOOK_URL_n / CUSTOM_WEBHOOK_EVENT_n pairs are recognized
+var MAX_WEBHOOKS = 4;
+
+var TIMEOUT_MS = 5000;
+
+function init (env) {
+
+  var webhooks = findWebhooks(env && env.settings);
+
+  var customwebhook = { };
+
+  //exposed for testing and for startup logging
+  customwebhook.webhooks = webhooks;
+
+  //The event names a notification can match. These mirror the granularity
+  //levels produced by makeRequests in lib/plugins/maker.js so operators can
+  //reuse the event names already documented for the Maker integration.
+  //Unlike Maker, a matching destination is sent exactly one request.
+  customwebhook.eventNames = function eventNames (event) {
+    var names = ['ns-event'];
+
+    if (event && event.level) {
+      names.push('ns-' + event.level);
+    }
+
+    if (event && event.name) {
+      names.push('ns' + ((event.level && '-' + event.level) || '') + '-' + event.name);
+    }
+
+    return names;
+  };
+
+  customwebhook.sendEvent = function sendEvent (event, callback) {
+    callback = callback || function noopCallback ( ) { };
+
+    if (!event || !event.name) {
+      callback('No event name found');
+    } else if (!event.level) {
+      callback('No event level found');
+    } else {
+      deliver(customwebhook.eventNames(event), event, callback);
+    }
+  };
+
+  customwebhook.sendAllClear = function sendAllClear (notify, callback) {
+    callback = callback || function noopCallback ( ) { };
+
+    deliver(['ns-allclear'], {
+      name: 'allclear'
+      , title: (notify && notify.title) || 'All Clear'
+      , message: notify && notify.message
+    }, callback);
+  };
+
+  //exposed so tests can replace the outbound request
+  customwebhook.sendRequest = function sendRequest (webhook, payload, callback) {
+    var target = webhook.target;
+    var transport = target.protocol === 'https:' ? https : http;
+    var body = JSON.stringify(payload);
+    var finished = false;
+
+    //a destroyed socket can emit both 'timeout' and 'error', only report once
+    function finish (err, response) {
+      if (finished) { return; }
+      finished = true;
+      callback(err, response);
+    }
+
+    var options = {
+      hostname: target.hostname
+      , port: target.port || undefined
+      , path: target.pathname + target.search
+      , method: 'POST'
+      , timeout: TIMEOUT_MS
+      , headers: {
+        'Content-Type': 'application/json'
+        , 'Content-Length': Buffer.byteLength(body)
+      }
+    };
+
+    var request = transport.request(options, function onResponse (response) {
+      //drain the response so the socket is released
+      response.on('data', function onData ( ) { });
+      response.on('end', function onEnd ( ) {
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          finish(null, response);
+        } else {
+          finish('unexpected status ' + response.statusCode);
+        }
+      });
+    });
+
+    request.on('error', function onError (err) {
+      finish((err && err.message) || 'request failed');
+    });
+
+    request.on('timeout', function onTimeout ( ) {
+      //destroy triggers the error handler above, which reports the failure
+      request.destroy();
+    });
+
+    request.write(body);
+    request.end();
+  };
+
+  function deliver (names, event, callback) {
+    var matched = [ ];
+    //one delivery per destination per notification, so an endpoint configured
+    //for more than one matching event name is never sent duplicates
+    var seen = Object.create(null);
+
+    webhooks.forEach(function eachWebhook (webhook) {
+      if (names.indexOf(webhook.event) < 0 || seen[webhook.url]) {
+        return;
+      }
+      seen[webhook.url] = true;
+      matched.push(webhook);
+    });
+
+    if (matched.length === 0) {
+      callback(null, {sent: 0});
+      return;
+    }
+
+    var pending = matched.length;
+    var errs = [ ];
+
+    matched.forEach(function eachMatched (webhook) {
+      customwebhook.sendRequest(webhook, payloadFor(webhook, event), function requestCallback (err) {
+        if (err) {
+          //report the origin only, the full URL may carry a token
+          errs.push(describe(webhook) + ': ' + err);
+        }
+
+        pending -= 1;
+        if (pending === 0) {
+          callback(errs.length > 0 ? errs.join(', ') : null, {
+            sent: matched.length - errs.length
+            , matched: matched.length
+          });
+        }
+      });
+    });
+  }
+
+  function payloadFor (webhook, event) {
+    var now = Date.now();
+
+    return {
+      source: 'nightscout'
+      , event: webhook.event
+      , name: event.name
+      , level: event.level || null
+      , title: event.title
+      , message: event.message
+      , isAnnouncement: !!event.isAnnouncement
+      , mills: now
+      , iso: new Date(now).toISOString()
+    };
+  }
+
+  if (webhooks.length > 0) {
+    webhooks.forEach(function eachWebhook (webhook) {
+      console.info('custom webhook ' + webhook.index + ' listening for ' + webhook.event + ' at ' + describe(webhook));
+    });
+    return customwebhook;
+  } else {
+    return null;
+  }
+
+}
+
+//host and port only, never the path or query, which may contain a secret
+function describe (webhook) {
+  return webhook.target.protocol + '//' + webhook.target.host;
+}
+
+function findWebhooks (settings) {
+  var found = [ ];
+
+  if (!settings) {
+    return found;
+  }
+
+  for (var i = 1; i <= MAX_WEBHOOKS; i++) {
+    var url = trimmed(settings['customWebhookUrl' + i]);
+    var event = trimmed(settings['customWebhookEvent' + i]);
+
+    //an unused slot is normal, indexes do not have to be contiguous
+    if (!url && !event) {
+      continue;
+    }
+
+    if (!url || !event) {
+      console.warn('ignoring custom webhook ' + i + ', both CUSTOM_WEBHOOK_URL_' + i +
+        ' and CUSTOM_WEBHOOK_EVENT_' + i + ' are required');
+      continue;
+    }
+
+    var target = parseTarget(url);
+
+    if (!target) {
+      console.warn('ignoring custom webhook ' + i + ', CUSTOM_WEBHOOK_URL_' + i +
+        ' is not a valid http or https URL');
+      continue;
+    }
+
+    found.push({index: i, event: event, url: url, target: target});
+  }
+
+  return found;
+}
+
+function parseTarget (url) {
+  var target;
+
+  try {
+    target = new URL(url);
+  } catch (err) {
+    return null;
+  }
+
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    return null;
+  }
+
+  return target;
+}
+
+function trimmed (value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+module.exports = init;

--- a/lib/server/pushnotify.js
+++ b/lib/server/pushnotify.js
@@ -18,6 +18,7 @@ function init (env, ctx) {
     if (notify.clear) {
       cancelPushoverNotifications();
       sendMakerAllClear(notify);
+      sendCustomWebhookAllClear(notify);
       return;
     }
 
@@ -51,6 +52,7 @@ function init (env, ctx) {
 
     sendPushoverNotifications(notify);
     sendMakerEvent(notify);
+    sendCustomWebhookEvent(notify);
 
   };
 
@@ -142,6 +144,46 @@ function init (env, ctx) {
       }
     });
   }
+  //Custom webhooks are delivered independently of Maker, they are not gated on
+  //ctx.maker so they work without a MAKER_KEY, and they do not extend the
+  //recentlySent TTL, which stays owned by the pushover and Maker paths.
+  function sendCustomWebhookEvent (notify) {
+    if (!ctx.customwebhook) {
+      return;
+    }
+
+    var event = {
+      name: notify.eventName || notify.plugin.name
+      , level: levels.toLowerCase(notify.level)
+      , title: notify.title
+      , message: notify.message
+      , isAnnouncement: notify.isAnnouncement
+    };
+
+    ctx.customwebhook.sendEvent(event, function customWebhookCallback (err, result) {
+      //only the event name and counts are logged, never the notification content
+      if (err) {
+        console.error('unable to send custom webhook event ' + event.name + ': ', err);
+      } else if (result && result.sent > 0) {
+        console.info('sent custom webhook event: ' + event.name + ', destinations: ' + result.sent);
+      }
+    });
+  }
+
+  function sendCustomWebhookAllClear (notify) {
+    if (!ctx.customwebhook) {
+      return;
+    }
+
+    ctx.customwebhook.sendAllClear(notify, function customWebhookCallback (err, result) {
+      if (err) {
+        console.error('unable to send custom webhook allclear: ', err);
+      } else if (result && result.sent > 0) {
+        console.info('sent custom webhook allclear, destinations: ' + result.sent);
+      }
+    });
+  }
+
   function notifyToHash (notify) {
     var hash = crypto.createHash('sha1');
     var info = JSON.stringify({

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -67,6 +67,14 @@ function init () {
     , frameName6: ''
     , frameName7: ''
     , frameName8: ''
+    , customWebhookUrl1: ''
+    , customWebhookUrl2: ''
+    , customWebhookUrl3: ''
+    , customWebhookUrl4: ''
+    , customWebhookEvent1: ''
+    , customWebhookEvent2: ''
+    , customWebhookEvent3: ''
+    , customWebhookEvent4: ''
     , authFailDelay: 5000
     , adminNotifiesEnabled: true
     , obscured: ''
@@ -82,6 +90,11 @@ function init () {
     , 'password'
     , 'obscured'
     , 'obscureDeviceProvenance'
+    //custom webhook URLs can embed per-destination tokens, don't publish them in status.json
+    , 'customWebhookUrl1'
+    , 'customWebhookUrl2'
+    , 'customWebhookUrl3'
+    , 'customWebhookUrl4'
   ];
 
   var valueMappers = {

--- a/tests/customwebhook.test.js
+++ b/tests/customwebhook.test.js
@@ -1,0 +1,403 @@
+'use strict';
+
+var should = require('should');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Build a customwebhook instance from the numbered settings an operator would
+// configure. Returns null when nothing usable is configured, same as the module.
+function makeWebhooks (settings) {
+  return require('../lib/server/customwebhook')({settings: settings || {}});
+}
+
+// Replace the outbound request so no test ever touches the network, and record
+// what would have been sent.
+function capture (customwebhook, err) {
+  var sent = [ ];
+
+  customwebhook.sendRequest = function captureRequest (webhook, payload, callback) {
+    sent.push({url: webhook.url, target: webhook.target, payload: payload});
+    callback(err || null);
+  };
+
+  return sent;
+}
+
+function urgentEvent ( ) {
+  return {
+    name: 'simplealarms'
+    , level: 'urgent'
+    , title: 'Urgent LOW'
+    , message: 'BG 51'
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+describe('customwebhook - configuration', function ( ) {
+
+  it('is not created when nothing is configured', function ( ) {
+    should.not.exist(makeWebhooks({}));
+  });
+
+  it('is not created when there are no settings at all', function ( ) {
+    should.not.exist(require('../lib/server/customwebhook')({}));
+  });
+
+  it('loads a complete url and event pair', function ( ) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-urgent'
+    });
+
+    customwebhook.webhooks.length.should.equal(1);
+    customwebhook.webhooks[0].event.should.equal('ns-urgent');
+    customwebhook.webhooks[0].url.should.equal('https://example.com/hook');
+  });
+
+  it('skips a url configured without an event', function ( ) {
+    should.not.exist(makeWebhooks({customWebhookUrl1: 'https://example.com/hook'}));
+  });
+
+  it('skips an event configured without a url', function ( ) {
+    should.not.exist(makeWebhooks({customWebhookEvent1: 'ns-urgent'}));
+  });
+
+  it('skips a malformed url without throwing', function ( ) {
+    should.not.exist(makeWebhooks({
+      customWebhookUrl1: 'this is not a url'
+      , customWebhookEvent1: 'ns-urgent'
+    }));
+  });
+
+  it('rejects a scheme that is not http or https', function ( ) {
+    should.not.exist(makeWebhooks({
+      customWebhookUrl1: 'ftp://example.com/hook'
+      , customWebhookEvent1: 'ns-urgent'
+    }));
+  });
+
+  it('keeps the valid entries when another entry is invalid', function ( ) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'nope'
+      , customWebhookEvent1: 'ns-urgent'
+      , customWebhookUrl2: 'https://good.example.com/hook'
+      , customWebhookEvent2: 'ns-urgent'
+    });
+
+    customwebhook.webhooks.length.should.equal(1);
+    customwebhook.webhooks[0].index.should.equal(2);
+  });
+
+  it('supports sparse indexes', function ( ) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://one.example.com/hook'
+      , customWebhookEvent1: 'ns-urgent'
+      , customWebhookUrl4: 'https://four.example.com/hook'
+      , customWebhookEvent4: 'ns-urgent'
+    });
+
+    customwebhook.webhooks.length.should.equal(2);
+    customwebhook.webhooks[0].index.should.equal(1);
+    customwebhook.webhooks[1].index.should.equal(4);
+  });
+
+  it('trims surrounding whitespace', function ( ) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: '  https://example.com/hook  '
+      , customWebhookEvent1: '  ns-urgent  '
+    });
+
+    customwebhook.webhooks[0].url.should.equal('https://example.com/hook');
+    customwebhook.webhooks[0].event.should.equal('ns-urgent');
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Event matching
+// ---------------------------------------------------------------------------
+
+describe('customwebhook - event matching', function ( ) {
+
+  it('generates the same event names Maker uses', function ( ) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-event'
+    });
+
+    customwebhook.eventNames({name: 'simplealarms', level: 'urgent'})
+      .should.eql(['ns-event', 'ns-urgent', 'ns-urgent-simplealarms']);
+  });
+
+  it('sends one request to the configured destination on a match', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-urgent'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback (err, result) {
+      should.not.exist(err);
+      result.sent.should.equal(1);
+      sent.length.should.equal(1);
+      sent[0].url.should.equal('https://example.com/hook');
+      sent[0].payload.event.should.equal('ns-urgent');
+      done();
+    });
+  });
+
+  it('matches the generic ns-event name', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-event'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback (err, result) {
+      should.not.exist(err);
+      result.sent.should.equal(1);
+      sent.length.should.equal(1);
+      done();
+    });
+  });
+
+  it('matches the level and name qualified event', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-urgent-simplealarms'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback (err) {
+      should.not.exist(err);
+      sent.length.should.equal(1);
+      done();
+    });
+  });
+
+  it('sends nothing when the configured event does not match', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-warning'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback (err, result) {
+      should.not.exist(err);
+      result.sent.should.equal(0);
+      sent.length.should.equal(0);
+      done();
+    });
+  });
+
+  it('delivers to every configured destination that matches', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://one.example.com/hook'
+      , customWebhookEvent1: 'ns-urgent'
+      , customWebhookUrl2: 'https://two.example.com/hook'
+      , customWebhookEvent2: 'ns-event'
+      , customWebhookUrl3: 'https://three.example.com/hook'
+      , customWebhookEvent3: 'ns-warning'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback (err, result) {
+      should.not.exist(err);
+      result.sent.should.equal(2);
+      sent.map(function eachSent (item) { return item.url; }).should.eql([
+        'https://one.example.com/hook'
+        , 'https://two.example.com/hook'
+      ]);
+      done();
+    });
+  });
+
+  it('sends a destination only once even when several event names match it', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-event'
+      , customWebhookUrl2: 'https://example.com/hook'
+      , customWebhookEvent2: 'ns-urgent'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback (err, result) {
+      should.not.exist(err);
+      result.sent.should.equal(1);
+      sent.length.should.equal(1);
+      done();
+    });
+  });
+
+  it('does not send a request without an event name', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-event'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent({level: 'urgent'}, function sendCallback (err) {
+      should.exist(err);
+      sent.length.should.equal(0);
+      done();
+    });
+  });
+
+  it('does not send a request without an event level', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-event'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent({name: 'simplealarms'}, function sendCallback (err) {
+      should.exist(err);
+      sent.length.should.equal(0);
+      done();
+    });
+  });
+
+  it('delivers an allclear only to destinations configured for it', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://clear.example.com/hook'
+      , customWebhookEvent1: 'ns-allclear'
+      , customWebhookUrl2: 'https://alarm.example.com/hook'
+      , customWebhookEvent2: 'ns-event'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendAllClear({title: 'All Clear'}, function sendCallback (err, result) {
+      should.not.exist(err);
+      result.sent.should.equal(1);
+      sent.length.should.equal(1);
+      sent[0].url.should.equal('https://clear.example.com/hook');
+      sent[0].payload.event.should.equal('ns-allclear');
+      done();
+    });
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Payload
+// ---------------------------------------------------------------------------
+
+describe('customwebhook - payload', function ( ) {
+
+  it('includes the event, level, name, title and message', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-urgent'
+    });
+    var sent = capture(customwebhook);
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback ( ) {
+      var payload = sent[0].payload;
+      payload.source.should.equal('nightscout');
+      payload.event.should.equal('ns-urgent');
+      payload.level.should.equal('urgent');
+      payload.name.should.equal('simplealarms');
+      payload.title.should.equal('Urgent LOW');
+      payload.message.should.equal('BG 51');
+      payload.isAnnouncement.should.equal(false);
+      payload.mills.should.be.type('number');
+      payload.iso.should.be.type('string');
+      done();
+    });
+  });
+
+  it('marks announcements', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-event'
+    });
+    var sent = capture(customwebhook);
+
+    var event = urgentEvent();
+    event.isAnnouncement = true;
+
+    customwebhook.sendEvent(event, function sendCallback ( ) {
+      sent[0].payload.isAnnouncement.should.equal(true);
+      done();
+    });
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+describe('customwebhook - transport', function ( ) {
+
+  it('keeps the parsed target for an https destination', function ( ) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com:8443/hook?token=abc'
+      , customWebhookEvent1: 'ns-event'
+    });
+    var target = customwebhook.webhooks[0].target;
+
+    target.protocol.should.equal('https:');
+    target.hostname.should.equal('example.com');
+    target.port.should.equal('8443');
+    target.pathname.should.equal('/hook');
+    target.search.should.equal('?token=abc');
+  });
+
+  it('keeps the parsed target for an http destination', function ( ) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'http://192.168.1.5:3000/nightscout'
+      , customWebhookEvent1: 'ns-event'
+    });
+    var target = customwebhook.webhooks[0].target;
+
+    target.protocol.should.equal('http:');
+    target.hostname.should.equal('192.168.1.5');
+    target.port.should.equal('3000');
+  });
+
+  it('reports a network failure through the callback without throwing', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://example.com/hook'
+      , customWebhookEvent1: 'ns-urgent'
+    });
+    capture(customwebhook, 'getaddrinfo ENOTFOUND example.com');
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback (err, result) {
+      should.exist(err);
+      result.sent.should.equal(0);
+      result.matched.should.equal(1);
+      done();
+    });
+  });
+
+  it('reports a partial failure but still counts the successful send', function (done) {
+    var customwebhook = makeWebhooks({
+      customWebhookUrl1: 'https://bad.example.com/hook?token=SUPERSECRET'
+      , customWebhookEvent1: 'ns-urgent'
+      , customWebhookUrl2: 'https://good.example.com/hook'
+      , customWebhookEvent2: 'ns-urgent'
+    });
+
+    customwebhook.sendRequest = function oneFails (webhook, payload, callback) {
+      callback(webhook.url.indexOf('bad') > -1 ? 'unexpected status 500' : null);
+    };
+
+    customwebhook.sendEvent(urgentEvent(), function sendCallback (err, result) {
+      should.exist(err);
+      //the failing destination is identified by origin, without the secret bearing path
+      err.indexOf('bad.example.com').should.be.above(-1);
+      err.indexOf('SUPERSECRET').should.equal(-1);
+      err.indexOf('/hook').should.equal(-1);
+      result.sent.should.equal(1);
+      result.matched.should.equal(2);
+      done();
+    });
+  });
+
+});

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -137,6 +137,47 @@ describe('settings', function ( ) {
     fresh.secureCsp.should.equal(true);
   });
 
+  it('support setting numbered custom webhook env vars', function () {
+    var userSetting = {
+      CUSTOM_WEBHOOK_URL_1: 'https://one.example.com/hook'
+      , CUSTOM_WEBHOOK_EVENT_1: 'ns-urgent'
+      //sparse on purpose, index 3 is set while index 2 is left unconfigured
+      , CUSTOM_WEBHOOK_URL_3: 'http://three.example.com/hook'
+      , CUSTOM_WEBHOOK_EVENT_3: 'ns-allclear'
+    };
+
+    var fresh = require('../lib/settings')();
+    fresh.eachSettingAsEnv(function (name) {
+      return userSetting[name];
+    });
+
+    fresh.customWebhookUrl1.should.equal('https://one.example.com/hook');
+    fresh.customWebhookEvent1.should.equal('ns-urgent');
+    fresh.customWebhookUrl2.should.equal('');
+    fresh.customWebhookEvent2.should.equal('');
+    fresh.customWebhookUrl3.should.equal('http://three.example.com/hook');
+    fresh.customWebhookEvent3.should.equal('ns-allclear');
+  });
+
+  it('does not publish custom webhook urls in filtered settings', function () {
+    var userSetting = {
+      CUSTOM_WEBHOOK_URL_1: 'https://one.example.com/hook?token=SUPERSECRET'
+      , CUSTOM_WEBHOOK_EVENT_1: 'ns-urgent'
+    };
+
+    var fresh = require('../lib/settings')();
+    fresh.eachSettingAsEnv(function (name) {
+      return userSetting[name];
+    });
+
+    var published = fresh.filteredSettings(fresh);
+
+    should.not.exist(published.customWebhookUrl1);
+    JSON.stringify(published).indexOf('SUPERSECRET').should.equal(-1);
+    //the event name is not a secret and stays available to the client
+    published.customWebhookEvent1.should.equal('ns-urgent');
+  });
+
   it('have default features', function () {
     var fresh = require('../lib/settings')();
     fresh.eachSettingAsEnv(function () {


### PR DESCRIPTION
Closes #5742

## Why

Issue #5742 describes delays caused by routing Nightscout notification events through IFTTT Maker. Today, the Maker notification path is tied to an IFTTT key and a hardcoded IFTTT destination, so operators cannot route those same notification events directly to their own endpoints.

This PR adds an independent custom notification-webhook path while preserving the existing Maker/IFTTT behavior.

## What changed

Operators can configure up to four URL/event pairs:

```text
CUSTOM_WEBHOOK_URL_1="https://my-endpoint.example.com/nightscout"
CUSTOM_WEBHOOK_EVENT_1="ns-urgent"

CUSTOM_WEBHOOK_URL_2="http://192.168.1.50:3000/nightscout"
CUSTOM_WEBHOOK_EVENT_2="ns-event"
```

Matching notifications are delivered directly to the configured endpoint as JSON `POST` requests.

The implementation:

- adds a dedicated `lib/server/customwebhook.js` sender
- dispatches custom webhooks independently from Maker in `pushnotify`
- uses Nightscout's existing numbered-settings convention for configuration
- supports both HTTP and HTTPS
- uses a 5-second timeout and treats any 2xx response as successful
- skips malformed or incomplete configuration without preventing startup
- deduplicates by destination so one notification is not accidentally delivered multiple times to the same endpoint
- protects configured webhook URLs through `secureSettings`
- avoids logging full webhook URLs or notification contents
- leaves `lib/plugins/maker.js` and `lib/plugins/webhook.js` unchanged

## Design notes

### Independent from Maker / IFTTT

`lib/plugins/maker.js` is intentionally not modified.

Maker's existing three-event fan-out (`ns-event`, `ns-<level>`, `ns-<level>-<name>`) is an IFTTT-specific compatibility behavior that dates back to the original implementation. Extending the Maker sender directly would also inherit the requirement for a `MAKER_KEY`.

Instead, this PR adds a sibling delivery path from the notification dispatcher. Custom webhooks therefore work even when `ctx.maker === null`, while existing Maker behavior remains unchanged.

### Configuration naming

The issue illustrates names such as `CUSTOM_WEBHOOK_1_URL`, but Nightscout's current numbered-setting convention maps naturally to:

```text
CUSTOM_WEBHOOK_URL_1
CUSTOM_WEBHOOK_EVENT_1
```

This matches existing settings such as `FRAME_URL_1` and avoids changing the global settings-name parser.

### Event matching

Custom webhook event matching follows Nightscout's existing Maker event vocabulary:

- `ns-event`
- `ns-<level>`
- `ns-<level>-<name>`
- `ns-allclear`

For low blood glucose alarms, the level-qualified forms are used, for example:

```text
ns-urgent-low
ns-warning-low
```

There is no bare `ns-low` event in the current event vocabulary.

### Delivery behavior

A single configured destination is sent at most one request for a notification, even if more than one generated event name would match that same destination.

The JSON payload includes the notification fields needed by the receiving endpoint, and the transport uses Node's built-in `http`, `https`, and `URL` APIs. No new dependencies were added.

## Security considerations

Webhook URLs may contain credentials or tokens, so the new URL settings are included in `secureSettings` and are not exposed through normal serialized settings output.

The implementation also:

- only accepts `http:` and `https:` schemes
- does not log full URLs, query strings, titles, or message bodies
- skips malformed URLs rather than crashing startup
- reports network failures through callbacks rather than throwing into the alarm path

Custom webhook URLs are operator-controlled configuration. They can point to private-network hosts, which is intentional for this use case and consistent with Nightscout's existing server webhook functionality. This is documented because it creates the expected SSRF surface of an operator-configurable outbound webhook feature.

## Backward compatibility

The default configuration contains no custom webhook destinations, so the new module initializes to `null` and produces no additional outbound traffic unless explicitly configured.

Existing behavior is preserved:

- `lib/plugins/maker.js` is unchanged
- `lib/plugins/webhook.js` is unchanged
- existing Maker key handling is unchanged
- existing Maker three-request fan-out is unchanged
- existing SGV webhook behavior is unchanged
- custom webhook delivery does not depend on `MAKER_KEY`
- custom delivery does not modify the existing `recentlySent` TTL or Pushover receipt handling

## Testing

### Focused feature tests

```bash
npx env-cmd -f ./my.test.env npx mocha --timeout 5000 --require ./tests/hooks.js --exit ./tests/customwebhook.test.js
```

Result:

```text
26 passing
0 failing
```

### Related regression suites

```bash
npx env-cmd -f ./my.test.env npx mocha --timeout 5000 --require ./tests/hooks.js --exit ./tests/maker.test.js ./tests/webhook.test.js ./tests/settings.test.js ./tests/env.test.js
```

Relevant results:

```text
maker:        6 passing
webhook:     10 passing
settings:    16 passing
combined:    55 passing, 0 failing
```

The existing Maker and SGV-webhook test files were not modified.

### Broader unit suite

The broader local unit suite produced:

```text
293 passing
6 failing
```

The six failures are MongoDB-dependent local-environment failures in the existing security/authentication tests. To verify they were not introduced by this change, I temporarily removed the custom-webhook source changes and re-ran the failing suites; the same four `verifyauth` timeouts and two `security` failures remained.

### Lint

`npm run lint` reports the same 32 pre-existing problems with or without the custom-webhook source changes.

Running ESLint against the new/modified source and test files produces no new lint problems.

### Manual transport verification

Because automated tests stub the outbound request seam, I also exercised the real transport against a local HTTP listener:

```text
204 response -> success
500 response -> failure
dead port -> callback error, no throw
query string -> preserved
JSON body -> delivered
custom delivery with ctx.maker === null -> successful
```

## Acceptance criteria

- [x] Tests added for new/changed behavior
- [x] Relevant feature and regression suites pass
- [x] New and modified files introduce no new lint problems
- [x] Existing Maker behavior remains unchanged
- [x] Existing SGV-webhook behavior remains unchanged
- [x] No breaking changes intentionally introduced
- [x] Documentation updated
- [x] Pull request targets upstream `dev`
- [x] Original issue referenced with `Closes #5742`
- [ ] Full local unit suite completely green — 6 MongoDB-dependent failures remain, but they were reproduced without the feature changes and documented as pre-existing local-environment failures

## Before / after verification evidence

Before implementation, reproducing an urgent-low notification through the existing path generated three requests to the hardcoded IFTTT Maker endpoint and zero requests to the configured custom endpoint:

```text
maker.ifttt.com requests: 3
configured custom endpoint requests: 0
```

After implementation:

```text
customwebhook tests: 26 passing
related Maker/webhook/settings/env suites: 55 passing, 0 failing
custom delivery with ctx.maker === null: 1 destination delivered
```

The existing Maker and SGV-webhook implementations remain unchanged.

## Documentation

This PR updates:

- `README.md` with a new Custom Notification WebHooks section
- `docs/example-template.env` with commented configuration examples

The README documents the configuration variables, event matching behavior, JSON delivery behavior, low/high alarm event naming, and security considerations.
