### PR TITLE
Harden request validation and browser security

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,18 +14,21 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ dev, master ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ dev ]
+    branches: [ dev, master ]
   schedule:
     - cron: '43 23 * * 3'
+
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/dev' && github.repository_owner == 'nightscout'
+    if: github.repository_owner == 'nightscout'
 
     strategy:
       fail-fast: false
@@ -37,33 +40,20 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        build-mode: none
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/lib/api/activity/index.js
+++ b/lib/api/activity/index.js
@@ -3,6 +3,7 @@
 var consts = require('../../constants');
 var moment = require('moment');
 var objectIdValidation = require('../shared/objectid-validation');
+var writePayload = require('../shared/write-payload');
 
 function configure(app, wares, ctx) {
     var express = require('express')
@@ -63,23 +64,22 @@ function configure(app, wares, ctx) {
 
     function config_authed(app, api, wares, ctx) {
         function post_response(req, res) {
-            var activity = req.body;
-
-            if (!Array.isArray(activity)) {
-                activity = [activity];
+            var normalized = writePayload.normalize(req.body);
+            if (normalized.error === 'size') {
+                return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+                    'Too many activity records', 'Maximum records per request: ' + writePayload.MAX_BATCH_ITEMS);
             }
+            if (normalized.error) {
+                return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+                    'Invalid activity payload', 'Expected an object or array of objects');
+            }
+            var activity = normalized.documents;
 
             // Validate _id fields before storage (return 400 on invalid)
             var invalid = objectIdValidation.findInvalidId(activity);
             if (invalid) {
                 return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
                     'Invalid _id format', 'Must be 24-character hex string or omit for auto-generation. Got: ' + String(invalid.id));
-            }
-
-            // Sanitize free-text fields for symmetry with treatments/entries/
-            // devicestatus/profile/food REST writes and the WS write path.
-            for (var i = 0; i < activity.length; i++) {
-                ctx.purifier.purifyObject(activity[i]);
             }
 
             ctx.activity.create(activity, function(err, created) {
@@ -108,6 +108,10 @@ function configure(app, wares, ctx) {
 
         // update record
         api.put('/activity/', ctx.authorization.isPermitted('api:activity:update'), function(req, res) {
+            if (!writePayload.isDocument(req.body)) {
+                return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+                    'Invalid activity payload', 'Expected an object');
+            }
             var data = req.body;
 
             // Validate _id if provided
@@ -115,8 +119,6 @@ function configure(app, wares, ctx) {
                 return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
                     'Invalid _id format', 'Must be 24-character hex string. Got: ' + String(data._id));
             }
-
-            ctx.purifier.purifyObject(data);
 
             ctx.activity.save(data, function(err, created) {
                 if (err) {

--- a/lib/api/devicestatus/index.js
+++ b/lib/api/devicestatus/index.js
@@ -4,6 +4,7 @@ const consts = require('../../constants');
 const moment = require('moment');
 const objectIdValidation = require('../shared/objectid-validation');
 const normalizeDeleteStatus = require('../shared/delete-status');
+const writePayload = require('../shared/write-payload');
 
 /**
  * @typedef {import('express').Application} ExpressApp
@@ -144,23 +145,22 @@ function configure (app, wares, ctx, env) {
      * @param {ExpressResponse} res
      */
     function doPost (req, res) {
-      var statuses = req.body;
-
-      // Normalize to array (NightscoutKit sends arrays)
-      if (!Array.isArray(statuses)) {
-        statuses = [statuses];
+      var normalized = writePayload.normalize(req.body);
+      if (normalized.error === 'size') {
+        return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+          'Too many devicestatus records', 'Maximum records per request: ' + writePayload.MAX_BATCH_ITEMS);
       }
+      if (normalized.error) {
+        return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+          'Invalid devicestatus payload', 'Expected an object or array of objects');
+      }
+      var statuses = normalized.documents;
 
       // Validate _id fields before storage (return 400 on invalid)
       var invalid = objectIdValidation.findInvalidId(statuses);
       if (invalid) {
         return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
           'Invalid _id format', 'Must be 24-character hex string or omit for auto-generation. Got: ' + String(invalid.id));
-      }
-
-      // Purify each devicestatus object
-      for (var i = 0; i < statuses.length; i++) {
-        ctx_authed.purifier.purifyObject(statuses[i]);
       }
 
       ctx_authed.devicestatus.create(statuses, function(err, created) {

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -4,6 +4,7 @@ const moment = require('moment');
 
 const consts = require('../../constants');
 const normalizeDeleteStatus = require('../shared/delete-status');
+const writePayload = require('../shared/write-payload');
 const es = require('event-stream');
 const braces = require('braces');
 const expand = braces.expand;
@@ -270,23 +271,31 @@ function configure (app, wares, ctx, env) {
    */
   // middleware to process "uploads" of sgv data
   function insert_entries (req, res, next) {
-    // list of incoming records
-    var incoming = [];
-    // Potentially a single json encoded body.
-    // This can happen from either an url-encoded or json content-type.
-    if ('date' in req.body) {
-      // add it to the incoming list
-      incoming.push(req.body);
+    var normalized = writePayload.normalize(req.body);
+    if (normalized.error === 'size') {
+      return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+        'Too many entries', 'Maximum records per request: ' + writePayload.MAX_BATCH_ITEMS);
     }
-    // potentially a list of json entries
-    if (req.body.length) {
-      // add them to the list
-      incoming = incoming.concat(req.body);
+    if (normalized.error) {
+      return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+        'Invalid entries payload', 'Expected an object or array of objects');
     }
 
-    for (let i = 0; i < incoming.length; i++) {
-      const e = incoming[i];
-      ctx.purifier.purifyObject(e);
+    var incoming = normalized.documents;
+
+    // Preserve the historical no-op response for a single object without a
+    // date. Arrays continue through the entry pipeline unchanged.
+    if (!Array.isArray(req.body)
+      && !Object.prototype.hasOwnProperty.call(req.body, 'date')) {
+      incoming = [];
+    }
+
+    // Preview does not reach a storage adapter, so retain its sanitized echo.
+    // Persistent writes are purified at the final storage boundary.
+    if (!req.persist_entries) {
+      incoming.forEach(function (entry) {
+        ctx.purifier.purifyObject(entry);
+      });
     }
 
     /**

--- a/lib/api/food/index.js
+++ b/lib/api/food/index.js
@@ -2,6 +2,7 @@
 
 var consts = require('../../constants');
 var objectIdValidation = require('../shared/objectid-validation');
+var writePayload = require('../shared/write-payload');
 
 function configure (app, wares, ctx) {
     var express = require('express'),
@@ -43,27 +44,22 @@ function configure (app, wares, ctx) {
 
       // create new record(s) - supports both single object and array input
       api.post('/food/', ctx.authorization.isPermitted('api:food:create'), function(req, res) {
-        var data = req.body;
-
-        // Normalize to array for consistent handling
-        if (!Array.isArray(data)) {
-            data = [data];
+        var normalized = writePayload.normalize(req.body);
+        if (normalized.error === 'size') {
+          return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+            'Too many food records', 'Maximum records per request: ' + writePayload.MAX_BATCH_ITEMS);
         }
+        if (normalized.error) {
+          return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+            'Invalid food payload', 'Expected an object or array of objects');
+        }
+        var data = normalized.documents;
 
         // Validate _id fields before storage (return 400 on invalid)
         var invalid = objectIdValidation.findInvalidId(data);
         if (invalid) {
             return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
                 'Invalid _id format', 'Must be 24-character hex string or omit for auto-generation. Got: ' + String(invalid.id));
-        }
-
-        // Sanitize free-text fields (name, unit, ...) before storage -
-        // matches treatments/entries/devicestatus/profile REST writes.
-        // Food names are rendered raw in careportal's quickpick UI
-        // (lib/client/boluscalc.js), so unsanitized input here is a
-        // Stored XSS vector.
-        for (var i = 0; i < data.length; i++) {
-          ctx.purifier.purifyObject(data[i]);
         }
 
         ctx.food.create(data, function (err, created) {
@@ -80,22 +76,22 @@ function configure (app, wares, ctx) {
 
       // update record(s) - supports both single object and array input
       api.put('/food/', ctx.authorization.isPermitted('api:food:update'), function(req, res) {
-        var data = req.body;
-
-        // Normalize to array for consistent handling
-        if (!Array.isArray(data)) {
-            data = [data];
+        var normalized = writePayload.normalize(req.body);
+        if (normalized.error === 'size') {
+          return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+            'Too many food records', 'Maximum records per request: ' + writePayload.MAX_BATCH_ITEMS);
         }
+        if (normalized.error) {
+          return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
+            'Invalid food payload', 'Expected an object or array of objects');
+        }
+        var data = normalized.documents;
 
         // Validate _id fields before storage (return 400 on invalid)
         var invalid = objectIdValidation.findInvalidId(data);
         if (invalid) {
             return res.sendJSONStatus(res, consts.HTTP_BAD_REQUEST,
                 'Invalid _id format', 'Must be 24-character hex string. Got: ' + String(invalid.id));
-        }
-
-        for (var i = 0; i < data.length; i++) {
-          ctx.purifier.purifyObject(data[i]);
         }
 
         ctx.food.save(data, function (err, created) {

--- a/lib/api/shared/objectid-validation.js
+++ b/lib/api/shared/objectid-validation.js
@@ -11,10 +11,12 @@ function isValidObjectId(id) {
 }
 
 function findInvalidId(docs) {
-  for (var i = 0; i < docs.length; i++) {
-    if (!isValidObjectId(docs[i]._id)) {
-      return { index: i, id: docs[i]._id };
-    }
+  var invalidIndex = docs.findIndex(function (doc) {
+    return !isValidObjectId(doc._id);
+  });
+
+  if (invalidIndex !== -1) {
+    return { index: invalidIndex, id: docs[invalidIndex]._id };
   }
 
   return null;

--- a/lib/api/shared/write-payload.js
+++ b/lib/api/shared/write-payload.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// Loop backfills are documented to use batches of up to 1,000 records. Keep
+// ten times that capacity for other established clients while bounding the
+// amount of per-request validation and storage work.
+var MAX_BATCH_ITEMS = 10000;
+
+function isDocument (value) {
+  return value !== null
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && !(typeof Buffer !== 'undefined' && Buffer.isBuffer(value));
+}
+
+/**
+ * Accept the legacy single-document and document-array write shapes.
+ *
+ * The size check deliberately happens before inspecting individual items, so
+ * request-controlled arrays cannot cause unbounded validation work.
+ *
+ * @param {*} body parsed request body
+ * @returns {{documents?: Array<object>, error?: string, invalidIndex?: number}}
+ */
+function normalize (body) {
+  if (!Array.isArray(body) && !isDocument(body)) {
+    return {error: 'shape'};
+  }
+
+  var documents = Array.isArray(body) ? body : [body];
+  if (documents.length > MAX_BATCH_ITEMS) {
+    return {error: 'size'};
+  }
+
+  var invalidIndex = documents.findIndex(function (document) {
+    return !isDocument(document);
+  });
+  if (invalidIndex !== -1) {
+    return {error: 'shape', invalidIndex: invalidIndex};
+  }
+
+  return {documents: documents};
+}
+
+module.exports = {
+  MAX_BATCH_ITEMS: MAX_BATCH_ITEMS,
+  isDocument: isDocument,
+  normalize: normalize
+};

--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -7,6 +7,31 @@ var toTextContent = require('../utils/html').toTextContent;
 var client = {};
 var latestProperties = {};
 
+function appendClockFaceParam ($inner, faceParam) {
+  // Clock faces support a fixed set of components and optional sizes from
+  // 0-99. Keep DOM-derived face configuration out of HTML, class lists, and
+  // CSS unless it matches that complete grammar.
+  if (!/^(?:ag|ar|dt|em|nl|sg|tm)[0-9]{0,2}$/.test(faceParam)) {
+    return;
+  }
+
+  let faceClass = faceParam.substr(0, 2);
+  let faceDiv = document.createElement('div');
+  faceDiv.className = faceClass;
+
+  let sizeText = faceParam.substr(2);
+  let size = Number(sizeText);
+  if (sizeText && size > 0) {
+    if (faceClass === 'ar') {
+      faceDiv.style.height = size + 'vmin';
+    } else {
+      faceDiv.style.fontSize = size + 'vmin';
+    }
+  }
+
+  $inner.append(faceDiv);
+}
+
 client.query = function query () {
   var parts = (location.search || '?').substring(1).split('&');
   var token = '';
@@ -76,7 +101,7 @@ client.render = function render () {
   }
 
   //Parse face parameters
-  let face = $inner.data('face').toLowerCase();
+  let face = String($inner.attr('data-face') || '').toLowerCase();
 
   // Backward compatible
   if (face === 'clock-color') {
@@ -86,7 +111,7 @@ client.render = function render () {
   } else if (face === 'bgclock') {
     face = 'b' + (window.serverSettings.settings.showClockLastTime ? 'y' : 'n') + '13-sg35-' + (window.serverSettings.settings.showClockDelta ? 'dt14-' : '') + 'nl-ar25-nl-ag6';
   } else if (face === 'config') {
-    face = $inner.attr('data-face-config');
+    face = String($inner.attr('data-face-config') || '').toLowerCase();
     $inner.empty();
   }
 
@@ -107,8 +132,7 @@ client.render = function render () {
     } else if (!clockCreated) {
       /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
       let faceParam = faceParams[param];
-      let div = '<div class="' + faceParam.substr(0, 2) + '"' + ((faceParam.substr(2, 2) - 0 > 0) ? ' style="' + ((faceParam.substr(0, 2) === 'ar') ? 'height' : 'font-size') + ':' + faceParam.substr(2, 2) + 'vmin"' : '') + '></div>';
-      $inner.append(div);
+      appendClockFaceParam($inner, faceParam);
     }
   }
 

--- a/lib/server/app.js
+++ b/lib/server/app.js
@@ -89,7 +89,7 @@ function create (env, ctx) {
           , includeSubDomains: includeSubDomainsValue
           , preload: preloadValue
         }
-        , frameguard: false
+        , frameguard: { action: 'sameorigin' }
         , contentSecurityPolicy: cspPolicy
       }));
 
@@ -106,6 +106,9 @@ function create (env, ctx) {
           res.status(204).end();
         })
       }
+    } else {
+      // Frame protection is independent of whether HSTS is enabled.
+      app.use(require('helmet').frameguard({ action: 'sameorigin' }));
     }
   } else {
     console.info('Security settings: INSECURE_USE_HTTP=', insecureUseHttp, ', SECURE_HSTS_HEADER=', secureHstsHeader);

--- a/tests/api.shape-handling.test.js
+++ b/tests/api.shape-handling.test.js
@@ -3,6 +3,7 @@
 var request = require('supertest');
 var should = require('should');
 var language = require('../lib/language')();
+var writePayload = require('../lib/api/shared/write-payload');
 
 describe('API Shape Handling - Single Object vs Array Input', function () {
   this.timeout(15000);
@@ -508,6 +509,187 @@ describe('API Shape Handling - Single Object vs Array Input', function () {
           if (err) return done(err);
           res.body.should.be.instanceof(Array);
           done();
+        });
+    });
+  });
+
+  describe('Bounded API write payloads', function () {
+    var scriptPayload = '<script>alert(1)</script>safe';
+    var writeCases = [
+      {
+        name: 'entries POST',
+        method: 'post',
+        path: '/api/entries/',
+        errorMessage: /entries payload/i,
+        tooManyMessage: /Too many entries/i,
+        textField: 'notes',
+        collection: function () { return self.ctx.entries(); },
+        document: function (marker) {
+          var now = Date.now();
+          return {type: 'sgv', sgv: 120, date: now, dateString: new Date(now).toISOString(), testMarker: marker};
+        }
+      },
+      {
+        name: 'devicestatus POST',
+        method: 'post',
+        path: '/api/devicestatus/',
+        errorMessage: /devicestatus payload/i,
+        tooManyMessage: /Too many devicestatus records/i,
+        textField: 'device',
+        collection: function () { return self.ctx.devicestatus(); },
+        document: function (marker) {
+          return {device: 'test-device', created_at: new Date().toISOString(), testMarker: marker};
+        }
+      },
+      {
+        name: 'activity POST',
+        method: 'post',
+        path: '/api/activity/',
+        errorMessage: /activity payload/i,
+        tooManyMessage: /Too many activity records/i,
+        textField: 'activitylevel',
+        collection: function () { return self.ctx.activity(); },
+        document: function (marker) {
+          return {created_at: new Date().toISOString(), steps: 100, activitylevel: 'walking', testMarker: marker};
+        }
+      },
+      {
+        name: 'food POST',
+        method: 'post',
+        path: '/api/food/',
+        errorMessage: /food payload/i,
+        tooManyMessage: /Too many food records/i,
+        textField: 'name',
+        collection: function () { return self.ctx.food(); },
+        document: function (marker) {
+          return {type: 'food', name: 'Test food', carbs: 10, testMarker: marker};
+        }
+      },
+      {
+        name: 'food PUT',
+        method: 'put',
+        path: '/api/food/',
+        errorMessage: /food payload/i,
+        tooManyMessage: /Too many food records/i,
+        textField: 'name',
+        collection: function () { return self.ctx.food(); },
+        document: function (marker) {
+          return {type: 'food', name: 'Test food update', carbs: 12, testMarker: marker};
+        }
+      }
+    ];
+
+    function clearWriteCollections () {
+      return Promise.all([
+        self.ctx.entries().deleteMany({}),
+        self.ctx.devicestatus().deleteMany({}),
+        self.ctx.activity().deleteMany({}),
+        self.ctx.food().deleteMany({})
+      ]);
+    }
+
+    function oversizedPayload () {
+      var documents = [];
+      while (documents.length <= writePayload.MAX_BATCH_ITEMS) {
+        documents.push({});
+      }
+      return documents;
+    }
+
+    beforeEach(clearWriteCollections);
+    afterEach(clearWriteCollections);
+
+    writeCases.forEach(function (writeCase) {
+      it(writeCase.name + ' treats a forged length as a document field', function () {
+        var document = writeCase.document('forged-length-' + Date.now());
+        document.length = writePayload.MAX_BATCH_ITEMS + 1;
+
+        return request(self.app)[writeCase.method](writeCase.path)
+          .set('api-secret', known)
+          .send(document)
+          .expect(200)
+          .then(function (res) {
+            res.body.should.be.instanceof(Array);
+            res.body.length.should.equal(1);
+            res.body[0].length.should.equal(writePayload.MAX_BATCH_ITEMS + 1);
+          });
+      });
+
+      [null, 42].forEach(function (invalidItem) {
+        var itemName = invalidItem === null ? 'null' : 'scalar';
+        it(writeCase.name + ' rejects a ' + itemName + ' array item before writing', function () {
+          var marker = 'invalid-item-' + writeCase.name + '-' + itemName + '-' + Date.now();
+
+          return request(self.app)[writeCase.method](writeCase.path)
+            .set('api-secret', known)
+            .send([writeCase.document(marker), invalidItem])
+            .expect(400)
+            .then(function (res) {
+              res.body.message.should.match(writeCase.errorMessage);
+              return writeCase.collection().findOne({testMarker: marker});
+            })
+            .then(function (stored) {
+              should.not.exist(stored);
+            });
+        });
+      });
+
+      it(writeCase.name + ' rejects batches above the 10,000 item limit', function () {
+        return request(self.app)[writeCase.method](writeCase.path)
+          .set('api-secret', known)
+          .send(oversizedPayload())
+          .expect(400)
+          .then(function (res) {
+            res.body.message.should.match(writeCase.tooManyMessage);
+            res.body.description.should.match(/10000/);
+          });
+      });
+
+      it(writeCase.name + ' remains sanitized at storage', function () {
+        var marker = 'storage-purifier-' + writeCase.name + '-' + Date.now();
+        var document = writeCase.document(marker);
+        document[writeCase.textField] = scriptPayload;
+
+        return request(self.app)[writeCase.method](writeCase.path)
+          .set('api-secret', known)
+          .send(document)
+          .expect(200)
+          .then(function (res) {
+            res.body.should.be.instanceof(Array);
+            res.body[0][writeCase.textField].should.equal('safe');
+            return writeCase.collection().findOne({testMarker: marker});
+          })
+          .then(function (stored) {
+            should.exist(stored);
+            stored[writeCase.textField].should.equal('safe');
+          });
+      });
+    });
+
+    it('entries preview sanitizes without persisting', function () {
+      var marker = 'sanitized-preview-' + Date.now();
+      var now = Date.now();
+      var document = {
+        type: 'sgv',
+        sgv: 125,
+        date: now,
+        dateString: new Date(now).toISOString(),
+        notes: scriptPayload,
+        testMarker: marker
+      };
+
+      return request(self.app)
+        .post('/api/entries/preview')
+        .set('api-secret', known)
+        .send(document)
+        .expect(200)
+        .then(function (res) {
+          res.body.should.be.instanceof(Array);
+          res.body[0].notes.should.equal('safe');
+          return self.ctx.entries().findOne({testMarker: marker});
+        })
+        .then(function (stored) {
+          should.not.exist(stored);
         });
     });
   });

--- a/tests/clock-client.test.js
+++ b/tests/clock-client.test.js
@@ -3,7 +3,7 @@
 var should = require('should');
 var benv = require('./fixtures/benv-loader');
 
-describe('clock client units', function() {
+describe('clock client', function() {
   var $, clockClient;
 
   function setupClockClient(done) {
@@ -83,6 +83,36 @@ describe('clock client units', function() {
 
   beforeEach(setupClockClient);
   afterEach(teardownClockClient);
+
+  it('constructs every supported face component with bounded numeric sizing', function() {
+    $('#inner').attr('data-face', 'bn0-sg40-dt14-nl-ar25-ag6-tm10-em40');
+
+    renderProperties('mg/dl', 'mg/dl', propertiesWithUnits('100', '+5'));
+
+    $('#inner').children().map(function() {
+      return this.className;
+    }).get().should.deepEqual(['sg', 'dt', 'nl', 'ar', 'ag', 'tm', 'em']);
+    $('.sg')[0].style.fontSize.should.equal('40vmin');
+    $('.dt')[0].style.fontSize.should.equal('14vmin');
+    $('.nl')[0].style.fontSize.should.equal('');
+    $('.ar')[0].style.height.should.equal('25vmin');
+  });
+
+  it('does not interpret face configuration as markup, classes, or styles', function() {
+    $('#inner')
+      .attr('data-face', 'config')
+      .attr('data-face-config', 'cy10-sg40-xx99-sg40" onclick="alert(1)-ar25;background:red-<img src=x onerror=alert(1)>-tm10');
+
+    renderProperties('mg/dl', 'mg/dl', propertiesWithUnits('100', '+5'));
+
+    $('#inner').children().map(function() {
+      return this.className;
+    }).get().should.deepEqual(['sg', 'tm']);
+    $('#inner').find('img, script, [onclick], [onerror]').length.should.equal(0);
+    $('.sg')[0].style.fontSize.should.equal('40vmin');
+    $('.tm')[0].style.fontSize.should.equal('10vmin');
+    $('#inner').text().should.not.match(/alert|onerror|onclick/);
+  });
 
   it('should render browser mmol preference when server units are mg/dl', function() {
     renderProperties('mg/dl', 'mmol', propertiesWithUnits(100, '+5'));

--- a/tests/server.security-headers.test.js
+++ b/tests/server.security-headers.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const request = require('supertest');
+const should = require('should');
+
+const createApp = require('../lib/server/app');
+
+function securityApp (options) {
+  options = options || {};
+
+  const settings = require('../lib/settings')();
+  Object.assign(settings, options.settings);
+
+  const env = {
+    name: 'security-header-test'
+    , version: '1.0.0'
+    , insecureUseHttp: false
+    , secureHstsHeader: options.secureHstsHeader !== undefined
+      ? options.secureHstsHeader
+      : true
+    , secureHstsHeaderIncludeSubdomains: false
+    , secureHstsHeaderPreload: false
+    , secureCsp: options.secureCsp || false
+    , secureCspReportOnly: options.secureCspReportOnly || false
+    , settings: settings
+    , static_files: '/static'
+  };
+
+  // A boot error returns before APIs and storage are initialized, while retaining
+  // the security middleware and simple routes needed for these focused tests.
+  return createApp(env, { bootErrors: [{ desc: 'test', err: 'test' }] });
+}
+
+function getRobots (app) {
+  return request(app)
+    .get('/robots.txt')
+    .set('x-forwarded-proto', 'https')
+    .expect(200);
+}
+
+describe('server security headers', function () {
+  it('denies cross-origin framing when CSP is disabled', async function () {
+    const res = await getRobots(securityApp());
+
+    res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+    should.not.exist(res.headers['content-security-policy']);
+    should.not.exist(res.headers['content-security-policy-report-only']);
+  });
+
+  it('keeps frame protection when HSTS is disabled', async function () {
+    const res = await getRobots(securityApp({ secureHstsHeader: false }));
+
+    res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+    should.not.exist(res.headers['strict-transport-security']);
+  });
+
+  it('keeps frame protection when enforcing the configured CSP', async function () {
+    const res = await getRobots(securityApp({
+      secureCsp: true
+      , settings: {
+        frameUrl1: 'https://one.example'
+        , frameUrl2: 'https://two.example'
+      }
+    }));
+
+    res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+    res.headers['content-security-policy'].should.containEql(
+      "frame-ancestors 'self' https://one.example https://two.example"
+    );
+    should.not.exist(res.headers['content-security-policy-report-only']);
+  });
+
+  it('keeps frame protection while CSP is report-only', async function () {
+    const res = await getRobots(securityApp({
+      secureCsp: true
+      , secureCspReportOnly: true
+    }));
+
+    res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+    should.not.exist(res.headers['content-security-policy']);
+    res.headers['content-security-policy-report-only'].should.containEql(
+      "frame-ancestors 'self'"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- validate and bound API write payloads while preserving supported single-record and batch clients
- construct configurable clock elements with safe DOM primitives and enable same-origin framing protection
- run CodeQL for `dev` and `master` pushes and pull requests using current supported actions

## Validation

- full clean-database CI suite: 1,516 passing, 3 pending
- focused affected-area suite: 144 passing
- scoped ESLint: no errors
- workflow syntax and structure checks pass

## Compatibility note

Pages now send same-origin framing protection in normal HTTPS configurations. Deployments that intentionally frame a Nightscout page from a different origin will need a separately designed parent-origin CSP allowlist.