### PR TITLE
Preserve iframe compatibility during frame-protection rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ autonomy for your data:
   * `SECURE_HSTS_HEADER_PRELOAD` (`false`) - ask for preload in browsers for HSTS. Possible values `false`, or `true`.
   * `SECURE_CSP` (`false`) - Add Content Security Policy headers. Possible values `false`, or `true`.
   * `SECURE_CSP_REPORT_ONLY` (`false`) - If set to `true` allows to experiment with policies by monitoring (but not enforcing) their effects. Possible values `false`, or `true`.
+  * `ALLOW_UNRESTRICTED_FRAME_EMBEDDING` (`true`) - Allow other origins to embed this Nightscout site in an iframe. The default `true` preserves compatibility with existing dashboards and split-view installations, but allows clickjacking attacks against users who are already authorized in the embedded browser. Set this to `false` to send `X-Frame-Options: SAMEORIGIN` and an enforced CSP `frame-ancestors 'self'` policy. The default is temporarily `true` for compatibility and is expected to become `false` in a future release. Existing cross-origin embedding installations can set it explicitly to `true` to preserve their intended behavior when that default changes.
 
 ### Views
 
@@ -354,6 +355,8 @@ autonomy for your data:
   Some users will need easy access to multiple Nightscout views at the same time. We have a special view for this case, accessed on /split path on your Nightscout URL. The view supports any number of sites between 1 to 8 way split, where the content for the screen can be loaded from multiple Nightscout instances. Note you still need to host separate instances for each Nightscout being monitored including the one that hosts the split view page - these variables only add the ability to load multiple views into one browser page. To set the URLs from which the content is loaded, set:
   * `FRAME_URL_1` - URL where content is loaded, for the first view (increment the number up to 8 to get more views)
   * `FRAME_NAME_1` - Name for the first split view portion of the screen (increment the number to name more views)
+
+  When `SECURE_CSP=true`, the valid HTTP(S) origins configured in `FRAME_URL_1` through `FRAME_URL_8` are allowed by the CSP `frame-src` directive so the split page can load them. `FRAME_URL_n` controls what the split page may embed; it does not grant another site permission to embed this Nightscout instance. That inbound permission is controlled independently on each instance by `ALLOW_UNRESTRICTED_FRAME_EMBEDDING`. Setting it to `false` on the split-view host does not prevent that host from loading its configured frames, but a cross-origin Nightscout instance displayed inside the split view must allow cross-origin embedding.
 
 ### Plugins
 

--- a/lib/server/app.js
+++ b/lib/server/app.js
@@ -20,6 +20,31 @@ function resolvePath(filePath) {
   return require.resolve(filePath);
 }
 
+function getFrameSources (settings) {
+  const sources = new Set(["'self'"]);
+
+  for (let i = 1; i <= 8; i++) {
+    const value = settings && settings['frameUrl' + i];
+    if (typeof value !== 'string') continue;
+
+    const candidate = value.trim();
+    if (!candidate || /[\s;,*\\]/.test(candidate)) continue;
+
+    try {
+      const frameUrl = new URL(candidate);
+      const isHttp = frameUrl.protocol === 'http:' || frameUrl.protocol === 'https:';
+      const hasCredentials = frameUrl.username || frameUrl.password;
+      if (isHttp && !hasCredentials && frameUrl.origin !== 'null') {
+        sources.add(frameUrl.origin);
+      }
+    } catch (err) {
+      // Relative URLs are already covered by 'self'; malformed URLs fail closed.
+    }
+  }
+
+  return Array.from(sources);
+}
+
 function create (env, ctx) {
   var app = express();
   var appInfo = env.name + ' ' + env.version;
@@ -27,6 +52,55 @@ function create (env, ctx) {
   app.enable('trust proxy'); // Allows req.secure test on heroku https connections.
   var insecureUseHttp = env.insecureUseHttp;
   var secureHstsHeader = env.secureHstsHeader;
+  var allowUnrestrictedFrameEmbedding = env.allowUnrestrictedFrameEmbedding !== false;
+  const helmet = require('helmet');
+  const enableCSP = env.secureCsp ? true : false;
+  const secureCspReportOnly = enableCSP && env.secureCspReportOnly;
+
+  let cspPolicy = false;
+  let enforcedCspPolicy = false;
+
+  if (enableCSP) {
+    if (secureCspReportOnly) {
+      console.info('Enabled SECURE_CSP (Content Security Policy header). Not enforcing. Report only.');
+    } else {
+      console.info('Enabled SECURE_CSP (Content Security Policy header). Enforcing.');
+    }
+
+    const directives = { //TODO make NS work without 'unsafe-inline'
+      defaultSrc: ["'self'"]
+      , styleSrc: ["'self'", 'https://fonts.googleapis.com/', 'https://fonts.gstatic.com/', "'unsafe-inline'"]
+      , scriptSrc: ["'self'", "'unsafe-inline'"]
+      , fontSrc: ["'self'", 'https://fonts.googleapis.com/', 'https://fonts.gstatic.com/', 'data:']
+      , imgSrc: ["'self'", 'data:']
+      , objectSrc: ["'none'"] // Restricts <object>, <embed>, and <applet> elements
+      , reportUri: '/report-violation'
+      , baseUri: ["'none'"] // Restricts use of the <base> tag
+      , formAction: ["'self'"] // Restricts where <form> contents may be submitted
+      , connectSrc: ["'self'", "ws:", "wss:", 'https://fonts.googleapis.com/', 'https://fonts.gstatic.com/']
+      , frameSrc: getFrameSources(env.settings)
+      , frameAncestors: allowUnrestrictedFrameEmbedding ? null : ["'self'"]
+    };
+
+    cspPolicy = {
+      directives: directives
+      , reportOnly: secureCspReportOnly
+    };
+
+    if (!secureCspReportOnly) {
+      enforcedCspPolicy = cspPolicy;
+    }
+  }
+
+  if (!allowUnrestrictedFrameEmbedding && !enforcedCspPolicy) {
+    enforcedCspPolicy = {
+      directives: {
+        defaultSrc: helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc
+        , frameAncestors: ["'self'"]
+      }
+    };
+  }
+
   if (!insecureUseHttp) {
     console.info('Redirecting http traffic to https because INSECURE_USE_HTTP=', insecureUseHttp);
     app.use((req, res, next) => {
@@ -37,50 +111,7 @@ function create (env, ctx) {
       }
     });
     if (secureHstsHeader) { // Add HSTS (HTTP Strict Transport Security) header
-
-      const enableCSP = env.secureCsp ? true : false;
-
-      let cspPolicy = false;
-
-      if (enableCSP) {
-        var secureCspReportOnly = env.secureCspReportOnly;
-        if (secureCspReportOnly) {
-          console.info('Enabled SECURE_CSP (Content Security Policy header). Not enforcing. Report only.');
-        } else {
-          console.info('Enabled SECURE_CSP (Content Security Policy header). Enforcing.');
-        }
-
-        let frameAncestors = ["'self'"];
-
-        for (let i = 0; i <= 8; i++) {
-          let u = env.settings['frameUrl' + i];
-          if (u) {
-            frameAncestors.push(u);
-          }
-        }
-
-        cspPolicy = { //TODO make NS work without 'unsafe-inline'
-          directives: {
-            defaultSrc: ["'self'"]
-            , styleSrc: ["'self'", 'https://fonts.googleapis.com/', 'https://fonts.gstatic.com/', "'unsafe-inline'"]
-            , scriptSrc: ["'self'", "'unsafe-inline'"]
-            , fontSrc: ["'self'", 'https://fonts.googleapis.com/', 'https://fonts.gstatic.com/', 'data:']
-            , imgSrc: ["'self'", 'data:']
-            , objectSrc: ["'none'"] // Restricts <object>, <embed>, and <applet> elements
-            , reportUri: '/report-violation'
-            , baseUri: ["'none'"] // Restricts use of the <base> tag
-            , formAction: ["'self'"] // Restricts where <form> contents may be submitted
-            , connectSrc: ["'self'", "ws:", "wss:", 'https://fonts.googleapis.com/', 'https://fonts.gstatic.com/']
-            , frameSrc: ["'self'"]
-            , frameAncestors: frameAncestors
-          }
-          , reportOnly: secureCspReportOnly
-        };
-      }
-
-
       console.info('Enabled SECURE_HSTS_HEADER (HTTP Strict Transport Security)');
-      const helmet = require('helmet');
       var includeSubDomainsValue = env.secureHstsHeaderIncludeSubdomains;
       var preloadValue = env.secureHstsHeaderPreload;
       app.use(helmet({
@@ -89,29 +120,41 @@ function create (env, ctx) {
           , includeSubDomains: includeSubDomainsValue
           , preload: preloadValue
         }
-        , frameguard: { action: 'sameorigin' }
-        , contentSecurityPolicy: cspPolicy
+        , frameguard: allowUnrestrictedFrameEmbedding ? false : { action: 'sameorigin' }
+        , contentSecurityPolicy: enforcedCspPolicy
       }));
-
-      if (enableCSP) {
-
-        app.use(helmet.referrerPolicy({ policy: 'no-referrer' }));
-        app.use(bodyParser.json({ type: ['json', 'application/csp-report'] }));
-        app.post('/report-violation', (req, res) => {
-          if (req.body) {
-            console.log('CSP Violation: ', req.body);
-          } else {
-            console.log('CSP Violation: No data received!');
-          }
-          res.status(204).end();
-        })
-      }
     } else {
-      // Frame protection is independent of whether HSTS is enabled.
-      app.use(require('helmet').frameguard({ action: 'sameorigin' }));
+      if (!allowUnrestrictedFrameEmbedding) {
+        app.use(helmet.frameguard({ action: 'sameorigin' }));
+      }
+      if (enforcedCspPolicy) {
+        app.use(helmet.contentSecurityPolicy(enforcedCspPolicy));
+      }
     }
   } else {
     console.info('Security settings: INSECURE_USE_HTTP=', insecureUseHttp, ', SECURE_HSTS_HEADER=', secureHstsHeader);
+    if (!allowUnrestrictedFrameEmbedding) {
+      app.use(helmet.frameguard({ action: 'sameorigin' }));
+    }
+    if (enforcedCspPolicy) {
+      app.use(helmet.contentSecurityPolicy(enforcedCspPolicy));
+    }
+  }
+
+  if (enableCSP) {
+    if (secureCspReportOnly) {
+      app.use(helmet.contentSecurityPolicy(cspPolicy));
+    }
+    app.use(helmet.referrerPolicy({ policy: 'no-referrer' }));
+    app.use(bodyParser.json({ type: ['json', 'application/csp-report'] }));
+    app.post('/report-violation', (req, res) => {
+      if (req.body) {
+        console.log('CSP Violation: ', req.body);
+      } else {
+        console.log('CSP Violation: No data received!');
+      }
+      res.status(204).end();
+    })
   }
 
   app.set('view engine', 'ejs');

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -81,6 +81,8 @@ function setSSL () {
   env.secureHstsHeaderPreload = readENVTruthy("SECURE_HSTS_HEADER_PRELOAD", false);
   env.secureCsp = readENVTruthy("SECURE_CSP", false);
   env.secureCspReportOnly = readENVTruthy("SECURE_CSP_REPORT_ONLY", false);
+  // Transitional compatibility default; switch to false in a future release.
+  env.allowUnrestrictedFrameEmbedding = readENVTruthy("ALLOW_UNRESTRICTED_FRAME_EMBEDDING", true);
 
   // UUID handling for specific client patterns that send UUID as _id field
   // When true (default): UUID _id values are extracted to 'identifier' field, server generates ObjectId

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -144,6 +144,34 @@ describe('env', function () {
     env.secureHstsHeader.should.be.true();
   });
 
+  it( 'allows unrestricted frame embedding by default and supports opting out', function () {
+    var originalValue = process.env.ALLOW_UNRESTRICTED_FRAME_EMBEDDING;
+
+    try {
+      delete process.env.ALLOW_UNRESTRICTED_FRAME_EMBEDDING;
+      var env = require( '../lib/server/env' )();
+      env.allowUnrestrictedFrameEmbedding.should.be.true();
+
+      process.env.ALLOW_UNRESTRICTED_FRAME_EMBEDDING = 'false';
+      env = require( '../lib/server/env' )();
+      env.allowUnrestrictedFrameEmbedding.should.be.false();
+
+      process.env.ALLOW_UNRESTRICTED_FRAME_EMBEDDING = 'true';
+      env = require( '../lib/server/env' )();
+      env.allowUnrestrictedFrameEmbedding.should.be.true();
+
+      process.env.ALLOW_UNRESTRICTED_FRAME_EMBEDDING = 'invalid';
+      env = require( '../lib/server/env' )();
+      env.allowUnrestrictedFrameEmbedding.should.be.true();
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env.ALLOW_UNRESTRICTED_FRAME_EMBEDDING;
+      } else {
+        process.env.ALLOW_UNRESTRICTED_FRAME_EMBEDDING = originalValue;
+      }
+    }
+  });
+
   describe('HOSTNAME', function () {
     var originalHostname;
     var originalNightscoutHostname;

--- a/tests/server.security-headers.test.js
+++ b/tests/server.security-headers.test.js
@@ -14,7 +14,9 @@ function securityApp (options) {
   const env = {
     name: 'security-header-test'
     , version: '1.0.0'
-    , insecureUseHttp: false
+    , insecureUseHttp: options.insecureUseHttp !== undefined
+      ? options.insecureUseHttp
+      : false
     , secureHstsHeader: options.secureHstsHeader !== undefined
       ? options.secureHstsHeader
       : true
@@ -22,6 +24,9 @@ function securityApp (options) {
     , secureHstsHeaderPreload: false
     , secureCsp: options.secureCsp || false
     , secureCspReportOnly: options.secureCspReportOnly || false
+    , allowUnrestrictedFrameEmbedding: options.allowUnrestrictedFrameEmbedding !== undefined
+      ? options.allowUnrestrictedFrameEmbedding
+      : true
     , settings: settings
     , static_files: '/static'
   };
@@ -38,48 +43,160 @@ function getRobots (app) {
     .expect(200);
 }
 
+function getRobotsOverHttp (app) {
+  return request(app)
+    .get('/robots.txt')
+    .expect(200);
+}
+
+function shouldHaveSameOriginFrameProtection (res) {
+  res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+  res.headers['content-security-policy'].should.containEql("frame-ancestors 'self'");
+}
+
 describe('server security headers', function () {
-  it('denies cross-origin framing when CSP is disabled', async function () {
+  it('preserves unrestricted cross-origin embedding by default', async function () {
     const res = await getRobots(securityApp());
 
-    res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+    should.not.exist(res.headers['x-frame-options']);
     should.not.exist(res.headers['content-security-policy']);
+    should.not.exist(res.headers['content-security-policy-report-only']);
+    res.headers['strict-transport-security'].should.containEql('max-age=31536000');
+  });
+
+  it('enforces same-origin framing when unrestricted embedding is disabled', async function () {
+    const res = await getRobots(securityApp({
+      allowUnrestrictedFrameEmbedding: false
+    }));
+
+    shouldHaveSameOriginFrameProtection(res);
+    res.headers['content-security-policy'].should.equal("frame-ancestors 'self'");
     should.not.exist(res.headers['content-security-policy-report-only']);
   });
 
   it('keeps frame protection when HSTS is disabled', async function () {
-    const res = await getRobots(securityApp({ secureHstsHeader: false }));
+    const res = await getRobots(securityApp({
+      allowUnrestrictedFrameEmbedding: false
+      , secureHstsHeader: false
+    }));
 
-    res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+    shouldHaveSameOriginFrameProtection(res);
+    res.headers['content-security-policy'].should.equal("frame-ancestors 'self'");
     should.not.exist(res.headers['strict-transport-security']);
   });
 
-  it('keeps frame protection when enforcing the configured CSP', async function () {
+  it('keeps frame protection while insecure HTTP is allowed', async function () {
+    const res = await getRobotsOverHttp(securityApp({
+      allowUnrestrictedFrameEmbedding: false
+      , insecureUseHttp: true
+    }));
+
+    shouldHaveSameOriginFrameProtection(res);
+    res.headers['content-security-policy'].should.equal("frame-ancestors 'self'");
+    should.not.exist(res.headers['strict-transport-security']);
+  });
+
+  it('keeps unrestricted embedding while insecure HTTP is allowed', async function () {
+    const res = await getRobotsOverHttp(securityApp({ insecureUseHttp: true }));
+
+    should.not.exist(res.headers['x-frame-options']);
+    should.not.exist(res.headers['content-security-policy']);
+    should.not.exist(res.headers['content-security-policy-report-only']);
+    should.not.exist(res.headers['strict-transport-security']);
+  });
+
+  it('allows configured split-view origins under an enforced CSP', async function () {
     const res = await getRobots(securityApp({
       secureCsp: true
       , settings: {
-        frameUrl1: 'https://one.example'
-        , frameUrl2: 'https://two.example'
+        frameUrl1: 'https://one.example/clock?token=secret'
+        , frameUrl2: 'https://two.example:8443/view#clock'
+        , frameUrl3: 'https://one.example/another-view'
+        , frameUrl4: '/clock/color'
+        , frameUrl5: 'javascript:alert(1)'
+        , frameUrl6: 'https://good.example;frame-src *'
+        , frameUrl7: 'https://good.example@evil.example/clock'
+        , frameUrl8: 'https://good.example,https://evil.example'
       }
     }));
 
-    res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+    should.not.exist(res.headers['x-frame-options']);
     res.headers['content-security-policy'].should.containEql(
-      "frame-ancestors 'self' https://one.example https://two.example"
+      "frame-src 'self' https://one.example https://two.example:8443"
+    );
+    res.headers['content-security-policy'].should.not.containEql('frame-ancestors');
+    res.headers['content-security-policy'].should.not.containEql('token=secret');
+    res.headers['content-security-policy'].should.not.containEql('javascript:');
+    res.headers['content-security-policy'].should.not.containEql('good.example');
+    res.headers['content-security-policy'].should.not.containEql('evil.example');
+    res.headers['content-security-policy'].split('https://one.example').length.should.equal(2);
+    should.not.exist(res.headers['content-security-policy-report-only']);
+  });
+
+  it('adds same-origin protection to an enforced full CSP', async function () {
+    const res = await getRobots(securityApp({
+      allowUnrestrictedFrameEmbedding: false
+      , secureCsp: true
+      , settings: {
+        frameUrl1: 'https://one.example/clock'
+      }
+    }));
+
+    shouldHaveSameOriginFrameProtection(res);
+    res.headers['content-security-policy'].should.containEql(
+      "frame-src 'self' https://one.example"
     );
     should.not.exist(res.headers['content-security-policy-report-only']);
   });
 
-  it('keeps frame protection while CSP is report-only', async function () {
+  it('keeps the full CSP report-only while enforcing same-origin framing', async function () {
+    const res = await getRobots(securityApp({
+      allowUnrestrictedFrameEmbedding: false
+      , secureCsp: true
+      , secureCspReportOnly: true
+      , settings: {
+        frameUrl1: 'https://one.example/clock'
+      }
+    }));
+
+    shouldHaveSameOriginFrameProtection(res);
+    res.headers['content-security-policy'].should.equal("frame-ancestors 'self'");
+    res.headers['content-security-policy-report-only'].should.containEql(
+      "frame-src 'self' https://one.example"
+    );
+  });
+
+  it('does not report ancestor violations in unrestricted report-only mode', async function () {
     const res = await getRobots(securityApp({
       secureCsp: true
       , secureCspReportOnly: true
+      , settings: {
+        frameUrl1: 'https://one.example/clock'
+      }
     }));
 
-    res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+    should.not.exist(res.headers['x-frame-options']);
     should.not.exist(res.headers['content-security-policy']);
     res.headers['content-security-policy-report-only'].should.containEql(
-      "frame-ancestors 'self'"
+      "frame-src 'self' https://one.example"
     );
+    res.headers['content-security-policy-report-only'].should.not.containEql('frame-ancestors');
+  });
+
+  it('applies the full CSP independently of HSTS', async function () {
+    const res = await getRobots(securityApp({
+      secureCsp: true
+      , secureHstsHeader: false
+      , settings: {
+        frameUrl1: 'https://one.example/clock'
+      }
+    }));
+
+    should.not.exist(res.headers['x-frame-options']);
+    res.headers['content-security-policy'].should.containEql(
+      "frame-src 'self' https://one.example"
+    );
+    res.headers['content-security-policy'].should.not.containEql('frame-ancestors');
+    should.not.exist(res.headers['strict-transport-security']);
   });
 });


### PR DESCRIPTION
## Summary

- add ALLOW_UNRESTRICTED_FRAME_EMBEDDING with a temporary default of true so existing cross-origin iframe and split-view deployments continue to work
- allow administrators to opt into X-Frame-Options: SAMEORIGIN plus enforced CSP frame-ancestors self protection by setting the option to false
- place validated FRAME_URL_1 through FRAME_URL_8 origins in CSP frame-src, which controls what the Nightscout split page may load
- apply CSP independently from the HSTS and HTTP transport settings

## Rollout and security note

This is a compatibility follow-up to #8592. The default of true intentionally preserves unrestricted framing and therefore retains clickjacking exposure for authorized users during the transition. It may leave GHAS alert #65 open; this PR does not disguise or dismiss that accepted transitional risk. A later release should change the default to false. Deployments that intentionally require cross-origin embedding should set the option explicitly to true before that change.

## Validation

- full clean-database CI suite: 1,523 passing, 3 pending
- focused environment and security-header suite: 34 passing
- scoped ESLint: no errors
- git diff check: clean
- independent final review: no blocking findings