### PR TITLE
Upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/close-accidental-sync-prs.yml
+++ b/.github/workflows/close-accidental-sync-prs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-close sync PRs from forks
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: CI test and publish Docker image
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -18,19 +21,16 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
         mongodb-version: [4.4, 5.0, 6.0]
-    env:
-      # Temporary: Allow Node 20 until branch protection rules are updated
-      # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
 
       - name: Start MongoDB ${{ matrix.mongodb-version }}
         uses: supercharge/mongodb-github-action@1.3.0
@@ -43,6 +43,26 @@ jobs:
         run: npm run-script test-ci
       - name: Send Coverage
         run: npm run-script coverage
+
+  docker-build-pr:
+    name: Validate Docker image
+    needs: test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build Docker image without publishing
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64
+          tags: nightscout/cgm-remote-monitor:pr-${{ github.event.pull_request.number }}
 
   docker-build:
     name: Build Docker image (${{ matrix.arch }})
@@ -63,15 +83,15 @@ jobs:
       DOCKER_IMAGE: nightscout/cgm-remote-monitor
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
       - name: Clean git Checkout
         if: success()
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Prepare Docker tags
         id: docker-tags
         shell: bash
@@ -85,7 +105,7 @@ jobs:
             echo "latest_tag=${DOCKER_IMAGE}:latest-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
           fi
       - name: Build, tag and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -104,14 +124,14 @@ jobs:
       DOCKER_IMAGE: nightscout/cgm-remote-monitor
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
       - name: Clean git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Prepare Docker manifest tags
         id: docker-tags
         shell: bash


### PR DESCRIPTION
## Summary

- migrate checkout, setup-node, Docker, and github-script actions to Node 24-compatible releases
- remove the temporary insecure Node runtime opt-out while retaining the Node 20/22/24 application test matrix
- keep dependency caching disabled explicitly and limit the workflow token to read-only repository contents
- add a credential-free, non-publishing Docker build for pull requests

## Validation

- workflow YAML parsing passed
- actionlint v1.7.12 passed
- verified each upgraded JavaScript action declares the Node 24 runtime
- independently reviewed action inputs and Docker publishing compatibility