### PR TITLE
Restore legacy report test quarantine

### DIFF
--- a/docs/proposals/testing-modernization-proposal.md
+++ b/docs/proposals/testing-modernization-proposal.md
@@ -1,7 +1,7 @@
 # Testing & Architecture Modernization Proposal
 
-**Document Version:** 1.2
-**Last Updated:** May 2026
+**Document Version:** 1.5
+**Last Updated:** September 2026
 **Status:** Tracks 1+2 substantially complete; Track 3 pending
 **Authors:** Nightscout Development Team
 
@@ -54,7 +54,7 @@ The following context informed the revised strategy:
 | `profileeditor.test.js` | Skip/Defer | Complex UI mocking, low ROI |
 | `pluginbase.test.js` | Skip/Defer | Review after logic extraction |
 | `admintools.test.js` | Skip/Defer | UI code may be rewritten |
-| `reports.test.js` | **Retain** | Bundle renderer is covered in modern jsdom; stats may later move to a server API |
+| `reports.test.js` | **Skip/Replace** | Full-bundle jsdom coverage is brittle and low-fidelity; retain manual checks while extracting report statistics behind a DOM-free boundary |
 | `adminnotifies.test.js` | Skip/Defer | Low priority |
 
 ### Architectural Problem: Bundle Conflation
@@ -407,10 +407,11 @@ Note: `benv` removed; direct jsdom usage with secure harness.
     `tests/profileeditor.records.test.js` plus 44 Node-only tests
     under `tests/client-core/profile-editor-*.test.js`
     (Phase 5b, commit `55968ff3`).
-  - `reports.test.js` — restored under the modern jsdom harness in
-    September 2026. It complements `tests/bundle.smoke.test.js`
-    (wiring) and `docs/test-specs/manual-smoke-checklist.md` (visual
-    browser verification). See `docs/test-specs/coverage-gaps.md`.
+  - `reports.test.js` — retained as intentionally skipped. The bundle smoke
+    test covers only public entry-point wiring, while
+    `docs/test-specs/manual-smoke-checklist.md` provides the current release
+    check. Deterministic report-statistics unit or contract coverage remains
+    open and should land with the planned extraction or API.
 
 ### Track 2 (Logic/DOM Separation)
 - [x] `lib/client-core/` established with extracted modules
@@ -584,11 +585,10 @@ profile-editor failure under `USE_BENV_SHIM=1`: jsdom 24 returns `null`
 where jsdom 11 returned `""` for some absent attribute, surfacing as a
 `Cannot read properties of null` deep inside the minified bundle's jQuery
 click handler chain. The decision to retire the profile-editor bundle test
-rather than bisect it was vindicated. The reports suite was later restored by
-giving each test a fresh jsdom window and evaluating the bundle in that
-window. Together these are lived examples of the broader principle:
-**testing through a minified bundle in a polyfilled DOM is brittle to silent
-host-environment drift**, and that brittleness compounds with every
+and quarantine the report bundle test rather than shape the shim around their
+quirks was vindicated. This is lived experience that backs the broader
+principle: **testing through a minified bundle in a polyfilled DOM is brittle
+to silent host-environment drift**, and that brittleness compounds with every
 dependency upgrade.
 
 **Implication for the Playwright proposal:** real-browser E2E avoids the
@@ -596,22 +596,26 @@ polyfill-drift class entirely. The trade-off (slower, harder to debug)
 is the right one for the small set of workflows where bundle-level
 wiring matters and per-module pure tests cannot reach.
 
-### L6. Layered coverage limits bundle-driven integration tests
+### L6. Layered coverage makes remaining gaps explicit
 
-Phase 5c established a layered coverage shape for bundle-heavy UI behavior.
-The profile-editor bundle test remains retired, while `reports.test.js` was
-restored in September 2026 after its harness was made deterministic:
+Phase 5c established a layered coverage shape for bundle-heavy UI behavior:
 
-1. **Pure logic** → Node-only `tests/client-core/*` suites (~70 ms).
+1. **Extracted pure logic** → Node-only `tests/client-core/*` suites.
 2. **Bundle wiring** → `tests/bundle.smoke.test.js` (asserts
    `window.Nightscout.{client,reportclient,profileclient,units}`).
-3. **Automated report rendering** → `tests/reports.test.js` under jsdom.
-4. **Visual browser behavior** → `docs/test-specs/manual-smoke-checklist.md`.
+3. **Real-browser behavior** →
+   `docs/test-specs/manual-smoke-checklist.md`.
 
-The unautomated layer (4) is where a future Playwright suite belongs —
-and only there. This bounding is the right way to size any browser-E2E
-investment: a small enumerated workflow set, not a sprawling
-"replace all UI tests" effort.
+For profile editing, substantial business logic has moved into the first
+layer. For reports, that work is not complete: statistics remain coupled to
+the legacy client bundle and do not yet have comprehensive DOM-free tests.
+The bundle smoke test must not be treated as calculation or rendering
+coverage.
+
+A future statistics API or pure-logic extraction should add deterministic
+unit and contract tests. If automated browser coverage is later justified,
+keep it to a small set of high-value workflows after the UI direction is
+settled.
 
 ### L7. Bundler hygiene problems surface during modernization
 
@@ -631,12 +635,15 @@ This is a follow-up worth a sweep: any test file with N tests and a
 
 ### L9. Statistics API has become a precondition for Track 3
 
-Although `reports.test.js` is active again, report statistics are still
-calculated in the legacy client bundle. The statistics-API design (currently
-a proposal in `rag-nightscout-ecosystem-alignment/docs/sdqctl-proposals/
-statistics-api-proposal.md`) remains a precondition for a new UI shell so it
-does not re-implement that client-side path. Track 3 framework discovery
-should not start until the stats-API contract exists.
+The quarantined report-rendering suite does not have a one-for-one automated
+replacement. Report preferences and selected output-safety paths are covered,
+but report statistics remain calculated in the legacy client bundle without
+comprehensive deterministic tests.
+
+The statistics API should define a reproducible contract and test boundary
+before a new UI shell is asked to reproduce those calculations. Track 3
+framework discovery should not commit to a report implementation until that
+contract exists.
 
 ---
 
@@ -649,4 +656,4 @@ should not start until the stats-API contract exists.
 | May 2026 | 1.2 | Added Lessons Learned section (L1–L9) capturing empirical findings from Phases 0–5e: captured-fixture library leverage, domain corpus principle, jsdom-free production tree, render-path inertia, jsdom semantic drift, three-legged-stool pattern, bundler hygiene, boot-amortization, statistics-API as Track 3 precondition. |
 | May 2026 | 1.3 | Phase 5f: extracted OpenAPS pill math to `lib/client-core/devicestatus/openaps.js`; closes the last devicestatus pure-logic gap. Pill-output goldens (aaps/loop/trio/phone-uploader) byte-identical pre/post — extraction verified end-to-end. |
 | May 2026 | 1.4 | Phase 5g: Trio (oref1) captured-fixture coverage hardened. Sanitizer extended to time-shift inner `openaps.{enacted,suggested,iob,mmtune}` timestamps so the `recent` window stays meaningful against the time-anchored fixture; added `DS_KEY_BY_LABEL` diverse-slice for devicestatus. Trio fixtures regenerated from a Trio-only Nightscout source (every record carries `enacted.received=true`), exercising the previously-untested oref1 enacted-selection branches. Plugin-wiring tests added for `loop` and `pump` plugins (mirrors the existing `openaps` wiring test) — all four extracted modules now have explicit delegation contracts. |
-| Sep 2026 | 1.5 | Restored `reports.test.js` under the modern jsdom harness and updated the layered coverage guidance. |
+| Sep 2026 | 1.5 | Reinstated the intentional quarantine of the legacy reports jsdom suite; clarified current structural/manual coverage and the outstanding deterministic report-statistics gap. |

--- a/docs/test-specs/coverage-gaps.md
+++ b/docs/test-specs/coverage-gaps.md
@@ -6,17 +6,6 @@ This document aggregates coverage gaps from all test specifications to provide a
 
 ---
 
-## Recently Closed (September 2026)
-
-- **Report rendering end-to-end coverage** — `tests/reports.test.js` is active
-  again under the modern jsdom harness. Its two scenarios render the standard
-  reports and the week-to-week view from fixture data and assert representative
-  output from the report plugins. `tests/bundle.smoke.test.js` retains the
-  faster structural bundle check, and `manual-smoke-checklist.md` remains the
-  release check for behavior that requires a real browser and visual review.
-
----
-
 ## Recently Closed (Phase 5c, May 2026)
 
 - **Loop devicestatus pill math** — extracted to
@@ -108,6 +97,7 @@ These gaps represent functional coverage that should be addressed after high pri
 | Shape Handling | Cross-API consistency (v1 vs v3 storage) | `shape-handling-tests.md` | Cross-read verification tests |
 | Authorization | Subject CRUD operations | `authorization-tests.md` | Add API tests for admin endpoints |
 | Authorization | Role Management | `authorization-tests.md` | Test role creation and permission assignment |
+| Reports | Deterministic report-statistics and browser-rendering coverage | `testing-modernization-proposal.md` | Extract calculations behind DOM-free modules or API contracts; add unit/contract tests and retain manual browser smoke checks meanwhile |
 
 ---
 
@@ -150,14 +140,28 @@ When addressing a gap:
 
 ---
 
-## Track 1 / Phase 4 — `reports.test.js` restored (2026-09)
+## Open — report statistics and browser rendering
 
-The report-rendering suite was temporarily skipped in May 2026 while the
-legacy benv/jsdom-11 dependency was removed. Subsequent modern-harness work
-made the original scenarios reliable under jsdom 24, so the suite is enabled
-again. It now covers the standard multi-plugin report output and week-to-week
-rendering on every full test run. The manual report checklist is retained for
-visual behavior that jsdom cannot verify.
+`tests/reports.test.js` remains intentionally skipped. It loads the complete
+webpack bundle into jsdom, replaces browser and data-loading behavior with
+mocks, and asserts generated markup. That harness has been brittle across
+jsdom versions and does not provide enough browser fidelity to justify
+maintaining it as a release gate.
+
+Current automated coverage is narrower:
+
+- `tests/bundle.smoke.test.js` checks that the built bundle executes and
+  exposes the expected Nightscout entry points.
+- `tests/reportstorage.test.js` checks report-preference persistence.
+- `tests/stored-output-sinks.test.js` and `tests/profile-sinks.test.js`
+  exercise selected report output-safety paths.
+
+These tests do not comprehensively validate report calculations or
+end-to-end browser behavior. Until report statistics are extracted into
+DOM-free modules or exposed through a reproducible server API, use section 3
+of `manual-smoke-checklist.md` before releases and report-related changes.
+Add deterministic unit or contract tests as calculations are extracted;
+evaluate a small real-browser suite only after the UI direction is settled.
 
 ---
 

--- a/docs/test-specs/manual-smoke-checklist.md
+++ b/docs/test-specs/manual-smoke-checklist.md
@@ -1,23 +1,23 @@
 # Manual smoke checklist (Nightscout UI)
 
-This checklist supplements automated browser coverage with checks that need
-a real human and browser. Automated coverage now includes:
+This checklist covers browser behavior that automated tests do not currently
+exercise end-to-end. Current automated coverage includes:
 
-1. `tests/reports.test.js` boots the bundle in modern jsdom, renders standard
-   and week-to-week reports from fixture data, and checks representative
-   plugin output.
-2. `tests/bundle.smoke.test.js` provides a faster structural check that the
-   bundle exposes `Nightscout.client`, `.reportclient`, `.profileclient`, and
-   `.units`.
-3. Node-only suites under `tests/client-core/` cover extracted pure logic such
-   as record/profile/range CRUD, treatment normalization, and confirm-text
-   generation. The legacy `tests/profileeditor.test.js` browser suite remains
-   retired while that functionality is covered by these focused tests and
-   this checklist.
+1. `tests/bundle.smoke.test.js`, a structural check that the built bundle
+   executes and exposes `Nightscout.client`, `.reportclient`, `.profileclient`,
+   and `.units`.
+2. `tests/reportstorage.test.js`, which covers persisted report preferences,
+   plus selected output-safety checks in `tests/stored-output-sinks.test.js`
+   and `tests/profile-sinks.test.js`.
+3. Node-only suites under `tests/client-core/`, which cover already-extracted
+   business logic.
 
-What is not covered automatically is a real human eyeballing the chart,
-clicking around the profile editor, and submitting a report. Run this
-checklist before tagging a release or merging a UI-touching PR.
+The legacy full-bundle report suite remains intentionally skipped, and the
+profile-editor suite remains retired, because their jsdom-based assertions
+were brittle and did not faithfully represent a real browser. Report
+calculations are not yet comprehensively covered by deterministic DOM-free
+tests. Run this checklist before tagging a release or merging a UI- or
+report-related change.
 
 ## Setup
 
@@ -87,16 +87,17 @@ your equivalent) before `node lib/server/server.js`.
 
 ## When this checklist fails
 
-If a step fails, the regression is in adapter glue (jQuery, ajax,
-`bundle.app.js` wiring), not in the pure core. Check:
+A failure may be in data loading, report calculations, bundle wiring, or
+browser rendering. Record the selected date range and inspect:
 
-- `tests/bundle.smoke.test.js` — does the bundle still expose the
-  expected globals?
-- `tests/client-core/careportal-*.test.js` — do the pure transforms
-  still produce the expected output? (If they do, the bug is in
-  `lib/client/careportal.js` or `lib/profile/profileeditor.js`.)
-- Browser DevTools network tab — is the page hitting `/api/v1/...`
-  with the right payloads?
+- Browser DevTools console and network tabs.
+- `tests/bundle.smoke.test.js` for bundle entry-point failures.
+- `tests/reportstorage.test.js` for preference persistence.
+- Relevant `tests/client-core/` suites for already-extracted logic.
+
+Because report calculations are not yet comprehensively covered outside the
+legacy client bundle, add a focused unit or contract test when affected logic
+is extracted.
 
 See `docs/proposals/testing-modernization-proposal.md` for the full
 test pyramid layout and Track 2 rationale.

--- a/tests/bundle.smoke.test.js
+++ b/tests/bundle.smoke.test.js
@@ -1,11 +1,13 @@
 'use strict';
 
-// Phase 5c — bundle smoke test.
+// Phase 5c — structural bundle smoke test.
 //
-// This complements tests/reports.test.js: that suite exercises report
-// rendering with fixture data, while this one gives a fast, structural
-// signal that webpack produced a bundle exposing Nightscout.client,
-// .reportclient, and .profileclient without throwing on first execute.
+// This checks that webpack produced a bundle which executes and exposes
+// Nightscout.client, .reportclient, .profileclient, and .units. It does not
+// render report workflows or validate report statistics. Browser-level report
+// behavior is currently covered by the manual smoke checklist; calculations
+// should gain DOM-free unit or contract tests as they are extracted from the
+// legacy client bundle.
 //
 // This suite skips cleanly when the build artifact is missing so it
 // does not break a fresh checkout that has not yet run `npm install`

--- a/tests/fixtures/benv-shim.js
+++ b/tests/fixtures/benv-shim.js
@@ -18,10 +18,8 @@
  *   The legacy `benv` package was removed after the Phase 1 parity work.
  *
  * Notes:
- *   - Webpack browser bundles are evaluated in the active jsdom window. This
- *     lets each fresh DOM receive its own `window.Nightscout` and jQuery
- *     bindings without depending on Node's CommonJS cache.
- *   - Ordinary CommonJS fixture modules are loaded with cache-busted require.
+ *   - Browser modules are reloaded through Node's CommonJS loader after
+ *     wiring the active jsdom window onto the Node global object.
  *   - All existing call sites pass absolute paths via `__dirname + '...'`,
  *     so we drop benv's deprecated `module.parent.filename` resolution magic.
  */
@@ -66,17 +64,15 @@ function setGlobal (name, value) {
 }
 
 function setup (callback, options) {
-  // Every setup owns a fresh window. Some legacy callers use teardown(false),
-  // and reusing that window would retain the previously evaluated bundle and
-  // jQuery state when a later browser suite starts.
+  // Each setup owns a fresh window so callers cannot inherit DOM or global
+  // state left behind by another browser-oriented suite.
   if (activeEnv) {
     activeEnv.cleanup();
     activeEnv = null;
   }
 
   const html = (options && options.html) || '<!DOCTYPE html><html><body></body></html>';
-  const domOptions = Object.assign({ runScripts: 'outside-only' }, options || {});
-  activeEnv = createSecureDOM(html, domOptions);
+  activeEnv = createSecureDOM(html, options);
 
   setGlobal('window', activeEnv.window);
   DOM_GLOBALS.forEach(function (name) {
@@ -126,15 +122,10 @@ function shimRequire (filename /*, globalVarName */) {
   if (!fs.existsSync(filename)) {
     throw new Error('benv-shim.require: file not found: ' + filename);
   }
-  let result;
-  if (/^bundle\.(?:app|clock)\.js$/.test(path.basename(filename))) {
-    result = activeEnv.window.eval(fs.readFileSync(filename, 'utf8'));
-  } else {
-    // Bust Node's CommonJS cache so fixture modules are evaluated for the
-    // current test state.
-    delete require.cache[filename];
-    result = require(filename);
-  }
+  // Bust Node's CommonJS cache so each setup() can re-evaluate browser
+  // modules against the (potentially fresh) jsdom window.
+  delete require.cache[filename];
+  const result = require(filename);
 
   // Webpack UMD bundles attach `$`, `jQuery`, etc. to `window` at module
   // load. The previous benv (and its `rewire` execution wrapper) used to

--- a/tests/reports.test.js
+++ b/tests/reports.test.js
@@ -320,23 +320,12 @@ var exampleProfile = [
 exampleProfile[0].startDate.setSeconds(0);
 exampleProfile[0].startDate.setMilliseconds(0);
 
-function runImmediateReportTimers (win) {
-  var nativeSetTimeout = win.setTimeout.bind(win);
-  win.setTimeout = function reportSetTimeout (callback, delay) {
-    // reportclient deliberately defers rendering with an explicit zero delay.
-    // Keep other timers asynchronous so jQuery's scheduler cannot recurse.
-    if (delay === 0 && typeof callback === 'function') {
-      callback();
-      return 0;
-    }
-    return nativeSetTimeout.apply(win, arguments);
-  };
-}
-
-
-// Keep the end-to-end report renderer covered under the modern jsdom harness.
-// This suite previously had a temporary describe.skip while benv was removed.
-describe('reports', function ( ) {
+// Intentionally quarantined: this legacy suite drives the full webpack bundle
+// through a heavily mocked jsdom environment that does not faithfully represent
+// a browser. Bundle wiring remains covered by bundle.smoke.test.js; report
+// behavior is covered by the manual smoke checklist until report statistics can
+// be tested independently of the DOM.
+describe.skip('reports', function ( ) {
   var headless = require('./fixtures/headless')(benv, this);
   this.timeout(80000);
 
@@ -362,7 +351,7 @@ describe('reports', function ( ) {
   });
 
   afterEach(function (done) {
-    benv.teardown(true);
+    headless.teardown( );
     done( );
   });
 
@@ -385,7 +374,10 @@ describe('reports', function ( ) {
        return true;
      };
 
-     runImmediateReportTimers(window);
+     window.setTimeout = function mockSetTimeout (call, timer) {
+       if (timer == 60000) return;
+       call();
+     };
 
      window.Nightscout.reportclient();
 
@@ -455,7 +447,10 @@ describe('reports', function ( ) {
        return true;
      };
 
-     runImmediateReportTimers(window);
+     window.setTimeout = function mockSetTimeout (call, timer) {
+      if (timer == 60000) return;
+      call();
+     };
 
      window.Nightscout.reportclient();
 


### PR DESCRIPTION
## Summary

- return the full-bundle reports suite to its intentional quarantine
- remove the report-specific `window.eval` path and forced jsdom script-execution mode
- retain fresh-window isolation for the remaining browser-oriented tests
- preserve the manual release checklist and document the outstanding DOM-free report-statistics coverage gap
- keep every production/security fix from #8594 unchanged

## Rationale

The reports suite uses a heavily mocked jsdom/full-bundle path that is brittle and does not faithfully represent real-browser behavior. #8594 re-enabled it while responding to an automated review comment, but that conflicted with the established testing-modernization direction. This correction keeps the useful structural bundle smoke test and manual checks without treating the legacy report suite as a release gate.

Production remains jsdom-free, and this PR does not change dependencies or production code.

## Validation

- all 9 GitHub Node 20/22/24 × MongoDB 4.4/5/6 test jobs pass
- CodeQL passes
- the non-publishing Docker validation build passes
- `npm run bundle` passes locally
- focused browser/shim regression set: 30 passing, 2 expected pending
- changed JavaScript: ESLint 0 errors (2 existing dynamic fixture-path warnings)
- `npm ls jsdom --omit=dev` remains empty
