### PR TITLE
Fix npm 12 deployment failure for nightscout-connect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,25 @@ jobs:
       - name: Send Coverage
         run: npm run-script coverage
 
+  npm12-build:
+    name: Validate npm 12 install and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Use Node.js 24
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - name: Use npm 12
+        run: npm install --global npm@12
+      - name: Install dependencies and build production bundle
+        run: npm ci
+
   docker-build-pr:
     name: Validate Docker image
     needs: test

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 legacy-peer-deps=true
 engine-strict=false
+# npm 12 requires opting in to the nightscout-connect tarball declared in package.json.
+allow-remote=root


### PR DESCRIPTION
Heroku can select npm 12 through the current `engines.npm` range. npm 12 blocks remote tarball dependencies by default, causing the `nightscout-connect` GitHub release download to fail with `EALLOWREMOTE` before Nightscout can build.

Set `allow-remote=root` in the project `.npmrc` so npm permits URL dependencies explicitly declared in `package.json`. This preserves the existing connector version and lockfile while removing the need for the temporary `NPM_CONFIG_ALLOW_REMOTE=root` Heroku config variable after this fix is released.

Add a focused Node 24 / npm 12 CI job that performs `npm ci`, including the production webpack build and key generation. The existing Node matrix uses bundled npm versions and does not explicitly exercise npm 12.

Validation:
- Reproduced the original failure on released master with Node 24.20.0 and npm 12.0.2.
- On this branch, a clean `npm ci --no-audit --no-fund` with those versions and a fresh cache passed, including production bundles and key generation, without an environment override.
- Workflow YAML parsing and `git diff --check` passed.
- Local macOS validation reported webpack size warnings and a blocked optional `fsevents` install script; the build completed successfully. An actual Heroku deployment has not been tested.

Fixes #8600.
