### PR TITLE
Fix Daily Stats estimated A1c across glucose display units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to cgm-remote-monitor are documented in this file.
 
 ### Fixed
 
+- **Daily Stats estimated A1c:** Calculate both estimates from the original
+  mg/dL readings, correcting inflated results in mg/dL mode. A mean glucose of
+  150 mg/dL now displays 6.9% (DCCT) and 51 mmol/mol (IFCC). Switching glucose
+  display units gives the same estimates; mmol/L results can change slightly
+  because the calculation no longer uses rounded display values.
 - **Reports (#8588):** Closely spaced CGM readings no longer cause later valid
   readings to be discarded in a chain. The one-minute filter now compares each
   reading with the last retained reading. Regenerating reports from the same

--- a/docs/test-specs/manual-smoke-checklist.md
+++ b/docs/test-specs/manual-smoke-checklist.md
@@ -14,8 +14,8 @@ exercise end-to-end. Current automated coverage includes:
    timing jitter, duplicates and input preservation.
 4. `tests/report-sgv-pipeline.test.js`, which drives the report's Show action
    with newest-first API fixtures and checks retained chart data, Daily Stats
-   reading counts and range percentages in mg/dL and mmol/L. It uses the real
-   loading, filtering, unit conversion and table renderer; network responses
+   reading counts, range percentages and estimated A1c in mg/dL and mmol/L. It
+   uses the real loading, filtering, unit conversion and table renderer; network responses
    and canvas drawing are mocked, so it does not replace browser smoke checks.
 5. Node-only suites under `tests/client-core/`, which cover already-extracted
    business logic.
@@ -94,10 +94,25 @@ fixtures so cached historical data is loaded again.
       removed and **2 readings** remain. At **0s / 60s / 120s**, all **3 readings**
       remain, confirming the cutoff includes exactly one minute.
 - [ ] With readings at **0s / 300s / 600s**, all **3 readings** remain and the
-      chart and statistics match the same five-minute fixture before the fix.
+      chart, reading count and range percentages match the same five-minute
+      fixture before the filtering fix.
 
 These checks validate filtering and the resulting sample-based percentages;
 they do not change the target-band rules or introduce time-weighted statistics.
+
+### Daily Stats estimated A1c
+
+Use the same local test instance and select a day containing only the synthetic
+readings. Reload Reports after changing fixtures or display units.
+
+- [ ] With a single **150 mg/dL** reading, Daily Stats shows an average of
+      **150.0 mg/dL**, estimated A1c **6.9% DCCT** and **51 mmol/mol IFCC**.
+- [ ] Switch to mmol/L display. The average shows **8.3 mmol/L**, while the A1c
+      estimates remain **6.9%** and **51**. They are calculated from the original
+      mg/dL reading, before glucose is rounded for display.
+- [ ] Repeat with **100 and 200 mg/dL** readings five minutes apart. Both unit
+      modes show **2 readings** and the same **6.9% / 51** A1c estimates, using
+      the mean glucose rather than averaging rounded A1c values per reading.
 
 ## 4. Care portal (treatment entry)
 

--- a/docs/test-specs/manual-smoke-checklist.md
+++ b/docs/test-specs/manual-smoke-checklist.md
@@ -14,9 +14,11 @@ exercise end-to-end. Current automated coverage includes:
    timing jitter, duplicates and input preservation.
 4. `tests/report-sgv-pipeline.test.js`, which drives the report's Show action
    with newest-first API fixtures and checks retained chart data, Daily Stats
-   reading counts, range percentages and estimated A1c in mg/dL and mmol/L. It
-   uses the real loading, filtering, unit conversion and table renderer; network responses
-   and canvas drawing are mocked, so it does not replace browser smoke checks.
+   reading counts, range percentages and estimated A1c in mg/dL and mmol/L.
+   Multi-day fixtures cover separate daily averages, empty days and repeated
+   rendering from cached data. These tests use the real loading, filtering,
+   unit conversion and table renderer; network responses and canvas drawing
+   are mocked, so they do not replace browser smoke checks.
 5. Node-only suites under `tests/client-core/`, which cover already-extracted
    business logic.
 

--- a/lib/report_plugins/dailystats.js
+++ b/lib/report_plugins/dailystats.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var consts = require('../constants');
-
 var dailystats = {
   name: 'dailystats'
   , label: 'Daily Stats'
@@ -45,7 +43,7 @@ dailystats.report = function report_dailystats (datastorage, sorteddaystoshow, o
 
   var todo = [];
   var report = $('#dailystats-report');
-  var minForDay, maxForDay, sum;
+  var minForDay, maxForDay, sum, sumMgdl;
 
   report.empty();
   var table = $('<table class="centeraligned">');
@@ -84,6 +82,7 @@ dailystats.report = function report_dailystats (datastorage, sorteddaystoshow, o
     minForDay = daysRecords[0].sgv;
     maxForDay = daysRecords[0].sgv;
     sum = 0;
+    sumMgdl = 0;
 
     var stats = daysRecords.reduce(function(out, record) {
       record.sgv = parseFloat(record.sgv);
@@ -101,6 +100,7 @@ dailystats.report = function report_dailystats (datastorage, sorteddaystoshow, o
         maxForDay = record.sgv;
       }
       sum += record.sgv;
+      sumMgdl += record.bgValue;
       return out;
     }, {
       lows: 0
@@ -108,8 +108,10 @@ dailystats.report = function report_dailystats (datastorage, sorteddaystoshow, o
       , highs: 0
     });
     var average = sum / daysRecords.length;
-    var averageA1cDCCT = (average * consts.MMOL_TO_MGDL + 46.7) / 28.7;
-    var averageA1cIFCC = ((average * consts.MMOL_TO_MGDL + 46.7) / 28.7 - 2.15) * 10.929;
+    // bgValue retains the original mg/dL reading; sgv is rounded in display units.
+    var averageMgdl = sumMgdl / daysRecords.length;
+    var averageA1cDCCT = (averageMgdl + 46.7) / 28.7;
+    var averageA1cIFCC = (averageA1cDCCT - 2.15) * 10.929;
 
     var bgValues = daysRecords.map(function(r) { return r.sgv; });
     $('<td><div id="dailystat-chart-' + day.toString() + '" class="inlinepiechart"></div></td>').appendTo(tr);

--- a/tests/report-sgv-pipeline.test.js
+++ b/tests/report-sgv-pipeline.test.js
@@ -57,8 +57,7 @@ describe('report SGV loading and Daily Stats', function () {
     });
   });
 
-  function renderReport (offsets, units) {
-    const values = [100, 50, 200];
+  function renderReport (offsets, units, values = [100, 50, 200]) {
     // The API returns newest first. Freeze it to catch accidental in-place sorting.
     const entries = Object.freeze(offsets.map(function (seconds, index) {
       return Object.freeze({
@@ -152,7 +151,19 @@ describe('report SGV loading and Daily Stats', function () {
         assert.deepEqual([result.table.Low, result.table.Normal, result.table.High], fixture.bands);
         assert.deepEqual(result.pie.map(band => band.label), ['Low', 'In Range', 'High']);
         assert.deepEqual(result.pie.map(band => band.data), fixture.pie);
+        assert.equal(result.table['A1c est* %DCCT'], fixture.name === 'dense' ? '6.9%' : '5.7%');
+        assert.equal(result.table['A1c est* IFCC'], fixture.name === 'dense' ? '51' : '39');
       });
+    });
+
+    it('calculates estimated A1c before rounding glucose for display (' + units + ')', async function () {
+      // 150 mg/dL displays as 8.3 mmol/L. Converting that rounded display value
+      // back to mg/dL would incorrectly round the A1c estimate down to 6.8%.
+      const result = await renderReport([0], units, [150]);
+      assert.equal(result.table.Readings, '1');
+      assert.equal(result.table.Average, units === 'mg/dl' ? '150.0' : '8.3');
+      assert.equal(result.table['A1c est* %DCCT'], '6.9%');
+      assert.equal(result.table['A1c est* IFCC'], '51');
     });
   });
 });

--- a/tests/report-sgv-pipeline.test.js
+++ b/tests/report-sgv-pipeline.test.js
@@ -7,6 +7,7 @@ const domGlobals = require('./fixtures/dom-globals');
 
 const DAY = '2025-02-03'; // Monday, selected by the fixture's weekday filter.
 const BASE = Date.UTC(2025, 1, 3);
+const DAY_SECONDS = 24 * 60 * 60;
 const DOM_GLOBALS = ['window', 'document', 'navigator', '$', 'jQuery'];
 
 function clearReportModules () {
@@ -36,8 +37,11 @@ describe('report SGV loading and Daily Stats', function () {
       '<input id="rp_from"><input id="rp_to">' +
       '<input id="rp_targetlow"><input id="rp_targethigh">' +
       '<input id="rp_linear" type="radio"><input id="wrp_linear" type="radio">' +
+      '<input id="rp_oldestontop" type="radio" checked>' +
       '<input id="rp_enabledate" type="checkbox" checked>' +
-      '<input id="rp_mo" type="checkbox" checked><div id="info"></div>' +
+      '<input id="rp_mo" type="checkbox" checked>' +
+      '<input id="rp_tu" type="checkbox" checked>' +
+      '<input id="rp_we" type="checkbox" checked><div id="info"></div>' +
       '</body></html>'
     );
     state = domGlobals.installDomGlobals(env);
@@ -57,7 +61,7 @@ describe('report SGV loading and Daily Stats', function () {
     });
   });
 
-  function renderReport (offsets, units, values = [100, 50, 200]) {
+  function renderReport (offsets, units, values = [100, 50, 200], endDay = DAY) {
     // The API returns newest first. Freeze it to catch accidental in-place sorting.
     const entries = Object.freeze(offsets.map(function (seconds, index) {
       return Object.freeze({
@@ -65,15 +69,31 @@ describe('report SGV loading and Daily Stats', function () {
       });
     }).reverse());
     let entriesRequests = 0;
-    let pie;
+    let pies;
+    let resolveRender;
+    let rejectRender;
+
+    function show () {
+      return new Promise(function (resolve, reject) {
+        resolveRender = resolve;
+        rejectRender = reject;
+        pies = {};
+        $('#rp_show').trigger('click');
+      });
+    }
+
     // Exercise the real loading, filtering, unit conversion and table renderer;
     // only network responses and canvas drawing are replaced.
     $.ajax = function (url, options) {
       let response = [];
       if (url.startsWith('/api/v1/entries.json?')) {
         entriesRequests++;
-        assert.ok(url.includes('find[date][$gte]=' + BASE));
-        response = entries;
+        const query = new URL(url, 'http://localhost').searchParams;
+        const from = Number(query.get('find[date][$gte]'));
+        const to = Number(query.get('find[date][$lt]'));
+        assert.ok(from >= BASE && from <= moment.utc(endDay).valueOf());
+        assert.equal(to - from, DAY_SECONDS * 1000);
+        response = Object.freeze(entries.filter(entry => entry.date >= from && entry.date < to));
       } else {
         assert.ok(['/api/v1/food/regular.json', '/api/v1/treatments.json', '/api/v1/profiles']
           .some(function (path) { return url.startsWith(path); }), 'Unexpected request: ' + url);
@@ -82,8 +102,8 @@ describe('report SGV loading and Daily Stats', function () {
       return $.Deferred().resolve(response).promise();
     };
     $.plot = function (selector, series) {
-      assert.equal(selector, '#dailystat-chart-' + DAY);
-      pie = series;
+      assert.ok(selector.startsWith('#dailystat-chart-'));
+      pies[selector.slice('#dailystat-chart-'.length)] = series;
     };
 
     const ctx = { moment: moment, settings: { units: units }, language: { translate: value => value } };
@@ -99,39 +119,46 @@ describe('report SGV loading and Daily Stats', function () {
       ddata: { processDurations: treatments => treatments }
     };
 
-    return new Promise(function (resolve, reject) {
-      env.window.addEventListener('error', function (event) {
-        event.preventDefault();
-        reject(event.error || new Error(event.message));
-      });
-      env.window.Nightscout = {
-        client: client,
-        report_plugins_preinit: function (context) {
-          const plugins = require('../lib/report_plugins')(context);
-          const daily = plugins('dailystats');
-          // Keep the real plugin registry/HTML setup, rendering just Daily Stats.
-          plugins.eachPlugin = function (callback) {
-            callback(Object.assign({}, daily, {
-              report: function (storage, days, options) {
-                daily.report(storage, days, options);
-                const headers = $('#dailystats-report th').map((_, cell) => $(cell).text()).get();
-                const cells = $('#dailystats-report tr').eq(1).children();
-                resolve({
-                  data: storage[DAY],
-                  table: Object.fromEntries(headers.map((name, index) => [name, cells.eq(index).text()])),
-                  pie: pie,
-                  entriesRequests: entriesRequests
-                });
-              }
-            }));
-          };
-          return plugins;
-        }
-      };
-      require('../lib/report/reportclient')();
-      $('#rp_from, #rp_to').val(DAY);
-      $('#rp_show').trigger('click');
+    env.window.addEventListener('error', function (event) {
+      event.preventDefault();
+      rejectRender(event.error || new Error(event.message));
     });
+    env.window.Nightscout = {
+      client: client,
+      report_plugins_preinit: function (context) {
+        const plugins = require('../lib/report_plugins')(context);
+        const daily = plugins('dailystats');
+        // Keep the real plugin registry/HTML setup, rendering just Daily Stats.
+        plugins.eachPlugin = function (callback) {
+          callback(Object.assign({}, daily, {
+            report: function (storage, days, options) {
+              daily.report(storage, days, options);
+              const headers = $('#dailystats-report th').map((_, cell) => $(cell).text()).get();
+              const rows = $('#dailystats-report tr').get().slice(1).map(function (row) {
+                return $(row).children().map((_, cell) => $(cell).text()).get();
+              });
+              resolveRender({
+                data: storage[DAY],
+                table: Object.fromEntries(headers.map((name, index) => [name, rows[0][index]])),
+                pie: pies[DAY],
+                rows: rows,
+                days: days.slice(),
+                pies: pies,
+                // Snapshot cached records so a later render cannot alter the first result.
+                stats: days.map(day => storage[day].statsrecords.map(record => Object.assign({}, record))),
+                entriesRequests: entriesRequests,
+                showAgain: show
+              });
+            }
+          }));
+        };
+        return plugins;
+      }
+    };
+    require('../lib/report/reportclient')();
+    $('#rp_from').val(DAY);
+    $('#rp_to').val(endDay);
+    return show();
   }
 
   ['mg/dl', 'mmol'].forEach(function (units) {
@@ -164,6 +191,37 @@ describe('report SGV loading and Daily Stats', function () {
       assert.equal(result.table.Average, units === 'mg/dl' ? '150.0' : '8.3');
       assert.equal(result.table['A1c est* %DCCT'], '6.9%');
       assert.equal(result.table['A1c est* IFCC'], '51');
+    });
+
+    it('keeps daily A1c totals separate across an empty day and cached re-renders (' + units + ')', async function () {
+      // Different sample counts and means expose sums or denominators leaking
+      // between days: Monday averages 150 mg/dL, Wednesday averages 300 mg/dL.
+      const result = await renderReport(
+        [0, 300, 2 * DAY_SECONDS, 2 * DAY_SECONDS + 300, 2 * DAY_SECONDS + 600],
+        units, [100, 200, 200, 300, 400], '2025-02-05'
+      );
+      assert.equal(result.entriesRequests, 3);
+      assert.deepEqual(result.days, [DAY, '2025-02-04', '2025-02-05']);
+      assert.equal(result.rows.length, 3);
+      assert.equal(result.rows[0][5], '2');
+      assert.equal(result.rows[2][5], '3');
+      assert.equal(result.rows[0][8], units === 'mg/dl' ? '150.0' : '8.3');
+      assert.equal(result.rows[2][8], units === 'mg/dl' ? '300.0' : '16.7');
+      assert.deepEqual(result.rows[0].slice(13), ['6.9%', '51']);
+      assert.deepEqual(result.rows[2].slice(13), ['12.1%', '109']);
+      // The empty day has a date and message, with no numeric statistics or pie.
+      assert.equal(result.rows[1].length, 3);
+      assert.equal(result.rows[1][2], 'No data available');
+      assert.deepEqual(Object.keys(result.pies), [DAY, '2025-02-05']);
+      assert.deepEqual(result.stats.map(records => records.map(record => record.bgValue)),
+        [[100, 200], [], [200, 300, 400]]);
+
+      const repeated = await result.showAgain();
+      assert.equal(repeated.entriesRequests, 3, 'Historical CGM data should be reused from the report cache');
+      assert.deepEqual(repeated.days, result.days);
+      assert.deepEqual(repeated.rows, result.rows);
+      assert.deepEqual(repeated.pies, result.pies);
+      assert.deepEqual(repeated.stats, result.stats);
     });
   });
 });


### PR DESCRIPTION
Daily Stats applies the mmol/L conversion to its average even when glucose is already displayed in mg/dL. A mean of 150 mg/dL therefore renders an estimated A1c of 95.8%.

Calculate both estimated-A1c columns from the mean of `statsrecords.bgValue`, which retains the original mg/dL readings. This also avoids differences caused by rounding glucose for mmol/L display. A mean of 150 mg/dL now renders 6.9% DCCT and 51 mmol/mol IFCC in either display mode. The existing equations and output precision are retained ([NGSP glucose/A1c unit reference](https://ngsp.org/ifccngsp.asp)).

Follow-up to #8588. Extends its report-pipeline tests to assert both A1c columns for dense and five-minute data, plus a single-reading case that exposes display-rounding drift. Additional three-day fixtures, in both display modes, check separate daily averages with different sample counts, an empty middle day, and a second Show action using cached data. Repeated rendering must preserve the table, pie charts and cached readings without refetching historical CGM data. Updates the changelog and browser smoke checklist.

Validation:
- [GitHub Actions](https://github.com/nightscout/cgm-remote-monitor/actions/runs/33964912762) at `ec3da7df`: all nine Node 20/22/24 × MongoDB 4.4/5/6 combinations, npm 12 build, Docker validation and CodeQL pass. The inspected job reports 1,565 passing tests, three existing pending tests and 283 passing client-core tests.
- All eight report-pipeline cases pass locally; 46 focused report, output-safety and bundle tests pass, plus 283 client-core tests. Both sets were run with `TZ=UTC`.
- Regression sensitivity: both added cases fail if daily mg/dL totals carry between days, the empty-day guard is removed, or repeated rendering appends duplicate tables. All temporary mutations were restored before committing.
- Before the production fix, five of the original six pipeline cases fail on `dev`, including `95.8%` versus `6.9%` and mmol/L rounding differences.
- Changed test file passes ESLint; `git diff --check` passes.
- Production webpack bundle builds successfully. Browser smoke with the built bundle and synthetic data confirms a 150 mg/dL reading displays 6.9% DCCT and 51 mmol/mol IFCC in both glucose display modes.
