### PR TITLE
Match HTTP fixture requests to their address family

### DIFF
--- a/docs/test-specs/http-fixture-addresses.md
+++ b/docs/test-specs/http-fixture-addresses.md
@@ -1,0 +1,25 @@
+# HTTP fixture address families
+
+Supertest starts unbound fixture servers with listen(0), but its serverAddress
+implementation constructs an IPv4 loopback URL regardless of the bound family.
+An IPv6 wildcard listener and a separate IPv4 listener can own the same port.
+A local deterministic probe bound both and showed a request intended for the
+IPv6 fixture returning the IPv4 fixture's 405 response instead.
+
+The root test hooks now install an idempotent, test-only Supertest adapter:
+when the server is bound to IPv6 wildcard (::), use [::1] in the generated URL.
+Explicitly bound IPv4 fixtures retain their URLs. API fixture factories also
+choose their loopback address from the bound server family rather than relying
+on localhost address selection. Production listeners and request code do not
+change. The adapter wraps Supertest's serverAddress method, so its regression
+test must accompany future Supertest upgrades.
+
+`tests/supertest-loopback.test.js` places two servers on the same numeric port,
+then verifies two consecutive requests reach only the intended IPv6 fixture.
+It also verifies explicit IPv4 handling. Both cases pass on Node 22.23.2 and
+24.20.0. The full backend and hosted suites are required before integration.
+
+This proves a cause of wrong-fixture HTTP responses, consistent with earlier
+local 401/405 and socket-hang-up anomalies. It does not prove that every earlier
+failure had this cause, and it does not address the separate intercepted
+Firefox report-request stall.

--- a/tests/fixtures/api/instance.js
+++ b/tests/fixtures/api/instance.js
@@ -73,7 +73,8 @@ function configure () {
           instance.server = transport.createServer(instance.env.ssl || { }, instance.app).listen(0);
           instance.env.PORT = instance.server.address().port;
 
-          instance.baseUrl = `${useHttps ? 'https' : 'http'}://${instance.env.HOSTNAME}:${instance.env.PORT}`;
+          const loopback = instance.server.address().family === 'IPv6' ? '[::1]' : '127.0.0.1';
+          instance.baseUrl = `${useHttps ? 'https' : 'http'}://${loopback}:${instance.env.PORT}`;
 
           console.log(`Started ${useHttps ? 'SSL' : 'HTTP'} instance on ${instance.baseUrl}`);
           hasBooted = true;

--- a/tests/fixtures/api3/instance.js
+++ b/tests/fixtures/api3/instance.js
@@ -137,7 +137,8 @@ function configure () {
           instance.server = transport.createServer(instance.env.ssl || { }, instance.app).listen(0);
           instance.env.PORT = instance.server.address().port;
 
-          instance.baseUrl = `${useHttps ? 'https' : 'http'}://${instance.env.HOSTNAME}:${instance.env.PORT}`;
+          const loopback = instance.server.address().family === 'IPv6' ? '[::1]' : '127.0.0.1';
+          instance.baseUrl = `${useHttps ? 'https' : 'http'}://${loopback}:${instance.env.PORT}`;
 
           self.addSecuredOperations(instance);
           instance.cacheMonitor = new CacheMonitor(instance).listen();

--- a/tests/hooks.js
+++ b/tests/hooks.js
@@ -1,5 +1,7 @@
 'use strict;'
 
+require('./lib/supertest-loopback');
+
 var testHelpers = require('./lib/test-helpers');
 var productionSafety = require('./lib/production-safety');
 

--- a/tests/lib/supertest-loopback.js
+++ b/tests/lib/supertest-loopback.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// Supertest binds an unspecified address but always requests IPv4 loopback.
+// An IPv6 listener can share a port with an unrelated IPv4 listener. Match the
+// URL to the fixture's family rather than sending the request to that listener.
+const {Test} = require('supertest');
+const installed = Symbol.for('nightscout.supertest.loopback');
+if (!Test.prototype[installed]) {
+  const serverAddress = Test.prototype.serverAddress;
+  Test.prototype.serverAddress = function (app, path) {
+    const target = serverAddress.call(this, app, path);
+    const address = app.address();
+    if (address && address.family === 'IPv6' && address.address === '::') {
+      const url = new URL(target);
+      url.hostname = '[::1]';
+      return url.href;
+    }
+    return target;
+  };
+  Object.defineProperty(Test.prototype, installed, {value: true});
+}

--- a/tests/supertest-loopback.test.js
+++ b/tests/supertest-loopback.test.js
@@ -1,0 +1,35 @@
+'use strict';
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const {once} = require('node:events');
+require('./lib/supertest-loopback');
+const request = require('supertest');
+
+describe('Supertest fixture address family', function () {
+  it('reaches the intended IPv6 fixture when IPv4 has the same port', async function () {
+    let wrongRequests = 0;
+    const other = http.createServer((req, res) => {wrongRequests++; res.statusCode = 405; res.end('wrong fixture');});
+    const intended = http.createServer((req, res) => res.end('intended fixture'));
+    try {
+      other.listen(0, '127.0.0.1'); await once(other, 'listening');
+      intended.listen({port: other.address().port, host: '::', ipv6Only: true});
+      await once(intended, 'listening');
+      for (let cycle = 0; cycle < 2; cycle++) {
+        const response = await request(intended).get('/').expect(200);
+        assert.equal(response.text, 'intended fixture');
+      }
+      assert.equal(wrongRequests, 0);
+    } finally {
+      await Promise.all([other, intended].map(server => new Promise(resolve => server.close(resolve))));
+    }
+  });
+  it('retains IPv4 URLs for explicitly bound IPv4 fixtures', async function () {
+    const server = http.createServer((req, res) => res.end('ipv4'));
+    try {
+      server.listen(0, '127.0.0.1'); await once(server, 'listening');
+      const test = request(server).get('/');
+      assert.equal(new URL(test.url).hostname, '127.0.0.1');
+      assert.equal((await test.expect(200)).text, 'ipv4');
+    } finally {await new Promise(resolve => server.close(resolve));}
+  });
+});


### PR DESCRIPTION
Make test requests use the loopback address family of their fixture server. Supertest currently starts an unspecified-address listener but builds an IPv4 URL. With IPv4 and IPv6 fixtures on the same numeric port, this can send a request to the wrong server; a deterministic local probe returned the other fixture's 405 response.

Install an idempotent adapter through the root test hooks for IPv6 wildcard listeners, and make both API fixture factories construct matching URLs. Production networking is unchanged. Two regression tests cover consecutive same-port IPv6 requests and explicit IPv4 handling; both pass on Node 22.23.2 and 24.20.0. Lint passes. Full backend validation is running, and hosted/integration checks remain required.

This addresses a proven wrong-fixture routing mechanism consistent with the local HTTP anomalies during modernization; it does not prove every previous socket failure had this cause and does not fix the separate Firefox interception stall. The adapter's dependency on Supertest.serverAddress is documented in docs/test-specs/http-fixture-addresses.md.

Targets chore/nightscout-modernization as a validation prerequisite for the pending cleanup children. #8605 remains draft into dev.
