### PR TITLE
perf: retain only acknowledgement fields in notification receipts

### DIFF
--- a/docs/test-specs/notification-receipt-payload.md
+++ b/docs/test-specs/notification-receipt-payload.md
@@ -1,0 +1,24 @@
+# Notification receipt payload
+
+Pushover receipt acknowledgements need only level, group and eventName.
+The actual settings snooze selector reads eventName/level; notifications.ack
+receives level/group. Cache those fields instead of cloning the complete
+notification, including message data and plugin objects/functions.
+
+The send payload is unchanged. node-cache still clones the receipt snapshot
+and preserves its one-hour TTL, periodic cleanup, get/delete and cancellation
+behavior. This slice does not introduce eviction of outstanding receipts,
+change notification deduplication, or remove node-cache. Broader bounded-cache
+and maintained-library decisions remain open under M25.
+
+Seven focused cache tests pass on Node 22.23.2 and 24.20.0. Six also pass on
+the previous implementation; the retained-field assertion fails there. Tests
+cover high/low urgent/warning and plugin snooze selection using real settings,
+mutation after sending, repeated acknowledgement, receipt expiry twice,
+send-success TTL extension, failure retry suppression and cancellation retry.
+
+The retention improvement is structural: message/plugin/extra fields are
+absent from cached receipts. No whole-server RAM reduction is claimed without
+representative measurements. Full backend and hosted gates remain required.
+No persisted data, UI or configuration changes. Rollback restores the former
+full-notification receipt value; receipt caches are process-local and expire.

--- a/lib/server/pushnotify.js
+++ b/lib/server/pushnotify.js
@@ -103,7 +103,11 @@ function init (env, ctx) {
           if (result.receipt) {
             //if this was an emergency alarm, also hold on to the receipt/notify mapping, for later acking
             console.info('storing pushover receipt', result.receipt, notify);
-            receipts.set(result.receipt, notify);
+            // Acknowledgement/snooze selection needs only these fields. Avoid
+            // cloning and retaining message data and the entire plugin graph.
+            receipts.set(result.receipt, {
+              level: notify.level, group: notify.group, eventName: notify.eventName
+            });
           }
         }
       });

--- a/tests/pushnotify-cache.test.js
+++ b/tests/pushnotify-cache.test.js
@@ -53,6 +53,10 @@ describe('push notification deduplication cache', function () {
     assert.strictEqual(receipt.level, payload.level);
     assert.strictEqual(receipt.group, payload.group);
     assert.strictEqual(receipt.eventName, payload.eventName);
+    assert.deepStrictEqual(Object.keys(receipt).sort(), ['eventName', 'group', 'level']);
+    payload.level = levels.URGENT;
+    payload.group = 'changed-after-send';
+    payload.eventName = 'changed-after-send';
     push.emitNotification(notification());
     assert.strictEqual(sent.length, 1);
     assert.strictEqual(push.pushoverAck({receipt: 'fixture-receipt'}), true);
@@ -124,6 +128,34 @@ describe('push notification deduplication cache', function () {
       assert.strictEqual(cancellations, cycle * 2);
       now += 900001;
     }
+  });
+
+  it('preserves actual snooze selection for high, low and plugin alarms', function () {
+    const settings = require('../lib/server/env')().settings;
+    Object.assign(settings, {alarmHigh: true, alarmLow: true, alarmUrgentHigh: true, alarmUrgentLow: true,
+      alarmHighMins: [11], alarmLowMins: [13], alarmUrgentHighMins: [17], alarmUrgentLowMins: [19],
+      alarmWarnMins: [23], alarmUrgentMins: [29]});
+    env.settings = settings;
+    const push = initialize(env, ctx, caches);
+    for (const [eventName, level, minutes] of [['high', levels.WARN, 11], ['low', levels.WARN, 13],
+      ['high', levels.URGENT, 17], ['low', levels.URGENT, 19], ['fixture', levels.WARN, 23], ['fixture', levels.URGENT, 29]]) {
+      const payload = Object.assign(notification(), {eventName, level, notifyhash: eventName + level});
+      push.emitNotification(payload);
+      payload.eventName = 'mutated';
+      assert.strictEqual(push.pushoverAck({receipt: 'fixture-receipt'}), true);
+      assert.deepStrictEqual(acknowledgements.pop(), [level, 'fixture-group', minutes * 60000, true]);
+    }
+  });
+
+  it('expires receipt acknowledgements after an hour over two cycles', function () {
+    const push = initialize(env, ctx, caches);
+    for (let cycle = 0; cycle < 2; cycle++) {
+      push.emitNotification(notification());
+      now += 3600001;
+      assert.strictEqual(push.pushoverAck({receipt: 'fixture-receipt'}), false);
+    }
+    assert.strictEqual(sent.length, 2);
+    assert.deepStrictEqual(acknowledgements, []);
   });
 
 });


### PR DESCRIPTION
Cache only level, group and eventName for Pushover receipt acknowledgements. The current cache clones the whole notification, including unused messages and plugin graphs; the actual acknowledgement and snooze paths need only these three fields. Sending, cloning, expiry and cancellation behavior stay unchanged.

Seven focused cache cases pass on Node 22.23.2 and 24.20.0, including real high/low/plugin snooze selection, post-send mutation, repeat acknowledgements/expiry, failure suppression and cancellation retries. Six pass against the parent; the new retained-field regression fails there. Production build passes; the full backend suite passes 1,823 tests with one existing pending case. Hosted validation remains in progress.

Draft M25 slice targeting chore/nightscout-modernization. This does not remove node-cache or claim measured whole-server memory savings. Capacity/eviction and cache-maintenance decisions remain open. #8605 stays draft into dev.
