### PR TITLE
fix: reject server-side JavaScript in MongoDB query paths

### DIFF
--- a/docs/runtime-upgrade.md
+++ b/docs/runtime-upgrade.md
@@ -42,3 +42,13 @@ Before deploying the modernization release on a database currently running 4.4:
 4. Keep application rollback and database rollback separate. Reverting Nightscout does not undo database binary or FCV changes. Agree a recovery plan using MongoDB's documented downgrade restrictions and the verified backup; account for writes made since that backup.
 
 The follow-up database work must validate maintained MongoDB 7/8 releases with the selected driver and existing client/API fixtures before changing the recommended deployment version. Retiring 5/6 requires a separate support decision and release notice; they remain in CI during this migration. Database upgrade/restore evidence is required before final promotion of #8605. No production database is changed by this PR.
+
+
+## MongoDB query filters
+
+This release rejects `$where`, `$function` and `$accumulator` when used to
+submit JavaScript through Nightscout database queries. Replace such filters
+with ordinary MongoDB comparison, logical or aggregation operators. Explicit
+literal values containing these names remain data. Profile filter requests
+rejected by this validation return HTTP 400 with an explanatory message;
+other profile storage failures return a generic HTTP 500.

--- a/docs/test-specs/mongo-query-javascript.md
+++ b/docs/test-specs/mongo-query-javascript.md
@@ -1,0 +1,46 @@
+# MongoDB query JavaScript boundary
+
+The driver modernization review surfaced CodeQL alert 105 at the profile
+query sink. An owned MongoDB 6 database confirmed that a supplied `$where`
+predicate is evaluated by both driver 5.9.2 and 7.6.0. The profile read API
+accepts MongoDB filters, so retaining comparisons and logical operators is
+intentional; submitting JavaScript to the database is not required for those
+filters. MongoDB documents `$where`, `$function` and `$accumulator` as
+[server-side JavaScript operations](https://www.mongodb.com/docs/manual/reference/operator/query/where/).
+
+A shared, iterative guard rejects those three operators before database I/O.
+It applies to the legacy query builder, aggregation pipelines, API v3 filters,
+projections and bulk-delete filters. Query literals (`$eq`, `$ne`, `$in`,
+`$nin`, schema definitions and ordinary `$all` values) remain data. Aggregation
+expressions are checked recursively, except explicit `$literal` data; `$match`
+stages switch back to query semantics. A cycle is visited once per context,
+so reusing an object as both a literal comparison and an expression cannot
+bypass the expression check.
+
+The `/profiles/` HTTP route now reports rejected JavaScript queries as HTTP
+400 with a fixed explanatory message, instead of ignoring the storage error.
+Other storage errors return a generic HTTP 500 without exposing database error
+text. Aggregation validation reports failures through the existing promise
+and callback contract. There is no dependency, schema, credential or browser
+bundle change. Clients that submitted server-side JavaScript must express
+filters using ordinary MongoDB query/aggregation operators.
+
+## Evidence and remaining gates
+
+The initial before/after boundary check produced four passes and nine failures
+without the guard wiring, including the real profile endpoint accepting a
+JavaScript predicate with HTTP 200. The guard made all those cases pass.
+The final focused set includes 15 new cases plus five existing query tests:
+20 pass on Node 22/MongoDB 6 and Node 24/MongoDB 8. Coverage includes repeated
+HTTP rejection with no MongoDB find command, sorting/limit after rejection,
+operator names inside literal documents, nested expressions, projection and
+delete rejection, aggregate callback behavior and shared/cyclic contexts.
+The existing D3 source inventory parser also accepts the changed source.
+
+The full Node 22 / MongoDB 6 backend suite passes 1,846 tests with one pending.
+Clean installation/production build and the development/HTTP asset checks pass.
+Hosted browser, server matrix, Docker and CodeQL checks remain merge gates.
+Do not equate this narrowly scoped guard with a general query cost limit,
+a replacement for authorization, or proof that every NoSQL misuse is covered.
+CodeQL alert 105 must be reassessed on the driver branch after integrating
+the fix; it has not been dismissed.

--- a/lib/api/profile/index.js
+++ b/lib/api/profile/index.js
@@ -37,6 +37,10 @@ function configure (app, wares, ctx) {
 
         // perform the query
         ctx.profile.list_query(query, function payload(err, profiles) {
+            if (err) {
+                const status = err.name === 'MongoQueryValidationError' ? 400 : 500;
+                return res.status(status).json({status, message: status === 400 ? err.message : 'Unable to read profiles'});
+            }
             return res.json(profiles);
         });
     }

--- a/lib/api3/storage/mongoCollection/find.js
+++ b/lib/api3/storage/mongoCollection/find.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const utils = require('./utils');
+const assertNoQueryJavascript = require('../../../storage/assert-no-query-javascript');
 
 /**
  * Ensure Mongo limit/skip receive integers even when callers pass env strings.
@@ -33,6 +34,8 @@ function normalizeDocs (docs, options) {
 async function findOne (col, identifier, projection, options) {
 
   const filter = utils.filterForOne(identifier);
+  assertNoQueryJavascript(filter);
+  assertNoQueryJavascript({$expr: projection});
   const result = await col.find(filter)
     .project(projection)
     .sort({ identifier: -1 }) // document with identifier first (not the fallback one)
@@ -52,6 +55,8 @@ async function findOne (col, identifier, projection, options) {
  */
 async function findOneFilter (col, filter, projection, options) {
 
+  assertNoQueryJavascript(filter);
+  assertNoQueryJavascript({$expr: projection});
   const result = await col.find(filter)
     .project(projection)
     .sort({ identifier: -1 }) // document with identifier first (not the fallback one)
@@ -68,6 +73,8 @@ async function findOneFilter (col, filter, projection, options) {
 async function findMany (col, args) {
   const logicalOperator = args.logicalOperator || 'and';
   const filter = utils.parseFilter(args.filter, logicalOperator, args.onlyValid);
+  assertNoQueryJavascript(filter);
+  assertNoQueryJavascript({$expr: args.projection});
   const safeLimit = toSafeInt(args.limit, 1000);
   const safeSkip = toSafeInt(args.skip, 0);
   const result = await col.find(filter)

--- a/lib/api3/storage/mongoCollection/modify.js
+++ b/lib/api3/storage/mongoCollection/modify.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const assertNoQueryJavascript = require('../../../storage/assert-no-query-javascript');
+
 const utils = require('./utils')
   ;
 
@@ -72,6 +74,7 @@ async function deleteOne (col, identifier) {
 async function deleteManyOr (col, filterDef) {
 
   const filter = utils.parseFilter(filterDef, 'or');
+  assertNoQueryJavascript(filter);
   const result = await col.deleteMany(filter);
 
   return { deleted: result.deletedCount };

--- a/lib/server/aggregate.js
+++ b/lib/server/aggregate.js
@@ -1,4 +1,5 @@
 var find_options = require('./query');
+const assertNoQueryJavascript = require('../storage/assert-no-query-javascript');
 var runWithCallback = require('../storage/run-with-callback');
 
 function create (conf, api) {
@@ -16,13 +17,18 @@ function create (conf, api) {
 
   // var collection = api( );
   function aggregate (opts, done) {
-    var query = find_options(opts);
-
-    var pipeline = (conf.pipeline || [ ]).concat(opts.pipeline || [ ]);
-    var groupBy = [ {$match: query } ].concat(pipeline).concat(template( ));
-    console.log('$match query', query);
-    console.log('AGGREGATE', groupBy);
     return runWithCallback(function () {
+      var query = find_options(opts);
+
+      var pipeline = (conf.pipeline || [ ]).concat(opts.pipeline || [ ]);
+      var groupBy = [ {$match: query } ].concat(pipeline).concat(template( ));
+      for (const stage of groupBy) {
+        if (stage.$match) assertNoQueryJavascript(stage.$match);
+        const expressions = Object.fromEntries(Object.entries(stage).filter(([key]) => key !== '$match'));
+        assertNoQueryJavascript({$expr: expressions});
+      }
+      console.log('$match query', query);
+      console.log('AGGREGATE', groupBy);
       return api().aggregate(groupBy).toArray();
     }, done);
   }

--- a/lib/server/query.js
+++ b/lib/server/query.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const assertNoQueryJavascript = require('../storage/assert-no-query-javascript');
+
 const queryLeaves = require('../utils/query-leaves');
 const ObjectID = require('mongodb').ObjectId;
 const moment = require('moment');
@@ -148,6 +150,7 @@ function normalizeIdValue (value, opts) {
   * @returns Object An object which can be passed to `mongodb.find( )`
   */
 function create (params, opts) {
+  assertNoQueryJavascript(params && params.find);
   // setup default options for what/how to do things
   opts = default_options(opts);
   // Build the iterator, pass it our initial params to et the results.

--- a/lib/storage/assert-no-query-javascript.js
+++ b/lib/storage/assert-no-query-javascript.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// Public filters support MongoDB operators, but must not submit executable
+// JavaScript to the database. Values inside literal comparisons remain data.
+module.exports = function assertNoQueryJavascript(root) {
+  const pending = [{value:root, expression:false}];
+  const visited = new WeakMap();
+  while (pending.length) {
+    const {value, expression} = pending.pop();
+    if (!value || typeof value !== 'object') continue;
+    const mode = expression ? 2 : 1;
+    if ((visited.get(value) || 0) & mode) continue;
+    visited.set(value, (visited.get(value) || 0) | mode);
+    for (const key of Object.keys(value)) {
+      if (key === '$where' || key === '$function' || key === '$accumulator') {
+        const error = new Error('Server-side JavaScript is not allowed in database queries');
+        error.name = 'MongoQueryValidationError';
+        error.status = error.statusCode = 400;
+        throw error;
+      }
+      // Aggregation $literal and query/schema literal values are never code.
+      if (expression && key === '$literal') continue;
+      if (!expression && ['$eq', '$ne', '$in', '$nin', '$jsonSchema'].includes(key)) continue;
+      if (!expression && key === '$all' && Array.isArray(value[key])) {
+        for (const item of value[key]) {
+          if (item && Object.prototype.hasOwnProperty.call(item, '$elemMatch')) {
+            pending.push({value:item.$elemMatch, expression:false});
+          }
+        }
+        continue;
+      }
+      pending.push({value:value[key], expression:key === '$match' ? false : expression || key === '$expr'});
+    }
+  }
+  return root;
+};

--- a/tests/mongo-query-javascript.http.test.js
+++ b/tests/mongo-query-javascript.http.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {randomUUID} = require('node:crypto');
+const {MongoClient} = require('mongodb');
+const express = require('express');
+const request = require('supertest');
+const qs = require('qs');
+
+describe('Profile query JavaScript HTTP boundary', function () {
+  this.timeout(15000);
+  let client, col, server, findCommands = 0;
+  const collectionName = 'query_boundary_' + randomUUID().replaceAll('-', '');
+  before(async function () {
+    client = new MongoClient(process.env.CUSTOMCONNSTR_mongo || 'mongodb://127.0.0.1:27017/test', {monitorCommands:true});
+    await client.connect();
+    const db = client.db();
+    col = db.collection(collectionName);
+    client.on('commandStarted', event => {
+      if (event.commandName === 'find' && event.command.find === collectionName) findCommands++;
+    });
+    await col.insertMany([
+      {startDate:'2030-01-01T00:00:00.000Z', score:1, payload:{$where:'literal'}, notes:'$where is plain text'},
+      {startDate:'2030-01-02T00:00:00.000Z', score:2, payload:{$function:'literal'}},
+      {startDate:'2030-01-03T00:00:00.000Z', score:3}
+    ]);
+    const app = express();
+    app.set('query parser', 'extended');
+    const pass = (req, res, next) => next();
+    app.use(require('../lib/api/profile')(app, {
+      sendJSONStatus:pass, rawParser:pass, jsonParser:express.json(), urlencodedParser:express.urlencoded({extended:true})
+    }, {
+      profile:require('../lib/server/profile')(collectionName, {store:db}),
+      authorization:{isPermitted:() => pass}
+    }));
+    server = await new Promise(resolve => {const listening = app.listen(0, '127.0.0.1', () => resolve(listening));});
+  });
+  after(async function () {
+    if (server) await new Promise(resolve => server.close(resolve));
+    try {if (col) await col.drop();} finally {if (client) await client.close();}
+  });
+
+  it('rejects repeated direct and nested JavaScript predicates with 400 and no find', async function () {
+    for (let cycle = 0; cycle < 2; cycle++) {
+      for (const find of [{$where:'this.score === 1'},
+        {$or:[{$where:'this.score === 1'}]},
+        {$expr:{$function:{body:'function() { return true; }', args:[], lang:'js'}}}]) {
+        const before = findCommands;
+        const response = await request(server).get('/profiles/?' + qs.stringify({find})).expect(400);
+        assert.equal(response.body.status, 400);
+        assert.equal(response.body.message, 'Server-side JavaScript is not allowed in database queries');
+        assert.equal(findCommands, before);
+      }
+    }
+  });
+
+  it('preserves sorted and limited ordinary profile filters after rejection', async function () {
+    const result = await request(server).get('/profiles/?' + qs.stringify({find:{startDate:{$gte:'2030-01-02T00:00:00.000Z'}}, count:1})).expect(200);
+    assert.equal(result.body.length, 1);
+    assert.equal(result.body[0].score, 3);
+  });
+
+  it('treats operator names inside explicit literals as data', async function () {
+    for (const [find, score] of [
+      [{payload:{$eq:{$where:'literal'}}}, 1],
+      [{$expr:{$eq:[{$literal:{$function:'literal'}}, '$payload']}}, 2],
+      [{notes:{$regex:'\\$where is plain text'}}, 1]
+    ]) {
+      const result = await request(server).get('/profiles/?' + qs.stringify({find})).expect(200);
+      assert.equal(result.body.length, 1);
+      assert.equal(result.body[0].score, score);
+    }
+  });
+});

--- a/tests/mongo-query-javascript.test.js
+++ b/tests/mongo-query-javascript.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const guard = require('../lib/storage/assert-no-query-javascript');
+const query = require('../lib/server/query');
+const find = require('../lib/api3/storage/mongoCollection/find');
+const modify = require('../lib/api3/storage/mongoCollection/modify');
+const {ObjectId} = require('mongodb');
+
+function rejected(error) {
+  assert.equal(error.name, 'MongoQueryValidationError');
+  assert.equal(error.statusCode, 400);
+  assert(!error.message.includes('owned-expression'));
+  return true;
+}
+
+describe('MongoDB query JavaScript boundary', function () {
+  const dangerous = [
+    {$where:'owned-expression'},
+    {$and:[{date:{$gt:0}}, {$or:[{$where:'owned-expression'}]}]},
+    {$expr:{$function:{body:'owned-expression', args:[], lang:'js'}}},
+    {$expr:{$eq:[{$function:{body:'owned-expression', args:[], lang:'js'}}, true]}},
+    {items:{$all:[{$elemMatch:{$where:'owned-expression'}}]}},
+    {$expr:{$accumulator:{init:'owned-expression', accumulate:'owned-expression', lang:'js'}}}
+  ];
+  dangerous.forEach((filter, index) => {
+    it('rejects executable filter shape ' + index + ' before query conversion', function () {
+      assert.throws(() => query({find:filter}), rejected);
+    });
+  });
+
+  it('preserves normal filters and explicit literal data without mutation', function () {
+    const objectId = new ObjectId();
+    const filter = {_id:objectId, $and:[{sgv:{$gte:80, $lt:200}}, {type:{$in:['sgv','mbg']}}],
+      notes:{$regex:'literal \\$where and function', $options:'i'},
+      obj:{$eq:{$where:'literal document field'}},
+      schema:{$jsonSchema:{properties:{$where:{bsonType:'string'}}}},
+      $expr:{$eq:[{$literal:{$function:'literal document field'}}, '$payload']}};
+    const snapshot = JSON.stringify(filter);
+    assert.equal(guard(filter), filter);
+    assert.equal(filter._id, objectId);
+    assert.equal(JSON.stringify(filter), snapshot);
+  });
+
+  it('preserves literal values inside nested aggregation match stages', function () {
+    const pipeline = {$expr:{$facet:{rows:[{$match:{payload:{$eq:{$where:'literal'}}}}]}}};
+    assert.equal(guard(pipeline), pipeline);
+    pipeline.$expr.$facet.rows.push({$match:{$where:'owned-expression'}});
+    assert.throws(() => guard(pipeline), rejected);
+  });
+
+  it('checks cyclic objects in both query and expression contexts', function () {
+    const shared = {$eq:{$function:{body:'owned-expression'}}};
+    const root = {literal:shared, $expr:shared};
+    root.self = root;
+    assert.throws(() => guard(root), rejected);
+    const benign = {sgv:100};
+    benign.self = benign;
+    assert.equal(guard(benign), benign);
+  });
+
+  it('rejects API v3 filters, projections and delete filters before database I/O', async function () {
+    const col = {find:() => assert.fail('find must not run'), deleteMany:() => assert.fail('delete must not run')};
+    for (const filter of dangerous) {
+      await assert.rejects(find.findMany(col, {filter}), rejected);
+      await assert.rejects(find.findOneFilter(col, filter, {}), rejected);
+      await assert.rejects(modify.deleteManyOr(col, filter), rejected);
+    }
+    const projection = {computed:{$function:{body:'owned-expression', args:[], lang:'js'}}};
+    await assert.rejects(find.findMany(col, {projection}), rejected);
+    await assert.rejects(find.findOneFilter(col, {}, projection), rejected);
+    await assert.rejects(find.findOne(col, new ObjectId().toHexString(), projection), rejected);
+  });
+
+  it('reports aggregate rejection through its callback once', async function () {
+    const aggregate = require('../lib/server/aggregate')({}, () => ({aggregate:() => assert.fail('aggregate must not run')}));
+    let calls = 0;
+    await new Promise((resolve, reject) => {
+      aggregate({pipeline:[{$match:{$where:'owned-expression'}}]}, error => {
+        try {calls++; rejected(error); resolve();} catch (failure) {reject(failure);}
+      });
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(calls, 1);
+  });
+
+  it('rejects aggregate JavaScript before calling MongoDB', async function () {
+    const aggregate = require('../lib/server/aggregate')({}, () => ({aggregate:() => assert.fail('aggregate must not run')}));
+    for (const stage of [{$match:{$where:'owned-expression'}},
+      {$project:{value:{$function:{body:'owned-expression', args:[], lang:'js'}}}},
+      {$group:{_id:null, value:{$accumulator:{init:'owned-expression', lang:'js'}}}}]) {
+      await assert.rejects(aggregate({pipeline:[stage]}), rejected);
+    }
+  });
+});


### PR DESCRIPTION
Reject server-side JavaScript in MongoDB query paths while preserving the supported filter language. The driver migration review surfaced CodeQL alert 105 at the profile query sink; an owned-database comparison confirmed supplied `$where` predicates execute under both driver 5 and 7.

A shared context-aware guard rejects `$where`, `$function` and `$accumulator` before database I/O in legacy queries/aggregations and API v3 filters, projections and bulk-delete filters. Explicit literal comparisons and aggregation `$literal` values remain data. Profile filter errors now return HTTP 400; unrelated storage errors return generic HTTP 500. No dependency, schema, credential or browser bundle change.

Fifteen new tests cover direct/nested predicates, expression versus literal semantics, shared/cyclic contexts, callback errors, and the actual profile HTTP endpoint. The initial before/after run had nine failures without guard wiring, including HTTP 200 for an executable predicate. Twenty focused cases (including five existing query cases) pass on Node 22/MongoDB 6 and Node 24/MongoDB 8. The full Node 22/MongoDB 6 backend suite passes **1,846 tests, one pending**. Clean install/production build and development/HTTP asset checks pass; all twelve hosted backend combinations, all six browser jobs, npm 12 install/build, CodeQL and both Docker architecture validations pass at head 924aa8d712be93ecf1a8a56734781086c730c15e.

This is a narrow query-code boundary, not a general query-cost limit or replacement for authorization. CodeQL alert 105 on #8661 remains open and must be reassessed after this fix is integrated. Targets `chore/nightscout-modernization`; #8605 remains draft into dev. Runtime migration notes and the regression specification are included.
