### PR TITLE
fix: reject custom aggregation pipelines in the count API

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ You can get many more results, by using the `count`, `date`, `dateString`, and `
 
 Once you've installed Nightscout, you can access API documentation by loading `/api-docs/` URL in your instance.
 
+The `/api/v1/count/:storage/where` endpoint accepts `find` filters for counting records.
+Custom aggregation `pipeline` parameters are rejected with HTTP 400; they are not part of the public count API.
+
 #### Example Queries
 
 (replace `http://localhost:1337` with your own URL)

--- a/docs/test-specs/count-pipeline-boundary.md
+++ b/docs/test-specs/count-pipeline-boundary.md
@@ -1,0 +1,30 @@
+# Public count pipeline boundary
+
+The public `/api/v1/count/:storage/where` handler previously passed the complete
+request query to storage aggregation. A caller could append aggregation stages,
+including reads from other collections, despite the handler selecting only
+entries, treatments or device status. The JavaScript-operator guard in #8663
+is a separate boundary; declarative aggregation stages can also cross that
+collection boundary.
+
+The count handler now rejects any top-level `pipeline` parameter with HTTP 400
+before invoking storage aggregation. Its documented `find` filters and existing
+storage selection/fallback remain unchanged. An ordinary document field named
+`pipeline` inside `find` is still allowed. The internal aggregation helper is
+unchanged by this patch; trusted application pipelines are not removed.
+
+Four real HTTP/database tests cover normal filtered counts across the existing
+storage selections, repeated rejection before any aggregate command, malformed
+or transformation pipeline parameters, and literal `find.pipeline` filtering.
+The unpatched route has two passes and two failures: an owned cross-collection
+fixture returns HTTP 200 and count 6 instead of rejecting the custom pipeline.
+Both Node 22/MongoDB 6 and Node 24/MongoDB 8 pass all four cases after the fix.
+No real user database or private record was accessed for this comparison.
+
+Clean install/production build passes. The Node 22 / MongoDB 6 full backend
+run passes 1,835 tests with one pending before refreshing onto the query guard.
+Hosted validation remains required. There is no dependency, schema or browser code change. API clients
+using custom pipelines must switch to supported `find` filters or run their
+own authenticated database queries outside this public endpoint. The README
+records the API restriction. Authorization for the existing storage choices
+is unchanged; this patch does not claim a general authorization redesign.

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -447,6 +447,14 @@ function configure (app, wares, ctx, env) {
 
   function count_records (req, res, next) {
     var query = req.query;
+    // Count exposes filters for the selected storage, not an arbitrary
+    // aggregation pipeline that can read other collections.
+    if (Object.prototype.hasOwnProperty.call(query, 'pipeline')) {
+      return res.status(400).json({
+        status: 400,
+        message: 'Custom aggregation pipelines are not supported by the count endpoint'
+      });
+    }
     var storage = req.storage || ctx.entries;
     storage.aggregate(query, function payload (err, entries) {
       // assign payload

--- a/tests/count-pipeline-boundary.test.js
+++ b/tests/count-pipeline-boundary.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {randomUUID} = require('node:crypto');
+const {MongoClient} = require('mongodb');
+const express = require('express');
+const request = require('supertest');
+const qs = require('qs');
+
+describe('Public count query boundary', function () {
+  this.timeout(15000);
+  const prefix = 'count_boundary_' + randomUUID().replaceAll('-', '');
+  let client, entries, privateCollection, server, aggregateCommands = 0;
+  before(async function () {
+    client = new MongoClient(process.env.CUSTOMCONNSTR_mongo || 'mongodb://127.0.0.1:27017/test', {monitorCommands:true});
+    await client.connect();
+    const db = client.db();
+    entries = db.collection(prefix + '_entries');
+    privateCollection = db.collection(prefix + '_private');
+    await entries.insertMany([
+      {date:1700000000000, sgv:100, pipeline:'ordinary field'},
+      {date:1700000300000, sgv:150}, {date:1700000600000, sgv:200}
+    ]);
+    await privateCollection.insertMany([{fixture:'one'}, {fixture:'two'}]);
+    client.on('commandStarted', event => {
+      if (event.commandName === 'aggregate' && event.command.aggregate === entries.collectionName) aggregateCommands++;
+    });
+    const app = express();
+    app.set('query parser', 'extended');
+    const pass = (req, res, next) => next();
+    const storage = require('../lib/server/entries')({entries_collection:entries.collectionName}, {store:db});
+    app.use(require('../lib/api/entries')(app, {
+      sendJSONStatus:pass, rawParser:pass, bodyParser:express,
+      urlencodedParser:express.urlencoded({extended:true}), extensions:() => pass, obscure_device:pass
+    }, {entries:storage, treatments:storage, devicestatus:storage,
+      authorization:{isPermitted:() => pass}}, {settings:{}}));
+    server = await new Promise(resolve => {const listening = app.listen(0, '127.0.0.1', () => resolve(listening));});
+  });
+  after(async function () {
+    if (server) await new Promise(resolve => server.close(resolve));
+    try {
+      if (entries) await entries.drop();
+      if (privateCollection) await privateCollection.drop();
+    } finally {if (client) await client.close();}
+  });
+
+  it('preserves documented find counts and storage selection', async function () {
+    for (const storage of ['entries', 'treatments', 'devicestatus', 'unknown']) {
+      for (const [find, count] of [[{date:{$gte:0}}, 3], [{date:{$gte:0}, sgv:{$gte:150}}, 2]]) {
+        const response = await request(server).get('/count/' + storage + '/where?' + qs.stringify({find})).expect(200);
+        assert.equal(response.body[0].count, count);
+      }
+    }
+  });
+
+  it('rejects cross-collection pipelines before aggregation on successive requests', async function () {
+    const pipeline = [{$lookup:{from:privateCollection.collectionName,
+      localField:'missing', foreignField:'missing', as:'joined'}}, {$unwind:'$joined'}];
+    for (let cycle = 0; cycle < 2; cycle++) {
+      const before = aggregateCommands;
+      const response = await request(server).get('/count/entries/where?' + qs.stringify({find:{date:{$gte:0}}, pipeline}));
+      assert.equal(response.status, 400, JSON.stringify(response.body));
+      assert.equal(response.body.status, 400);
+      assert.equal(response.body.message, 'Custom aggregation pipelines are not supported by the count endpoint');
+      assert.equal(aggregateCommands, before);
+    }
+  });
+
+  it('rejects transformation, string and empty pipeline parameters', async function () {
+    for (const pipeline of [[{$limit:1}], 'unrecognized stage', '']) {
+      const before = aggregateCommands;
+      await request(server).get('/count/entries/where?' + qs.stringify({find:{date:{$gte:0}}, pipeline})).expect(400);
+      assert.equal(aggregateCommands, before);
+    }
+  });
+
+  it('still allows an ordinary document field named pipeline in find', async function () {
+    const response = await request(server).get('/count/entries/where?' + qs.stringify({find:{date:{$gte:0}, pipeline:'ordinary field'}})).expect(200);
+    assert.equal(response.body[0].count, 1);
+  });
+});


### PR DESCRIPTION
The public count endpoint previously forwarded caller-supplied aggregation pipelines to MongoDB. That allowed stages to read collections outside the endpoint's selected storage. An owned fixture with three entry records and two private records returned count 6 through a supplied join pipeline.

Reject top-level `pipeline` parameters with HTTP 400 before storage aggregation. Documented `find` filters, existing storage selection/fallback and ordinary document fields named `pipeline` remain supported. Internal application aggregation is unchanged. The README documents the API restriction; this does not redesign authorization for the existing storage choices.

Four HTTP/database regressions have two passes and two failures before the fix, and all pass afterward on Node 22/MongoDB 6 and Node 24/MongoDB 8. The full Node 22/MongoDB 6 backend run passes **1,835 tests, one pending** before refreshing onto #8663. After that refresh, 24 combined count/query-boundary cases pass on Node 24/MongoDB 8. Clean install/production build and development/HTTP asset checks pass; fresh hosted validation remains required.

Draft targeting `chore/nightscout-modernization`. Separate from #8663's JavaScript-operator guard: declarative pipeline stages also need a public API boundary. No package, schema or browser-code changes. #8605 remains draft into dev.
