### PR TITLE
test: validate MongoDB replica-set continuity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,52 @@ jobs:
       - name: Send Coverage
         run: npm run-script coverage
 
+  replica-test:
+    name: Replica set (${{ matrix.node-version }}, ${{ matrix.mongodb-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22.23.2', '24.20.0']
+        mongodb-version: ['5.0.32', '6.0.27', '7.0.40', '8.0.29']
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
+      - name: Start owned replica members
+        env:
+          MONGODB_TEST_VERSION: ${{ matrix.mongodb-version }}
+        run: |
+          for port in 27172 27173 27174; do
+            docker run -d --name "nightscout-owned-rs-$port" --network host \
+              "mongo:$MONGODB_TEST_VERSION" --port "$port" --bind_ip 127.0.0.1 \
+              --replSet nightscout_owned_rs --wiredTigerCacheSizeGB 0.25
+          done
+      # This exercises storage adapters; full builds run in the backend matrix.
+      - name: Install test dependencies
+        run: npm ci --ignore-scripts
+      - name: Validate reads and writes across two primary changes
+        run: node tools/validate-mongodb-replica-set.js
+      - name: Show owned replica logs on failure
+        if: failure()
+        run: |
+          for port in 27172 27173 27174; do
+            docker logs --tail 80 "nightscout-owned-rs-$port" || true
+          done
+      - name: Remove owned replica containers and volumes
+        if: always()
+        run: |
+          for port in 27172 27173 27174; do
+            if docker inspect "nightscout-owned-rs-$port" >/dev/null 2>&1; then
+              docker rm -fv "nightscout-owned-rs-$port"
+            fi
+          done
+
   browser-test:
     name: Browser tests (${{ matrix.node-version }}, ${{ matrix.browser }})
     runs-on: ubuntu-latest
@@ -141,7 +187,7 @@ jobs:
 
   docker-build-pr:
     name: Validate Docker image (${{ matrix.arch }})
-    needs: [test, browser-test, maintained-mongo]
+    needs: [test, browser-test, maintained-mongo, replica-test]
     if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -190,7 +236,7 @@ jobs:
 
   docker-build:
     name: Build Docker image (${{ matrix.arch }})
-    needs: [test, browser-test, maintained-mongo]
+    needs: [test, browser-test, maintained-mongo, replica-test]
     if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') && github.repository_owner == 'nightscout'
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/docs/audits/mongodb-replica-local.json
+++ b/docs/audits/mongodb-replica-local.json
@@ -1,0 +1,78 @@
+{
+  "validatorSHA256": "4c21c9c464bf4e883ec71ece0e86e43edded5fbc62aaf723f52564799e8ada44",
+  "results": [
+    {
+      "driver": "5.9.2",
+      "node": "v22.23.2",
+      "server": "8.0.29",
+      "transitions": [
+        {
+          "from": "127.0.0.1:27174",
+          "to": "127.0.0.1:27173"
+        },
+        {
+          "from": "127.0.0.1:27173",
+          "to": "127.0.0.1:27172"
+        }
+      ],
+      "records": 3,
+      "updates": 5,
+      "statsObjects": 3
+    },
+    {
+      "driver": "5.9.2",
+      "node": "v24.20.0",
+      "server": "8.0.29",
+      "transitions": [
+        {
+          "from": "127.0.0.1:27172",
+          "to": "127.0.0.1:27174"
+        },
+        {
+          "from": "127.0.0.1:27174",
+          "to": "127.0.0.1:27173"
+        }
+      ],
+      "records": 3,
+      "updates": 5,
+      "statsObjects": 3
+    },
+    {
+      "driver": "7.6.0",
+      "node": "v22.23.2",
+      "server": "8.0.29",
+      "transitions": [
+        {
+          "from": "127.0.0.1:27173",
+          "to": "127.0.0.1:27172"
+        },
+        {
+          "from": "127.0.0.1:27172",
+          "to": "127.0.0.1:27174"
+        }
+      ],
+      "records": 3,
+      "updates": 5,
+      "statsObjects": 3
+    },
+    {
+      "driver": "7.6.0",
+      "node": "v24.20.0",
+      "server": "8.0.29",
+      "transitions": [
+        {
+          "from": "127.0.0.1:27174",
+          "to": "127.0.0.1:27173"
+        },
+        {
+          "from": "127.0.0.1:27173",
+          "to": "127.0.0.1:27172"
+        }
+      ],
+      "records": 3,
+      "updates": 5,
+      "statsObjects": 3
+    }
+  ],
+  "scope": "Local MongoDB 8.0.29, two commanded primary stepdowns per case; not injected write failures or live deployment validation."
+}

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -247,3 +247,5 @@ The remaining M08, M19, M23 and M26 candidates are assembled into one verificati
 ### M25 profile-cache candidate
 
 A bounded reference cache replaces memory-cache's per-entry timers while preserving the application's five-second get/put/clear contracts. [Workload measurements and limits](../test-specs/profile-cache.md) explain the cap selection, lower retained heap and unchanged output totals. Notification-cache policy and full candidate validation remain open; M25 is not yet complete.
+
+- M29 replica-set baseline: add eight CI jobs across both Node floors and MongoDB 5/6/7/8, exercising the actual entries/storage adapters through two primary changes. Local driver 5.9.2 and proposed 7.6.0 comparisons pass on both Node floors with MongoDB 8.0.29; see [scope and evidence](../test-specs/mongodb-replica-set.md). Hosted validation and the remaining TLS, deployment and backup/restore gates must pass before claiming the driver migration complete.

--- a/docs/test-specs/mongodb-replica-set.md
+++ b/docs/test-specs/mongodb-replica-set.md
@@ -1,0 +1,39 @@
+# MongoDB replica-set continuity
+
+M29 requires evidence beyond standalone MongoDB tests before the driver migration.
+`tools/validate-mongodb-replica-set.js` exercises the actual storage initializer
+and entries adapter against three disposable localhost MongoDB members.
+
+The CI matrix runs Node 22.23.2 and 24.20.0 with MongoDB 5.0.32, 6.0.27,
+7.0.40 and 8.0.29. Both Docker validation jobs depend on this matrix.
+Each job owns its containers and volumes and removes them even after failure.
+
+The validator checks the dedicated replica-set name, ports and bind addresses
+before initialization. It creates a unique test database and drops only that
+database on exit. It must never be pointed at a deployment. For local use,
+start three disposable members with the exact options in the workflow, then run:
+
+```sh
+node tools/validate-mongodb-replica-set.js
+```
+
+An optional absolute checkout argument loads that checkout's actual driver and
+storage modules, allowing comparison before and after a driver migration.
+Run comparisons sequentially against the shared test replica set.
+
+Assertions cover majority-acknowledged writes immediately after each of two
+commanded primary stepdowns, election of a different primary, subsequent reads,
+identifier-preserving updates without duplicate records, descending entry order,
+five data-update events, and database statistics. There is no application retry
+loop around the writes. Driver retryWrites is enabled and asserted.
+
+Local evidence in `../audits/mongodb-replica-local.json` records all four Node/driver
+combinations on MongoDB 8.0.29. Driver 5.9.2 uses integration source `ea31587e`;
+driver 7.6.0 uses migration source `cc0b2e70`. Every run passed two primary changes.
+The report includes the validator hash to identify the exact tested source.
+
+These tests do not inject a retryable write error or prove that a write was
+retried. They do not cover process crashes, packet loss, authentication/TLS,
+live Atlas, backup/restore, HTTP request recovery or deployment rollback.
+Those remain separate migration gates. This PR changes CI only; it does not
+upgrade the production driver or change UI behavior.

--- a/tools/validate-mongodb-replica-set.js
+++ b/tools/validate-mongodb-replica-set.js
@@ -1,0 +1,134 @@
+'use strict';
+
+// Destructive only to the dedicated local test replica set: this initializes
+// its members and steps down primaries. Never point it at a deployment.
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const {createRequire} = require('node:module');
+const {randomUUID} = require('node:crypto');
+const {EventEmitter} = require('node:events');
+const root = process.argv[2] || path.resolve(__dirname, '..');
+assert(path.isAbsolute(root), 'Checkout path must be absolute');
+const req = createRequire(path.join(root, 'package.json'));
+const {MongoClient} = req('mongodb');
+const hosts = [27172, 27173, 27174].map(port => '127.0.0.1:' + port);
+const setName = 'nightscout_owned_rs';
+const database = 'nightscout_replica_test_' + randomUUID().replaceAll('-', '');
+const uri = 'mongodb://' + hosts.join(',') + '/' + database + '?replicaSet=' + setName + '&retryWrites=true&w=majority';
+const pause = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function initialize() {
+  let initialized = false;
+  for (const host of hosts) {
+    const direct = new MongoClient('mongodb://' + host + '/?directConnection=true', {serverSelectionTimeoutMS:5000});
+    try {
+      await direct.connect();
+      const options = (await direct.db('admin').command({getCmdLineOpts:1})).parsed;
+      assert.equal(options.replication.replSet, setName);
+      assert.equal(options.net.bindIp, '127.0.0.1');
+      assert.equal(options.net.port, Number(host.split(':')[1]));
+      if (host === hosts[0]) {
+        try {
+          const {config} = await direct.db('admin').command({replSetGetConfig:1});
+          assert.equal(config._id, setName);
+          assert.deepEqual(config.members.map(member => member.host).sort(), hosts);
+          initialized = true;
+        } catch (error) {
+          if (error.code !== 94) throw error; // NotYetInitialized only
+        }
+      }
+    } finally {await direct.close();}
+  }
+  // Inspect every member before initializing the owned set.
+  if (!initialized) {
+    const direct = new MongoClient('mongodb://' + hosts[0] + '/?directConnection=true');
+    try {
+      await direct.connect();
+      await direct.db('admin').command({replSetInitiate:{
+        _id:setName, members:hosts.map((host, _id) => ({_id, host})),
+        settings:{electionTimeoutMillis:1500, heartbeatIntervalMillis:500}
+      }});
+    } finally {await direct.close();}
+  }
+}
+
+async function primary(client, previous) {
+  const deadline = performance.now() + 30000;
+  while (performance.now() < deadline) {
+    try {
+      const hello = await client.db('admin').command({hello:1});
+      if (hello.isWritablePrimary && hello.primary !== previous) return hello.primary;
+    } catch (error) {
+      if (error.name !== 'MongoServerSelectionError' && error.name !== 'MongoNetworkError') throw error;
+    }
+    await pause(100);
+  }
+  throw new Error('Owned replica set did not elect a different primary');
+}
+
+(async function () {
+  await initialize();
+  const monitor = new MongoClient(uri, {serverSelectionTimeoutMS:10000});
+  let store;
+  const transitions = [];
+  try {
+    await monitor.connect();
+    let current = await primary(monitor);
+    store = await req('./lib/storage/mongo-storage')({storageURI:uri, mongo_pool_size:'2'}, undefined, true);
+    assert.equal(store.client.options.retryWrites, true);
+    assert.equal(store.client.options.writeConcern.w, 'majority');
+    const updates = [];
+    const bus = new EventEmitter();
+    bus.on('data-update', event => updates.push(event));
+    const entries = req('./lib/server/entries')({entries_collection:'entries'}, {
+      store, bus, purifier:req('./lib/server/purifier')(), ddata:{processRawDataForRuntime:docs => docs}
+    });
+    const makeEntry = (index, sgv) => ({identifier:'owned-replica-' + index,
+      date:1700000000000 + index * 300000, type:'sgv', sgv});
+    await entries.create([makeEntry(0, 100)]);
+    const initial = await entries.list({find:{date:{$gte:0}}});
+    assert.equal(initial.length, 1);
+    const ids = new Map([[initial[0].identifier, initial[0]._id.toHexString()]]);
+    for (let cycle = 1; cycle <= 2; cycle++) {
+      try {
+        await monitor.db('admin').command({replSetStepDown:5, force:true});
+      } catch (error) {
+        // Some server/driver combinations close the connection after stepdown.
+        if (error.name !== 'MongoNetworkError') throw error;
+      }
+      // No application retry loop: exercise the real storage/client behavior
+      // while the topology is changing, using majority-acknowledged writes.
+      await entries.create([makeEntry(cycle, 100 + cycle)]);
+      const next = await primary(monitor, current);
+      transitions.push({from:current, to:next});
+      current = next;
+      let rows = await entries.list({find:{date:{$gte:0}}});
+      assert.equal(rows.length, cycle + 1);
+      const inserted = rows.find(row => row.identifier === 'owned-replica-' + cycle);
+      assert(inserted);
+      ids.set(inserted.identifier, inserted._id.toHexString());
+      await entries.create([makeEntry(cycle, 200 + cycle)]);
+      rows = await entries.list({find:{date:{$gte:0}}});
+      assert.equal(rows.length, cycle + 1);
+      assert.equal(new Set(rows.map(row => row._id.toHexString())).size, rows.length);
+      for (const [identifier, id] of ids) {
+        assert.equal(rows.find(row => row.identifier === identifier)._id.toHexString(), id);
+      }
+      assert.equal(rows.find(row => row.identifier === inserted.identifier).sgv, 200 + cycle);
+      assert.equal(rows[0].identifier, inserted.identifier);
+    }
+    const stats = await store.db.stats();
+    assert.equal(stats.db, database);
+    assert.equal(stats.objects, 3);
+    assert.equal(updates.length, 5);
+    console.log(JSON.stringify({driver:req('mongodb/package.json').version, node:process.version,
+      server:(await monitor.db('admin').command({buildInfo:1})).version,
+      transitions, records:3, updates:updates.length, statsObjects:stats.objects}));
+  } finally {
+    try {if (store) await store.db.dropDatabase();}
+    finally {
+      if (store?.client) await store.client.close();
+      await monitor.close();
+    }
+  }
+})().catch(error => {console.error(error); process.exitCode = 1;});


### PR DESCRIPTION
Adds replica-set continuity coverage for M29 before merging the MongoDB driver migration. The existing backend matrix uses standalone servers and cannot detect failures across primary changes.

Eight new CI jobs cover both Node floors (22.23.2 / 24.20.0) and MongoDB 5.0.32, 6.0.27, 7.0.40 and 8.0.29. Each uses three disposable members and the actual Nightscout storage initializer and entries adapter. Writes begin immediately after two primary stepdowns; assertions cover reads, stable identifiers, duplicate prevention, ordering, update events and database statistics. Docker validation and publishing builds depend on the new matrix.

Local validation: all four combinations of drivers 5.9.2 / 7.6.0 and both Node floors passed against MongoDB 8.0.29. Committed JSON records transitions and the tested validator hash. Workflow YAML, eight matrix combinations and both Docker job dependencies validated. Hosted CI remains pending.

This proves continuity during commanded primary changes. It does not prove an injected failed write was retried or cover process crashes, network partitions, TLS/authentication, live Atlas, backup/restore or deployment rollback. No production dependency, runtime or UI change. The driver upgrade remains in draft #8661 with its other gates open.

Targets `chore/nightscout-modernization`; integration #8605 remains draft into `dev`.
