### PR TITLE
test: review native watch against the development restart policy

### DIFF
--- a/docs/audits/development-watch.json
+++ b/docs/audits/development-watch.json
@@ -1,0 +1,282 @@
+{
+  "sourceSHA256": "9a37b0585a08baf10643663ce7e50c31f3e54f13b5f69456dd708468f1a76d9c",
+  "scope": "Owned macOS fixtures, Node floors pinned for parent and children. Single sample of two update cycles per variant; no CPU/memory or IDE reconnect measurement. Source hash includes defensive already-exited-process and SIGTERM cleanup added after these successful samples.",
+  "samples": [
+    {
+      "node": "v22.23.2",
+      "platform": "Darwin",
+      "nodemon": "3.1.14",
+      "configuration": {
+        "ignore": [
+          "tests/*",
+          "node_modules/*",
+          "bin/*"
+        ]
+      },
+      "variants": {
+        "nodemon": {
+          "initial": {
+            "pid": 88418,
+            "inspectorReachable": true
+          },
+          "cycles": [
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 1,
+              "node_modules/owned-watch-dep/index.js": 0,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 88545,
+                "inspectorReachable": true
+              }
+            },
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 1,
+              "node_modules/owned-watch-dep/index.js": 0,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 88696,
+                "inspectorReachable": true
+              }
+            }
+          ],
+          "boots": [
+            {
+              "boot": true,
+              "pid": 88418,
+              "node": "v22.23.2",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 88472,
+              "node": "v22.23.2",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 88545,
+              "node": "v22.23.2",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 88617,
+              "node": "v22.23.2",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 88696,
+              "node": "v22.23.2",
+              "value": 2
+            }
+          ]
+        },
+        "native": {
+          "initial": {
+            "pid": 88713,
+            "inspectorReachable": true
+          },
+          "cycles": [
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 0,
+              "node_modules/owned-watch-dep/index.js": 1,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 88890,
+                "inspectorReachable": true
+              }
+            },
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 0,
+              "node_modules/owned-watch-dep/index.js": 1,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 88923,
+                "inspectorReachable": true
+              }
+            }
+          ],
+          "boots": [
+            {
+              "boot": true,
+              "pid": 88713,
+              "node": "v22.23.2",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 88851,
+              "node": "v22.23.2",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 88890,
+              "node": "v22.23.2",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 88917,
+              "node": "v22.23.2",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 88923,
+              "node": "v22.23.2",
+              "value": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "node": "v24.20.0",
+      "platform": "Darwin",
+      "nodemon": "3.1.14",
+      "configuration": {
+        "ignore": [
+          "tests/*",
+          "node_modules/*",
+          "bin/*"
+        ]
+      },
+      "variants": {
+        "nodemon": {
+          "initial": {
+            "pid": 88514,
+            "inspectorReachable": true
+          },
+          "cycles": [
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 1,
+              "node_modules/owned-watch-dep/index.js": 0,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 88662,
+                "inspectorReachable": true
+              }
+            },
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 1,
+              "node_modules/owned-watch-dep/index.js": 0,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 88845,
+                "inspectorReachable": true
+              }
+            }
+          ],
+          "boots": [
+            {
+              "boot": true,
+              "pid": 88514,
+              "node": "v24.20.0",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 88585,
+              "node": "v24.20.0",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 88662,
+              "node": "v24.20.0",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 88796,
+              "node": "v24.20.0",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 88845,
+              "node": "v24.20.0",
+              "value": 2
+            }
+          ]
+        },
+        "native": {
+          "initial": {
+            "pid": 88888,
+            "inspectorReachable": true
+          },
+          "cycles": [
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 0,
+              "node_modules/owned-watch-dep/index.js": 1,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 88922,
+                "inspectorReachable": true
+              }
+            },
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 0,
+              "node_modules/owned-watch-dep/index.js": 1,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 88937,
+                "inspectorReachable": true
+              }
+            }
+          ],
+          "boots": [
+            {
+              "boot": true,
+              "pid": 88888,
+              "node": "v24.20.0",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 88916,
+              "node": "v24.20.0",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 88922,
+              "node": "v24.20.0",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 88932,
+              "node": "v24.20.0",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 88937,
+              "node": "v24.20.0",
+              "value": 2
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/docs/audits/development-watch.json
+++ b/docs/audits/development-watch.json
@@ -278,5 +278,154 @@
         }
       }
     }
-  ]
+  ],
+  "debuggerFollowup": {
+    "sourceSHA256": "31d2d38dab61215b82ba862d9dbdc15ad8fcfafa355afc2eae53a97afddcbac9",
+    "scope": "Actual WebSocket inspector attachment and process.pid evaluation after each restart. Node 22 Mocha regression passed; Node 24 raw probe follows. Final source additionally isolates the inspector client environment; local samples had no injected NODE_OPTIONS.",
+    "node22Regression": "1 passing, two update cycles per watcher",
+    "node24": {
+      "node": "v24.20.0",
+      "platform": "Darwin",
+      "nodemon": "3.1.14",
+      "configuration": {
+        "ignore": [
+          "tests/*",
+          "node_modules/*",
+          "bin/*"
+        ]
+      },
+      "variants": {
+        "nodemon": {
+          "initial": {
+            "pid": 93032,
+            "inspectorReachable": true,
+            "inspectorEvaluatedPid": 93032
+          },
+          "cycles": [
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 1,
+              "node_modules/owned-watch-dep/index.js": 0,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 93121,
+                "inspectorReachable": true,
+                "inspectorEvaluatedPid": 93121
+              }
+            },
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 1,
+              "node_modules/owned-watch-dep/index.js": 0,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 93205,
+                "inspectorReachable": true,
+                "inspectorEvaluatedPid": 93205
+              }
+            }
+          ],
+          "boots": [
+            {
+              "boot": true,
+              "pid": 93032,
+              "node": "v24.20.0",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 93080,
+              "node": "v24.20.0",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 93121,
+              "node": "v24.20.0",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 93169,
+              "node": "v24.20.0",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 93205,
+              "node": "v24.20.0",
+              "value": 2
+            }
+          ]
+        },
+        "native": {
+          "initial": {
+            "pid": 93223,
+            "inspectorReachable": true,
+            "inspectorEvaluatedPid": 93223
+          },
+          "cycles": [
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 0,
+              "node_modules/owned-watch-dep/index.js": 1,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 93238,
+                "inspectorReachable": true,
+                "inspectorEvaluatedPid": 93238
+              }
+            },
+            {
+              "tests/ignored.js": 0,
+              "bin/ignored.js": 0,
+              "static/unimported.js": 0,
+              "node_modules/owned-watch-dep/index.js": 1,
+              "lib/loaded.js": 1,
+              "debuggerAfterRestart": {
+                "pid": 93259,
+                "inspectorReachable": true,
+                "inspectorEvaluatedPid": 93259
+              }
+            }
+          ],
+          "boots": [
+            {
+              "boot": true,
+              "pid": 93223,
+              "node": "v24.20.0",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 93233,
+              "node": "v24.20.0",
+              "value": 0
+            },
+            {
+              "boot": true,
+              "pid": 93238,
+              "node": "v24.20.0",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 93254,
+              "node": "v24.20.0",
+              "value": 1
+            },
+            {
+              "boot": true,
+              "pid": 93259,
+              "node": "v24.20.0",
+              "value": 2
+            }
+          ]
+        }
+      }
+    }
+  }
 }

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -127,7 +127,7 @@ Each row is a separate candidate PR after M01; entries marked M07 also need the 
 | [x] **M21** | `mongo-url-parser` → existing driver parsing; `lib/server/env.js` | Test SRV, multi-host, IPv6, encoded/no credentials, valid driver options, invalid URI and API-secret/password comparison. Do not substitute Node URL for MongoDB's grammar or connect just to parse. Remove one legacy parser after confirming driver-supported API stability. |
 | [ ] **M22** | Consolidate `forwarded-for` consumers in auth/status/API3/websocket modules | Define trusted-proxy/header policy first; cover raw Socket.IO requests as well as Express, IPv4/IPv6/ports, Fastly/X-Real-IP/Z-Forwarded precedence and spoofing. Package removal requires demonstrated equivalent or explicitly approved changed behavior. |
 | [x] **M23** | Narrow `traverse` operations; `lib/server/query.js` | Characterize nested query operators, arrays, ObjectIds, strings, nulls, mutation/prototype hazards and error behavior before writing a scoped walker. Remove only if local code is simpler and every query-security fixture passes. |
-| [ ] **M24** | `env-cmd`/`nodemon` → Node CLI capabilities; package scripts and developer docs (after M07) | Preserve or explicitly document env-file precedence: env-cmd overrides inherited env, native --env-file does the reverse. Test quoting/multiline values and Mocha/nyc children. Verify watch ignores, Linux support, inspector reconnect and no restart storms. Separate PRs; no production RAM claim. |
+| [x] **M24** | `env-cmd`/`nodemon` → Node CLI capabilities; package scripts and developer docs (after M07) | Preserve or explicitly document env-file precedence: env-cmd overrides inherited env, native --env-file does the reverse. Test quoting/multiline values and Mocha/nyc children. Verify watch ignores, Linux support, inspector reconnect and no restart storms. Separate PRs; no production RAM claim. |
 | [ ] **M25** | Review one bounded TTL helper for `node-cache`/`memory-cache`; pushnotify and `lib/profilefunctions.js` (after M05) | Specify clone/reference semantics separately, null/zero, cache bounds, TTL/extension, 5-second profile expiry, clear/profile-switch and timers/shutdown. Fake-clock tests plus repeated real workload/heap measurements; an unbounded Map is unacceptable. Retain a maintained cache if local complexity grows. |
 | [x] **M26** | Avoid repeated percentile sorts, then consider local statistics; `lib/report_plugins/{percentile,dailystats,hourlystats,success,glucosedistribution}.js` | First use the current quantile API's probability array to sort once per bin. Preserve empty/single/even/odd/repeated/unsorted inputs, boundary percentiles, population deviation and source arrays. `[1,2,3,4]` q25 must remain 1.5 and population deviation approximately 1.118; D3 defaults differ. Golden reports in both units and across DST must pass before any simple-statistics removal. Record sort/allocation/time reduction separately from package count. |
 
@@ -234,7 +234,7 @@ After the #8644 batching change, a scoped three-operation statistics module can 
 
 ### M24 compatible Node runner in progress
 
-Native --env-file changes both precedence and parsing of existing values, so the first slice uses a scoped Node runner with the existing .env grammar and file-wins policy. [Process contracts and validation](../test-specs/env-runner.md) cover startup flags, nyc/Mocha children and repeated signal handling. Two installed package paths are removed; nodemon/watch remains a separate unfinished slice.
+Native --env-file changes both precedence and parsing of existing values, so the first slice uses a scoped Node runner with the existing .env grammar and file-wins policy. [Process contracts and validation](../test-specs/env-runner.md) cover startup flags, nyc/Mocha children and repeated signal handling. Two installed package paths are removed; the nodemon/watch retain decision is recorded below.
 
 ### M19 completed import client retain decision
 
@@ -260,12 +260,17 @@ six-page/bundle/static/Socket.IO checks on both supported Node floors. The
 implementation is integrated; M10 stays open for final image/build-time
 measurements and live hosting release gates. See the build/runtime specification.
 
-### M24 watch decision proposal
+### M24 watch retain decision
 
-The [watch review](../test-specs/development-watch.md) proposes retaining nodemon
-3.1.14. Owned probes on both Node floors show native watch changes unimported
-application-file coverage and imported-dependency ignore behavior. Both watchers
-restart imported application code and expose a fresh inspector target twice.
-A reproducible probe and POSIX CI regression record these contracts. Hosted Linux
-and Windows/IDE validation or explicit release gating remain; M24 is not yet
-complete. No package or production runtime change is made by this proposal.
+The [watch review](../test-specs/development-watch.md) retains nodemon 3.1.14.
+Owned probes on both Node floors show native watch changes unimported application
+file coverage and imported-dependency ignore behavior. Both watchers restart
+application code twice; the strengthened probe attaches to each new inspector
+and evaluates its PID. The original policy comparison passed the complete hosted
+matrix, including Linux. Fresh checks for this strengthened candidate and current
+integration base are required before merge. Windows watch behavior and scripts
+are unchanged; overall Node hosting release gates remain separate. Together with
+the merged env-cmd replacement, this completes the M24 implementation decision.
+Revisit when Node provides equivalent portable watch/ignore behavior or the
+project explicitly changes its development restart contract. No production
+runtime or memory improvement is claimed for retaining a development tool.

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -244,8 +244,28 @@ Native fetch's default proxy behavior differs on both supported Node floors. The
 
 The remaining M08, M19, M23 and M26 candidates are assembled into one verification branch to test interactions and avoid serial CI/base-refresh churn. [Inputs and merge checks](../test-specs/cleanup-integration.md) identify the exact source heads. Completed in #8652, merged as `e3e3ec8f`, after all required checks passed on `2207cbf0` and actual merge tree `6a6b03ef` matched verification. GitHub marked all six source PRs merged. This completes M08, M19, M23 and M26; the source PR notes retain detailed validation and measurements.
 
-### M25 profile-cache candidate
+### M25 profile-cache and receipt implementation
 
-A bounded reference cache replaces memory-cache's per-entry timers while preserving the application's five-second get/put/clear contracts. [Workload measurements and limits](../test-specs/profile-cache.md) explain the cap selection, lower retained heap and unchanged output totals. Notification-cache policy and full candidate validation remain open; M25 is not yet complete.
+A bounded reference cache replaces memory-cache's per-entry timers while preserving the application's five-second get/put/clear contracts. [Workload measurements and limits](../test-specs/profile-cache.md) explain the cap selection, lower retained heap and unchanged output totals. The profile cache merged in #8653 after validation; #8658 additionally reduces receipt payloads to acknowledgement fields. Notification-cache policy and the final retain/replace decision remain open; M25 is not yet complete.
 
 - M29 replica-set baseline: add eight CI jobs across both Node floors and MongoDB 5/6/7/8, exercising the actual entries/storage adapters through two primary changes. Local driver 5.9.2 and proposed 7.6.0 comparisons pass on both Node floors with MongoDB 8.0.29; see [scope and evidence](../test-specs/mongodb-replica-set.md). Hosted validation and the remaining TLS, deployment and backup/restore gates must pass before claiming the driver migration complete.
+
+### M10 implementation and remaining release evidence
+
+#8657 merged as `0181cc99` after all 12 backend, eight replica-set, six browser,
+npm 12, CodeQL and both Docker checks passed on `b6e8c7cd`. The actual merge tree
+`5f3a6ae7f6caaa7db0573bc65e0396bb885914f8` matches the independently reviewed tree.
+Fresh install/build/prune artifacts pass real npm-start/database/config-import/
+six-page/bundle/static/Socket.IO checks on both supported Node floors. The
+implementation is integrated; M10 stays open for final image/build-time
+measurements and live hosting release gates. See the build/runtime specification.
+
+### M24 watch decision proposal
+
+The [watch review](../test-specs/development-watch.md) proposes retaining nodemon
+3.1.14. Owned probes on both Node floors show native watch changes unimported
+application-file coverage and imported-dependency ignore behavior. Both watchers
+restart imported application code and expose a fresh inspector target twice.
+A reproducible probe and POSIX CI regression record these contracts. Hosted Linux
+and Windows/IDE validation or explicit release gating remain; M24 is not yet
+complete. No package or production runtime change is made by this proposal.

--- a/docs/test-specs/development-watch.md
+++ b/docs/test-specs/development-watch.md
@@ -1,0 +1,45 @@
+# Development watch review (M24)
+
+Proposal: retain nodemon 3.1.14 for `dev` and `dev-test` in this modernization
+release. The registry reports that version as current on 2026-09-06. The native
+environment runner has already removed env-cmd; npm start never invokes nodemon,
+so removing this development tool would not reduce server runtime memory.
+
+The current nodemon configuration ignores tests, node_modules and bin. In owned
+fixtures on Node 22.23.2 and 24.20.0, two update cycles show:
+
+| Changed file | nodemon restarts | Native watch restarts |
+| --- | --- | --- |
+| tests/ignored.js | 0 | 0 |
+| bin/ignored.js | 0 | 0 |
+| static/unimported.js | 1 | 0 |
+| Imported node_modules dependency | 0 | 1 |
+| Imported lib module | 1 | 1 |
+
+Both restart the application module with updated exports and expose a new live
+Node inspector target after each cycle. This verifies inspector discovery, not
+an actual VS Code debugger reconnect. No unexpected extra restart occurred in
+the bounded 1.5-second observation windows; this is not a general stress or
+network-filesystem guarantee. Initial probes without explicit child-runtime
+pinning were discarded; recorded probes assert each child uses the chosen Node.
+
+`tools/probe-development-watch.py` uses temporary owned files and process groups,
+loads the repository's nodemon ignore configuration explicitly, and cleans up
+children and files. It never starts Nightscout or accesses a database. The Node
+regression runs the same comparison on POSIX CI; Windows is skipped explicitly.
+The raw local measurements are in `../audits/development-watch.json`.
+
+Node's [watch documentation](https://nodejs.org/docs/latest-v22.x/api/cli.html#--watch)
+describes module-based default watching. Explicit watch paths have platform
+limits; a drop-in switch cannot be assumed to preserve our Linux workflow or
+ignore policy. [Nodemon's documented configuration](https://github.com/remy/nodemon)
+supports those ignores and broader application-file watching. Reimplementing
+that policy, process lifecycle and platform behavior locally would add a watcher
+framework to remove one development dependency. Retaining it is the simpler
+proposal until native watch can meet these contracts on every supported platform.
+
+Remaining before closing M24: hosted Linux comparison, explicit Windows/IDE
+validation or a documented release gate, and final review of the retain decision.
+Revisit when Node supports the required ignore/watch policy portably or the
+project explicitly changes its development restart contract. No package/runtime
+change is made by this review, and M24 remains unchecked pending those gates.

--- a/docs/test-specs/development-watch.md
+++ b/docs/test-specs/development-watch.md
@@ -1,6 +1,6 @@
 # Development watch review (M24)
 
-Proposal: retain nodemon 3.1.14 for `dev` and `dev-test` in this modernization
+Decision: retain nodemon 3.1.14 for `dev` and `dev-test` in this modernization
 release. The registry reports that version as current on 2026-09-06. The native
 environment runner has already removed env-cmd; npm start never invokes nodemon,
 so removing this development tool would not reduce server runtime memory.
@@ -16,9 +16,10 @@ fixtures on Node 22.23.2 and 24.20.0, two update cycles show:
 | Imported node_modules dependency | 0 | 1 |
 | Imported lib module | 1 | 1 |
 
-Both restart the application module with updated exports and expose a new live
-Node inspector target after each cycle. This verifies inspector discovery, not
-an actual VS Code debugger reconnect. No unexpected extra restart occurred in
+Both restart the application module with updated exports. The strengthened
+probe connects to each new inspector over its WebSocket protocol and evaluates
+process.pid, verifying the reply identifies the restarted child. This tests
+debugger attachment after restart, not VS Code UI automation. No unexpected extra restart occurred in
 the bounded 1.5-second observation windows; this is not a general stress or
 network-filesystem guarantee. Initial probes without explicit child-runtime
 pinning were discarded; recorded probes assert each child uses the chosen Node.
@@ -35,11 +36,15 @@ limits; a drop-in switch cannot be assumed to preserve our Linux workflow or
 ignore policy. [Nodemon's documented configuration](https://github.com/remy/nodemon)
 supports those ignores and broader application-file watching. Reimplementing
 that policy, process lifecycle and platform behavior locally would add a watcher
-framework to remove one development dependency. Retaining it is the simpler
-proposal until native watch can meet these contracts on every supported platform.
+framework to remove one development dependency. Retaining it preserves the existing workflow with less local code until native
+watch can meet these contracts on every supported platform.
 
-Remaining before closing M24: hosted Linux comparison, explicit Windows/IDE
-validation or a documented release gate, and final review of the retain decision.
+The previous head passed every hosted check, including the Linux watch-policy
+comparison. Fresh hosted checks are required for the strengthened debugger probe
+and integration refresh before merging. No Windows watch implementation or
+package script changes are introduced by retaining nodemon; the overall Node
+runtime rollout still has its separate hosting/Windows release gates.
 Revisit when Node supports the required ignore/watch policy portably or the
-project explicitly changes its development restart contract. No package/runtime
-change is made by this review, and M24 remains unchecked pending those gates.
+project explicitly changes its development restart contract. No package/runtime change is made by retaining nodemon. Together with the
+merged environment-runner work, this completes the M24 implementation decision;
+the candidate must pass its fresh CI before integration.

--- a/tests/development-watch.test.js
+++ b/tests/development-watch.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const {execFile} = require('node:child_process');
+const {promisify} = require('node:util');
+
+(process.platform === 'win32' ? describe.skip : describe)('Development watch policy', function () {
+  this.timeout(120000);
+  it('preserves configured ignores and application watching through two restart cycles', async function () {
+    const root = path.resolve(__dirname, '..');
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'nightscout-watch-result-'));
+    const output = path.join(tmp, 'result.json');
+    try {
+      await promisify(execFile)('python3', [path.join(root, 'tools/probe-development-watch.py'),
+        '--node', process.execPath, '--dependency-root', root, '--output', output], {timeout:100000});
+      const result = JSON.parse(await fs.readFile(output, 'utf8'));
+      assert.equal(result.node, process.version);
+      for (const [mode, expected] of Object.entries({
+        nodemon:{'tests/ignored.js':0, 'bin/ignored.js':0, 'static/unimported.js':1, 'node_modules/owned-watch-dep/index.js':0, 'lib/loaded.js':1},
+        native:{'tests/ignored.js':0, 'bin/ignored.js':0, 'static/unimported.js':0, 'node_modules/owned-watch-dep/index.js':1, 'lib/loaded.js':1}
+      })) {
+        const variant = result.variants[mode];
+        assert.equal(variant.cycles.length, 2);
+        let previous = variant.initial.pid;
+        for (const cycle of variant.cycles) {
+          for (const [file, count] of Object.entries(expected)) assert.equal(cycle[file], count, mode + ': ' + file);
+          assert.equal(cycle.debuggerAfterRestart.inspectorReachable, true);
+          assert.notEqual(cycle.debuggerAfterRestart.pid, previous);
+          previous = cycle.debuggerAfterRestart.pid;
+        }
+      }
+    } finally {await fs.rm(tmp, {recursive:true, force:true});}
+  });
+});

--- a/tests/development-watch.test.js
+++ b/tests/development-watch.test.js
@@ -28,6 +28,7 @@ const {promisify} = require('node:util');
         for (const cycle of variant.cycles) {
           for (const [file, count] of Object.entries(expected)) assert.equal(cycle[file], count, mode + ': ' + file);
           assert.equal(cycle.debuggerAfterRestart.inspectorReachable, true);
+          assert.equal(cycle.debuggerAfterRestart.inspectorEvaluatedPid, cycle.debuggerAfterRestart.pid);
           assert.notEqual(cycle.debuggerAfterRestart.pid, previous);
           previous = cycle.debuggerAfterRestart.pid;
         }

--- a/tools/probe-development-watch.py
+++ b/tools/probe-development-watch.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Compare owned watch fixtures; does not start Nightscout or touch its data."""
+import argparse, json, os, pathlib, re, selectors, signal, subprocess, tempfile, time, urllib.request
+
+p = argparse.ArgumentParser()
+p.add_argument('--node', required=True)
+p.add_argument('--dependency-root', required=True)
+p.add_argument('--output', required=True)
+a = p.parse_args()
+def terminate(signum, frame):
+    raise SystemExit(128 + signum)
+signal.signal(signal.SIGTERM, terminate)
+repo = pathlib.Path(__file__).resolve().parents[1]
+package = json.loads((repo / 'package.json').read_text())
+dep = pathlib.Path(a.dependency_root).resolve()
+node = str(pathlib.Path(a.node).resolve())
+results = {'node': subprocess.check_output([node, '--version'], text=True).strip(),
+           'platform': os.uname().sysname, 'nodemon': json.loads((dep / 'node_modules/nodemon/package.json').read_text())['version'],
+           'configuration': package['nodemonConfig'], 'variants': {}}
+for mode in ['nodemon', 'native']:
+    with tempfile.TemporaryDirectory(prefix='nightscout-owned-watch-') as tmp:
+        root = pathlib.Path(tmp)
+        for folder in ['lib', 'static', 'tests', 'bin', 'node_modules/owned-watch-dep']:
+            (root / folder).mkdir(parents=True)
+        (root / 'watch.json').write_text(json.dumps(package['nodemonConfig']))
+        (root / 'lib/loaded.js').write_text('module.exports=0;\n')
+        (root / 'static/unimported.js').write_text('// initial\n')
+        (root / 'node_modules/owned-watch-dep/index.js').write_text('module.exports=0;\n')
+        (root / 'lib/main.js').write_text("const value=require('./loaded');require('owned-watch-dep');console.log(JSON.stringify({boot:true,pid:process.pid,node:process.version,value}));setInterval(()=>{},1000);process.on('SIGTERM',()=>process.exit(0));\n")
+        command = [node]
+        if mode == 'nodemon':
+            command += [str(dep / 'node_modules/nodemon/bin/nodemon.js'), '--config', str(root / 'watch.json')]
+        else:
+            command += ['--watch', '--watch-preserve-output']
+        command += ['--inspect=127.0.0.1:0', 'lib/main.js']
+        child = subprocess.Popen(command, cwd=root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                 start_new_session=True, bufsize=0,
+                                 env={'PATH': str(pathlib.Path(node).parent) + os.pathsep + os.environ.get('PATH', ''), 'NODE_ENV': 'test'})
+        selector = selectors.DefaultSelector(); selector.register(child.stdout, selectors.EVENT_READ)
+        pending = b''; boots = []; inspectors = []; lines = []
+        def observe(seconds):
+            global pending
+            deadline = time.monotonic() + seconds
+            while time.monotonic() < deadline:
+                if child.poll() is not None:
+                    raise RuntimeError('Watcher stopped: ' + '\n'.join(lines[-20:]))
+                for key, _ in selector.select(min(.1, max(0, deadline-time.monotonic()))):
+                    chunk = os.read(key.fileobj.fileno(), 65536)
+                    if not chunk: continue
+                    pending += chunk
+                    while b'\n' in pending:
+                        line, pending = pending.split(b'\n', 1)
+                        line = line.decode(errors='replace'); lines.append(line)
+                        if line.startswith('{"boot":'):
+                            boot = json.loads(line)
+                            assert boot['node'] == results['node'], ('Unexpected child runtime', boot)
+                            boots.append(boot)
+                        match = re.search(r'ws://127\.0\.0\.1:(\d+)/', line)
+                        if match: inspectors.append(int(match.group(1)))
+        def wait_boot(count):
+            deadline = time.monotonic() + 10
+            while len(boots) < count and time.monotonic() < deadline: observe(.1)
+            if len(boots) != count: raise AssertionError(('boot count', mode, count, boots, lines[-10:]))
+        def inspector():
+            with urllib.request.urlopen('http://127.0.0.1:' + str(inspectors[-1]) + '/json/list', timeout=2) as response:
+                targets = json.load(response)
+            assert len(targets) == 1 and targets[0]['type'] == 'node'
+            return {'pid': boots[-1]['pid'], 'inspectorReachable': True}
+        try:
+            wait_boot(1); observe(1)
+            record = {'initial': inspector(), 'cycles': []}
+            for cycle in range(2):
+                sample = {}
+                for file in ['tests/ignored.js', 'bin/ignored.js', 'static/unimported.js', 'node_modules/owned-watch-dep/index.js', 'lib/loaded.js']:
+                    before = len(boots)
+                    content = 'module.exports=' + str(cycle+1) + ';\n'
+                    (root / file).write_text(content)
+                    observe(1.5)
+                    sample[file] = len(boots)-before
+                    if file == 'lib/loaded.js':
+                        wait_boot(before+1)
+                        assert boots[-1]['value'] == cycle+1
+                        sample['debuggerAfterRestart'] = inspector()
+                record['cycles'].append(sample)
+            record['boots'] = boots
+            results['variants'][mode] = record
+        finally:
+            try: os.killpg(child.pid, signal.SIGTERM)
+            except ProcessLookupError: pass
+            try: child.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(child.pid, signal.SIGKILL); child.wait(timeout=5)
+            selector.close(); child.stdout.close()
+pathlib.Path(a.output).write_text(json.dumps(results, indent=2)+'\n')
+print(json.dumps(results, indent=2))

--- a/tools/probe-development-watch.py
+++ b/tools/probe-development-watch.py
@@ -62,10 +62,30 @@ for mode in ['nodemon', 'native']:
             while len(boots) < count and time.monotonic() < deadline: observe(.1)
             if len(boots) != count: raise AssertionError(('boot count', mode, count, boots, lines[-10:]))
         def inspector():
-            with urllib.request.urlopen('http://127.0.0.1:' + str(inspectors[-1]) + '/json/list', timeout=2) as response:
+            with urllib.request.build_opener(urllib.request.ProxyHandler({})).open('http://127.0.0.1:' + str(inspectors[-1]) + '/json/list', timeout=2) as response:
                 targets = json.load(response)
             assert len(targets) == 1 and targets[0]['type'] == 'node'
-            return {'pid': boots[-1]['pid'], 'inspectorReachable': True}
+            target = targets[0]['webSocketDebuggerUrl']
+            assert target.startswith('ws://127.0.0.1:' + str(inspectors[-1]) + '/')
+            # Connect to the new process's inspector, not merely its discovery URL.
+            script = """
+const assert = require('node:assert/strict');
+const socket = new WebSocket(process.argv[1]);
+const timeout = setTimeout(() => process.exit(2), 4000);
+socket.addEventListener('error', () => process.exit(3));
+socket.addEventListener('open', () => socket.send(JSON.stringify({id:1,method:'Runtime.evaluate',params:{expression:'process.pid',returnByValue:true}})));
+socket.addEventListener('message', event => {
+  const response = JSON.parse(event.data);
+  if (response.id !== 1) return;
+  assert.equal(response.result.result.value, Number(process.argv[2]));
+  console.log(response.result.result.value);
+  socket.close();
+});
+socket.addEventListener('close', () => clearTimeout(timeout));
+"""
+            evaluated = int(subprocess.check_output([node, '-e', script, target, str(boots[-1]['pid'])], timeout=6, text=True, env={'PATH': str(pathlib.Path(node).parent) + os.pathsep + os.environ.get('PATH', ''), 'NODE_ENV': 'test'}))
+            assert evaluated == boots[-1]['pid']
+            return {'pid': boots[-1]['pid'], 'inspectorReachable': True, 'inspectorEvaluatedPid': evaluated}
         try:
             wait_boot(1); observe(1)
             record = {'initial': inspector(), 'cycles': []}


### PR DESCRIPTION
Records the decision to retain nodemon 3.1.14 for the existing development workflow. Native Node watch does not preserve the current restart policy: in owned probes on both Node floors, it misses unimported application JavaScript changes and restarts on imported node_modules changes that nodemon ignores. Recreating portable watch/ignore and process behavior would add complexity to remove a development-only dependency.

Adds a reproducible POSIX probe and CI regression with two update cycles for ignored tests/bin files, unimported application files, imported dependencies and application modules. It pins parent/child Node versions, verifies changed exports and live inspector discovery after restarts, and cleans up owned process groups/files. The prior head passed the complete hosted matrix, including Linux. Follow-up eaebf0ab adds actual WebSocket debugger attachment and process.pid evaluation after each restart; the strengthened Node 22 regression and Node 24 raw probe pass. It also refreshes the branch onto integration ab7e33fa. Fresh hosted checks are required. No VS Code UI automation is claimed.

No dependency or production runtime behavior changes. The candidate marks the M24 implementation decision complete alongside the merged env-cmd replacement, but it must pass fresh CI before integration. Overall Node hosting/Windows release gates remain separate; retaining nodemon changes no Windows watcher or script behavior. The plan also records merged #8657 and #8653/#8658 accurately without claiming their remaining release/cache-policy work complete.

Targets `chore/nightscout-modernization`; #8605 remains draft into dev.
