### PR TITLE
docs: review legacy bridge dependencies and TLS migration requirements

### DIFF
--- a/docs/audits/legacy-bridge-source-hashes.json
+++ b/docs/audits/legacy-bridge-source-hashes.json
@@ -1,0 +1,13 @@
+{
+  "node_modules/request/lib/redirect.js": "4056494e80f0354a6253c6fc08a526bf10920c1b2bb517efb1249945a1291672",
+  "node_modules/request/lib/auth.js": "033318b8870b4a942c02fe04f8a9dce0930d9160399671f4c21806083681d994",
+  "node_modules/request/lib/oauth.js": "53fdc5f23d96f57db1e2a2152fc156949b37fccb5d3d9a39e035e919233798cb",
+  "node_modules/request/lib/multipart.js": "af2c0b45347049efcd475a47c15bd448fc714482d34b2caf7e3c912bef3ecf43",
+  "node_modules/share2nightscout-bridge/index.js": "0dc7198e24693c72a9a5e7284561d989a05a4b751739cadb3154eccbce8edf21",
+  "node_modules/minimed-connect-to-nightscout/index.js": "a9fb0b34d5552c86ea8954d7b257dd04354bdde16d093ce02193efcc2c796837",
+  "node_modules/minimed-connect-to-nightscout/nightscout.js": "12aee756b89cc6c810647c9a22241a0d6b14502ccc02ef9300648c6ec3e0d76c",
+  "lib/plugins/bridge.js": "494240ae2da288b2022a0c65d42c03b488fab4159cb117faec557aa75f5a45cf",
+  "lib/plugins/mmconnect.js": "d6de93f2ccdb8a6c14ffd1f1c946c34313899360b8df9e673f7ec7baef5b508a",
+  "lib/server/bridge-connect-compat.js": "aeb2db47de4f5de94cd470cac1d4c3fc290ba628c7f3424e911182ef916b0fe6",
+  "lib/server/bootevent.js": "39a7d2bba6660fc677b45968bef1f8d71e8621dd31dc5ab8a3835ab26a299e61"
+}

--- a/docs/audits/legacy-bridge-transport.json
+++ b/docs/audits/legacy-bridge-transport.json
@@ -1,0 +1,318 @@
+{
+  "sourceSHA256": "086571f84cc92a4c125fee6e82a2474d169c2868338c32968befd5af15660074",
+  "scope": "Owned loopback HTTP/TLS only, ephemeral self-signed certificate, fake credentials, two cycles per Node floor. Records unsafe legacy acceptance; not a correctness oracle or live vendor validation.",
+  "samples": [
+    {
+      "node": "v22.23.2",
+      "bridge": "0.2.12",
+      "minimed": "1.5.8",
+      "cycles": [
+        {
+          "strictClientRejectsUntrusted": true,
+          "trustedControlSucceeds": true,
+          "legacyAuthorizationAcceptsUntrusted": true,
+          "legacyGlucoseAcceptsUntrusted": true,
+          "redirects": [
+            {
+              "fromTLS": false,
+              "code": 301,
+              "status": 301,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 302,
+              "status": 302,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 303,
+              "status": 303,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 307,
+              "status": 307,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 308,
+              "status": 308,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 301,
+              "status": 301,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 302,
+              "status": 302,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 303,
+              "status": 303,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 307,
+              "status": 307,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 308,
+              "status": 308,
+              "targetHits": 0
+            }
+          ],
+          "minimedUpload": {
+            "rejected": true,
+            "targetHits": 0
+          }
+        },
+        {
+          "strictClientRejectsUntrusted": true,
+          "trustedControlSucceeds": true,
+          "legacyAuthorizationAcceptsUntrusted": true,
+          "legacyGlucoseAcceptsUntrusted": true,
+          "redirects": [
+            {
+              "fromTLS": false,
+              "code": 301,
+              "status": 301,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 302,
+              "status": 302,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 303,
+              "status": 303,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 307,
+              "status": 307,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 308,
+              "status": 308,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 301,
+              "status": 301,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 302,
+              "status": 302,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 303,
+              "status": 303,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 307,
+              "status": 307,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 308,
+              "status": 308,
+              "targetHits": 0
+            }
+          ],
+          "minimedUpload": {
+            "rejected": true,
+            "targetHits": 0
+          }
+        }
+      ],
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "warning": "Diagnostic observations are not a correctness oracle: accepting an untrusted TLS certificate is a known unresolved defect."
+    },
+    {
+      "node": "v24.20.0",
+      "bridge": "0.2.12",
+      "minimed": "1.5.8",
+      "cycles": [
+        {
+          "strictClientRejectsUntrusted": true,
+          "trustedControlSucceeds": true,
+          "legacyAuthorizationAcceptsUntrusted": true,
+          "legacyGlucoseAcceptsUntrusted": true,
+          "redirects": [
+            {
+              "fromTLS": false,
+              "code": 301,
+              "status": 301,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 302,
+              "status": 302,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 303,
+              "status": 303,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 307,
+              "status": 307,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 308,
+              "status": 308,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 301,
+              "status": 301,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 302,
+              "status": 302,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 303,
+              "status": 303,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 307,
+              "status": 307,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 308,
+              "status": 308,
+              "targetHits": 0
+            }
+          ],
+          "minimedUpload": {
+            "rejected": true,
+            "targetHits": 0
+          }
+        },
+        {
+          "strictClientRejectsUntrusted": true,
+          "trustedControlSucceeds": true,
+          "legacyAuthorizationAcceptsUntrusted": true,
+          "legacyGlucoseAcceptsUntrusted": true,
+          "redirects": [
+            {
+              "fromTLS": false,
+              "code": 301,
+              "status": 301,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 302,
+              "status": 302,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 303,
+              "status": 303,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 307,
+              "status": 307,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": false,
+              "code": 308,
+              "status": 308,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 301,
+              "status": 301,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 302,
+              "status": 302,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 303,
+              "status": 303,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 307,
+              "status": 307,
+              "targetHits": 0
+            },
+            {
+              "fromTLS": true,
+              "code": 308,
+              "status": 308,
+              "targetHits": 0
+            }
+          ],
+          "minimedUpload": {
+            "rejected": true,
+            "targetHits": 0
+          }
+        }
+      ],
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "warning": "Diagnostic observations are not a correctness oracle: accepting an untrusted TLS certificate is a known unresolved defect."
+    }
+  ]
+}

--- a/docs/audits/production-audit-2026-09-06.json
+++ b/docs/audits/production-audit-2026-09-06.json
@@ -117,5 +117,126 @@
         "total": 928
       }
     }
+  },
+  "followup": {
+    "baseline": "cbbd45810f3553a7e72526a4d456c2ad2e849ac9",
+    "node": "22.23.2",
+    "command": "npm audit --omit=dev --package-lock-only --json",
+    "audit": {
+      "auditReportVersion": 2,
+      "vulnerabilities": {
+        "minimed-connect-to-nightscout": {
+          "name": "minimed-connect-to-nightscout",
+          "severity": "moderate",
+          "isDirect": true,
+          "via": [
+            "request"
+          ],
+          "effects": [],
+          "range": "*",
+          "nodes": [
+            "node_modules/minimed-connect-to-nightscout"
+          ],
+          "fixAvailable": false
+        },
+        "request": {
+          "name": "request",
+          "severity": "moderate",
+          "isDirect": false,
+          "via": [
+            {
+              "source": 1096727,
+              "name": "request",
+              "dependency": "request",
+              "title": "Server-Side Request Forgery in Request",
+              "url": "https://github.com/advisories/GHSA-p8p7-x288-28g6",
+              "severity": "moderate",
+              "cwe": [
+                "CWE-918"
+              ],
+              "cvss": {
+                "score": 6.1,
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+              },
+              "range": "<=2.88.2"
+            },
+            "uuid"
+          ],
+          "effects": [
+            "minimed-connect-to-nightscout",
+            "share2nightscout-bridge"
+          ],
+          "range": "*",
+          "nodes": [
+            "node_modules/request"
+          ],
+          "fixAvailable": false
+        },
+        "share2nightscout-bridge": {
+          "name": "share2nightscout-bridge",
+          "severity": "moderate",
+          "isDirect": true,
+          "via": [
+            "request"
+          ],
+          "effects": [],
+          "range": "*",
+          "nodes": [
+            "node_modules/share2nightscout-bridge"
+          ],
+          "fixAvailable": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "severity": "moderate",
+          "isDirect": false,
+          "via": [
+            {
+              "source": 1119441,
+              "name": "uuid",
+              "dependency": "uuid",
+              "title": "uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided",
+              "url": "https://github.com/advisories/GHSA-w5hq-g745-h8pq",
+              "severity": "moderate",
+              "cwe": [
+                "CWE-787",
+                "CWE-1285"
+              ],
+              "cvss": {
+                "score": 7.5,
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+              },
+              "range": "<11.1.1"
+            }
+          ],
+          "effects": [
+            "request"
+          ],
+          "range": "<11.1.1",
+          "nodes": [
+            "node_modules/request/node_modules/uuid"
+          ],
+          "fixAvailable": false
+        }
+      },
+      "metadata": {
+        "vulnerabilities": {
+          "info": 0,
+          "low": 0,
+          "moderate": 4,
+          "high": 0,
+          "critical": 0,
+          "total": 4
+        },
+        "dependencies": {
+          "prod": 338,
+          "dev": 615,
+          "optional": 3,
+          "peer": 0,
+          "peerOptional": 0,
+          "total": 952
+        }
+      }
+    }
   }
 }

--- a/docs/audits/production-audit-2026-09-06.json
+++ b/docs/audits/production-audit-2026-09-06.json
@@ -1,0 +1,121 @@
+{
+  "baseline": "0181cc99",
+  "command": "npm audit --omit=dev --package-lock-only --json",
+  "node": "22.23.2",
+  "audit": {
+    "auditReportVersion": 2,
+    "vulnerabilities": {
+      "minimed-connect-to-nightscout": {
+        "name": "minimed-connect-to-nightscout",
+        "severity": "moderate",
+        "isDirect": true,
+        "via": [
+          "request"
+        ],
+        "effects": [],
+        "range": "*",
+        "nodes": [
+          "node_modules/minimed-connect-to-nightscout"
+        ],
+        "fixAvailable": false
+      },
+      "request": {
+        "name": "request",
+        "severity": "moderate",
+        "isDirect": false,
+        "via": [
+          {
+            "source": 1096727,
+            "name": "request",
+            "dependency": "request",
+            "title": "Server-Side Request Forgery in Request",
+            "url": "https://github.com/advisories/GHSA-p8p7-x288-28g6",
+            "severity": "moderate",
+            "cwe": [
+              "CWE-918"
+            ],
+            "cvss": {
+              "score": 6.1,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+            },
+            "range": "<=2.88.2"
+          },
+          "uuid"
+        ],
+        "effects": [
+          "minimed-connect-to-nightscout",
+          "share2nightscout-bridge"
+        ],
+        "range": "*",
+        "nodes": [
+          "node_modules/request"
+        ],
+        "fixAvailable": false
+      },
+      "share2nightscout-bridge": {
+        "name": "share2nightscout-bridge",
+        "severity": "moderate",
+        "isDirect": true,
+        "via": [
+          "request"
+        ],
+        "effects": [],
+        "range": "*",
+        "nodes": [
+          "node_modules/share2nightscout-bridge"
+        ],
+        "fixAvailable": false
+      },
+      "uuid": {
+        "name": "uuid",
+        "severity": "moderate",
+        "isDirect": false,
+        "via": [
+          {
+            "source": 1119441,
+            "name": "uuid",
+            "dependency": "uuid",
+            "title": "uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided",
+            "url": "https://github.com/advisories/GHSA-w5hq-g745-h8pq",
+            "severity": "moderate",
+            "cwe": [
+              "CWE-787",
+              "CWE-1285"
+            ],
+            "cvss": {
+              "score": 7.5,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+            },
+            "range": "<11.1.1"
+          }
+        ],
+        "effects": [
+          "request"
+        ],
+        "range": "<11.1.1",
+        "nodes": [
+          "node_modules/request/node_modules/uuid"
+        ],
+        "fixAvailable": false
+      }
+    },
+    "metadata": {
+      "vulnerabilities": {
+        "info": 0,
+        "low": 0,
+        "moderate": 4,
+        "high": 0,
+        "critical": 0,
+        "total": 4
+      },
+      "dependencies": {
+        "prod": 313,
+        "dev": 616,
+        "optional": 3,
+        "peer": 0,
+        "peerOptional": 0,
+        "total": 928
+      }
+    }
+  }
+}

--- a/docs/plans/legacy-bridge-review.md
+++ b/docs/plans/legacy-bridge-review.md
@@ -12,7 +12,7 @@ minimed-connect-to-nightscout 1.5.8.
 
 | Finding | Current evidence | Disposition |
 | --- | --- | --- |
-| request cross-protocol redirect SSRF | Advisory affects request through 2.88.2 with no patched request release. Inspected bridge request sites use POST without followAllRedirects; request's default redirect code does not follow POST redirects. | Narrow source review suggests the reported redirect mechanism is not used by these call sites. Actual owned redirect/transport tests are still required; do not dismiss the advisory globally. |
+| request cross-protocol redirect SSRF | Advisory affects request through 2.88.2 with no patched request release. Inspected bridge request sites use POST without followAllRedirects; request's default redirect code does not follow POST redirects. | Narrow source review suggests the reported redirect mechanism is not used by these call sites. Owned POST probes on both Node floors confirm no redirect target request for 301/302/303/307/308 in either protocol direction. Do not dismiss the advisory globally or infer other request methods/options are protected. |
 | private UUID buffer bounds | request imports only uuid/v4 in multipart/auth/oauth and calls it without a supplied buffer. Advisory concerns v3/v5/v6 with a buffer. | No affected call found in the inspected request consumer. Preserve this scope; it does not prove all private UUID consumers everywhere are safe. |
 | Dexcom TLS verification disabled | share2nightscout-bridge/index.js sets rejectUnauthorized:false at five request sites, including account authentication, login and glucose reads. | Open security issue independent of the npm audit. Require a strict-TLS fix or validated migration before final release; no global TLS-disable compatibility workaround. |
 
@@ -59,3 +59,24 @@ authentication and redirect review; the request finding is not that review.
 
 No production behavior, dependency version or support policy changes in this
 review. The TLS issue remains unresolved; M09 and M29 remain open.
+
+## Owned transport confirmation
+
+`tools/probe-legacy-bridge-transport.js DEPENDENCY_ROOT OUTPUT_JSON` generates
+an ephemeral certificate and binds only loopback HTTP/HTTPS listeners. It refuses
+proxy environment variables, uses fake credentials and removes keys/listeners
+afterward. On Node 22.23.2 and 24.20.0, two cycles each show:
+
+- Native strict TLS rejects the self-signed certificate; supplying its CA succeeds.
+- Actual legacy Dexcom authorize (account plus login) and glucose APIs accept
+  that same untrusted certificate. The TLS defect is dynamically confirmed.
+- Actual Dexcom POST calls return 301/302/303/307/308 without visiting the redirect
+  target for either HTTP-to-HTTPS or HTTPS-to-HTTP responses. The standalone
+  MiniMed uploader likewise rejects a 302 without visiting its target.
+
+Raw observations are in `../audits/legacy-bridge-transport.json`. The diagnostic
+does not treat unsafe certificate acceptance as a correctness requirement and is
+not an active CI assertion that a future secure fix must preserve. These tests
+do not validate vendor login, full polling/transform behavior, a live account,
+all redirect options, or a proposed replacement. The secure replacement/fix
+and required deployment cases remain open.

--- a/docs/plans/legacy-bridge-review.md
+++ b/docs/plans/legacy-bridge-review.md
@@ -1,0 +1,61 @@
+# Legacy bridge dependency and TLS review (M09/M29)
+
+Baseline: modernization integration `0181cc99`, 2026-09-06. The production-only
+lockfile audit reports four moderate affected package records, zero high or
+critical: request, its private uuid, and the two bridge packages that depend
+on request. This is the registry audit result, not a finding that the server
+has only four risks. Full-development audit and other dependency-major reviews
+remain separate. Raw audit and inspected source hashes are in `docs/audits`.
+Installed source versions were checked against the lock: request 2.88.2,
+private uuid 3.4.0, share2nightscout-bridge 0.2.12 and
+minimed-connect-to-nightscout 1.5.8.
+
+| Finding | Current evidence | Disposition |
+| --- | --- | --- |
+| request cross-protocol redirect SSRF | Advisory affects request through 2.88.2 with no patched request release. Inspected bridge request sites use POST without followAllRedirects; request's default redirect code does not follow POST redirects. | Narrow source review suggests the reported redirect mechanism is not used by these call sites. Actual owned redirect/transport tests are still required; do not dismiss the advisory globally. |
+| private UUID buffer bounds | request imports only uuid/v4 in multipart/auth/oauth and calls it without a supplied buffer. Advisory concerns v3/v5/v6 with a buffer. | No affected call found in the inspected request consumer. Preserve this scope; it does not prove all private UUID consumers everywhere are safe. |
+| Dexcom TLS verification disabled | share2nightscout-bridge/index.js sets rejectUnauthorized:false at five request sites, including account authentication, login and glucose reads. | Open security issue independent of the npm audit. Require a strict-TLS fix or validated migration before final release; no global TLS-disable compatibility workaround. |
+
+References: [request advisory](https://github.com/advisories/GHSA-p8p7-x288-28g6)
+and [UUID advisory](https://github.com/advisories/GHSA-w5hq-g745-h8pq).
+
+## Reachability and retained feature scope
+
+`lib/server/bridge-connect-compat.js` normally maps configured BRIDGE credentials
+to the Dexcom CONNECT source. `setupBridge` skips the legacy package when that
+source is active and no legacy override is set. The legacy path remains available
+through DEXCOM_BRIDGE_USE_LEGACY/CUSTOMCONNSTR_DEXCOM_BRIDGE_USE_LEGACY,
+bridge useLegacy/dexcomBridgeUseLegacy settings, or BRIDGE credentials alongside
+a different CONNECT source. Disabled bridges are already lazy-loaded. The package
+also accepts an operator-configured BRIDGE_SERVER host; do not assume every
+installation uses the default public endpoint.
+
+MiniMed's package index imports its request-based Nightscout upload helper, but
+the application plugin uses carelink.Client, transforms and filters, then writes
+through Nightscout storage adapters. The standalone package uploader is not the
+application plugin's write path. CareLink uses Axios and needs its own TLS,
+authentication and redirect review; the request finding is not that review.
+
+## Concrete next steps
+
+1. Obtain the required deployment cases for forced legacy Dexcom, combined
+   non-Dexcom CONNECT/BRIDGE and MiniMed. A question is pending; no answer is
+   assumed and no feature retirement is authorized by silence.
+2. Exercise the actual retained bridge request behavior against owned HTTP/TLS
+   fixtures: untrusted CA rejection, redirects, authentication/session refresh,
+   polling/cancellation and two data cycles. Use no real credentials or vendor
+   account. Confirm the source-derived advisory classifications dynamically.
+3. Prefer migration to the existing CONNECT path where its configuration and
+   output contracts cover the retained use case. Map credentials, region/custom
+   server, intervals, duplicate filtering and partial failures explicitly. Prove
+   no double ingestion during cutover and preserve rollback instructions.
+4. For cases that cannot migrate yet, prepare a narrowly reviewed upstream
+   transport/TLS fix or a maintained compatible transport replacement. Recheck
+   request/UUID removal and package cost; do not override private uuid to an
+   incompatible major or inject a global request/TLS monkey patch.
+5. Remove a legacy package only after required functionality has a validated
+   replacement and an explicit release notice. Publish final audit classification
+   and include live deployment/rollback evidence in M29/M30.
+
+No production behavior, dependency version or support policy changes in this
+review. The TLS issue remains unresolved; M09 and M29 remain open.

--- a/docs/plans/legacy-bridge-review.md
+++ b/docs/plans/legacy-bridge-review.md
@@ -80,3 +80,15 @@ not an active CI assertion that a future secure fix must preserve. These tests
 do not validate vendor login, full polling/transform behavior, a live account,
 all redirect options, or a proposed replacement. The secure replacement/fix
 and required deployment cases remain open.
+
+## Refresh after MongoDB driver 7 integration
+
+Rechecked against integration `cbbd4581` using Node 22.23.2 and the same
+production-only lockfile audit command. The four moderate affected package
+records remain unchanged, with zero high or critical records. Dependency counts
+now include the driver upgrade and its AWS authentication dependencies; the
+original counts are historical. Both raw audit snapshots are retained together.
+All recorded application and inspected dependency source hashes still match,
+and the four inspected installed package versions still match the current lock.
+The existing owned transport observations therefore cover unchanged inspected
+bridge sources; no new live vendor or production validation is claimed.

--- a/tools/probe-legacy-bridge-transport.js
+++ b/tools/probe-legacy-bridge-transport.js
@@ -1,0 +1,98 @@
+'use strict';
+
+// Diagnostic only: records legacy behavior, including known unsafe TLS acceptance.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const http = require('node:http');
+const https = require('node:https');
+const {execFileSync} = require('node:child_process');
+const {createRequire} = require('node:module');
+const {once} = require('node:events');
+
+async function main() {
+  const root = path.resolve(process.argv[2]);
+  const output = path.resolve(process.argv[3]);
+  for (const key of ['HTTP_PROXY','HTTPS_PROXY','ALL_PROXY','http_proxy','https_proxy','all_proxy']) {
+    assert(!process.env[key], 'Run this owned-network probe without proxy environment variables');
+  }
+  const load = createRequire(path.join(root, 'package.json'));
+  const bridge = load('share2nightscout-bridge');
+  const minimed = load('minimed-connect-to-nightscout');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nightscout-owned-bridge-tls-'));
+  let plain, secure, deadline;
+  const hits = [], results = {node:process.version, bridge:load('share2nightscout-bridge/package.json').version,
+    minimed:load('minimed-connect-to-nightscout/package.json').version, cycles:[]};
+  try {
+    const key = path.join(tmp, 'key.pem'), cert = path.join(tmp, 'cert.pem');
+    execFileSync('openssl', ['req','-x509','-newkey','rsa:2048','-sha256','-nodes','-keyout',key,
+      '-out',cert,'-days','1','-subj','/CN=127.0.0.1','-addext','subjectAltName=IP:127.0.0.1'], {stdio:'ignore', timeout:10000});
+    const certificate = fs.readFileSync(cert);
+    let plainOrigin, secureOrigin;
+    function handler(req, res) {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      hits.push({path:url.pathname, method:req.method, tls:!!req.socket.encrypted});
+      req.resume();
+      res.setHeader('Connection','close');
+      res.setHeader('Content-Type','application/json');
+      if (url.pathname.startsWith('/redirect/')) {
+        res.writeHead(Number(url.pathname.split('/').pop()), {Location:(req.socket.encrypted ? plainOrigin : secureOrigin) + '/target'});
+        return res.end('{}');
+      }
+      if (url.pathname === '/auth') return res.end(JSON.stringify('owned-account'));
+      if (url.pathname === '/login') return res.end(JSON.stringify('owned-session'));
+      if (url.pathname === '/glucose') return res.end(JSON.stringify([{Value:100, DT:'/Date(1700000000000)/', Trend:4}]));
+      res.end('{}');
+    }
+    plain = http.createServer(handler);
+    secure = https.createServer({key:fs.readFileSync(key), cert:certificate},handler);
+    plain.listen(0,'127.0.0.1'); await once(plain,'listening');
+    secure.listen(0,'127.0.0.1'); await once(secure,'listening');
+    plainOrigin = 'http://127.0.0.1:' + plain.address().port;
+    secureOrigin = 'https://127.0.0.1:' + secure.address().port;
+    function native(ca) {
+      return new Promise(resolve => {
+        const req = https.get(secureOrigin + '/glucose', {ca, timeout:2000}, res => {res.resume(); res.on('end',()=>resolve({status:res.statusCode}));});
+        req.on('error',error=>resolve({error:error.code}));
+        req.on('timeout',()=>req.destroy(new Error('Owned TLS control timed out')));
+      });
+    }
+    const fetch = uri => new Promise(resolve => bridge.fetch({LatestGlucose:uri,sessionID:'owned-session'},
+      (error,response,body)=>resolve({error:error && error.code,status:response && response.statusCode,body})));
+    async function run() {
+      for (let cycle=0;cycle<2;cycle++) {
+        const strict = await native();
+        assert.equal(strict.error,'DEPTH_ZERO_SELF_SIGNED_CERT');
+        assert.equal((await native(certificate)).status,200);
+        const authorization = await new Promise(resolve => bridge.authorize({auth:secureOrigin+'/auth',login:secureOrigin+'/login',
+          accountName:'owned-account',password:'owned-fixture-password'},(error,response,body)=>resolve({error:error && error.code,status:response && response.statusCode,body})));
+        const glucose = await fetch(secureOrigin+'/glucose');
+        const redirects = [];
+        for (const origin of [plainOrigin,secureOrigin]) for (const code of [301,302,303,307,308]) {
+          const before = hits.filter(hit=>hit.path==='/target').length;
+          const response = await fetch(origin+'/redirect/'+code);
+          redirects.push({fromTLS:origin===secureOrigin,code,status:response.status,targetHits:hits.filter(hit=>hit.path==='/target').length-before});
+        }
+        const upload = await new Promise(resolve=>minimed.nightscout.upload([],plainOrigin+'/redirect/302','owned-fixture-secret',
+          error=>resolve({rejected:!!error,targetHits:hits.filter(hit=>hit.path==='/target').length})));
+        results.cycles.push({strictClientRejectsUntrusted:true,trustedControlSucceeds:true,
+          legacyAuthorizationAcceptsUntrusted:!authorization.error && authorization.status===200,
+          legacyGlucoseAcceptsUntrusted:!glucose.error && glucose.status===200,redirects,minimedUpload:upload});
+      }
+    }
+    await Promise.race([run(),new Promise((_,reject)=>{deadline=setTimeout(()=>reject(new Error('Owned bridge probe deadline exceeded')),20000);})]);
+    results.methods = [...new Set(hits.map(hit=>hit.method))];
+    results.warning = 'Diagnostic observations are not a correctness oracle: accepting an untrusted TLS certificate is a known unresolved defect.';
+    fs.writeFileSync(output,JSON.stringify(results,null,2)+'\n');
+    console.log('Owned legacy transport observations written to ' + output);
+  } finally {
+    clearTimeout(deadline);
+    for (const server of [plain,secure]) if (server) {
+      server.closeAllConnections();
+      await new Promise(resolve=>server.close(resolve));
+    }
+    fs.rmSync(tmp,{recursive:true,force:true});
+  }
+}
+main().catch(error=>{console.error(error);process.exitCode=1;});


### PR DESCRIPTION
Records the production lockfile audit at integration 0181cc99 and traces the four remaining moderate affected-package records through the retained legacy bridges. request uses only the private UUID v4 API without a supplied buffer; inspected bridge request sites use POST with default redirect policy. Owned transport probes now confirm that Dexcom POST requests do not follow 301/302/303/307/308 redirects in either protocol direction on both Node floors; the standalone MiniMed uploader likewise rejects a 302. These are scoped findings, not blanket advisory dismissals.

The review also identifies an independent unresolved issue: share2nightscout-bridge disables TLS certificate validation at five request sites, including authentication/login/read calls. Normal BRIDGE settings migrate to CONNECT, but forced-legacy and mixed-source cases remain reachable. The plan sets concrete transport tests, configuration mapping, compatibility and rollback gates before fixing or replacing those paths. Required deployment cases have been requested without credentials; no feature retirement is inferred.

Docs/audit evidence only. Installed versions were matched to the lock, source hashes are recorded, and npm audit output is included. No dependency, runtime or support-policy changes; M09/M29 remain open. Targets chore/nightscout-modernization; #8605 stays draft into dev.

Follow-up `13794a10` adds a reproducible loopback HTTP/TLS diagnostic and raw observations. Two cycles on both Node floors confirm actual legacy authentication/login and glucose calls accept an untrusted self-signed certificate, while the strict native control rejects it and accepts the explicitly trusted CA. Ephemeral keys/listeners are cleaned up and only fake credentials are used. This records a known defect, not a correctness oracle that a future secure fix must preserve. The transport fix/replacement and full bridge data-cycle validation remain open.

Merged into `chore/nightscout-modernization` as `3f6a0761`. All required existing head checks passed. The owned transport diagnostic was rerun against the current merge result on both Node floors, with matching observations. The actual resulting integration tree matches the independently calculated current-base merge tree. Existing full head CI and focused current-tree validation are distinct evidence; no claim of a new full matrix on every audit-only merge. Follow-up modernization gates remain tracked by #8605, which stays draft into dev.
