### PR TITLE
Reduce CI environment duplication and shorten validation pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,16 +14,21 @@ on:
       - dev
       - chore/nightscout-modernization
 
+# Replace obsolete PR runs; never cancel a dev/master publication in progress.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Exact floors catch patch-level requirements; major aliases catch future patches.
-        node-version: ['22.23.2', '22', '24.20.0', '24']
+        # Test current releases in both supported Node majors.
+        node-version: ['22', '24']
         # MongoDB 4.4 is retired; keep 5/6 during the modernization migration.
-        mongodb-version: [5.0, 6.0]
+        mongodb-version: ['5.0.32', '6.0.27']
 
     steps:
       - name: Git Checkout
@@ -33,7 +38,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
-          package-manager-cache: false
+          check-latest: true
+          cache: npm
 
       - name: Start MongoDB ${{ matrix.mongodb-version }}
         uses: supercharge/mongodb-github-action@1.3.0
@@ -64,8 +70,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Validate both exact Node floors against maintained MongoDB releases.
-        node-version: ['22.23.2', '24.20.0']
+        # Keep full backend coverage for both Node majors on MongoDB 7/8.
+        node-version: ['22', '24']
         # Additional coverage; the retained MongoDB 5/6 matrix stays above.
         mongodb-version: ['7.0.40', '8.0.29']
 
@@ -77,7 +83,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
-          package-manager-cache: false
+          check-latest: true
+          cache: npm
 
       - name: Start MongoDB ${{ matrix.mongodb-version }}
         uses: supercharge/mongodb-github-action@1.3.0
@@ -110,8 +117,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22.23.2', '24.20.0']
-        mongodb-version: ['5.0.32', '6.0.27', '7.0.40', '8.0.29']
+        # Each server version exercises failover; the backend matrix covers
+        # every Node/MongoDB pair. Keep both Node majors in failover coverage.
+        include:
+          - node-version: '22'
+            mongodb-version: '5.0.32'
+          - node-version: '24'
+            mongodb-version: '6.0.27'
+          - node-version: '22'
+            mongodb-version: '7.0.40'
+          - node-version: '24'
+            mongodb-version: '8.0.29'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -119,7 +135,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
-          package-manager-cache: false
+          check-latest: true
+          cache: npm
       - name: Start owned replica members
         env:
           MONGODB_TEST_VERSION: ${{ matrix.mongodb-version }}
@@ -156,8 +173,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22.23.2', '24.20.0']
-        browser: [chromium, firefox, webkit]
+        # All browser engines on Node 24; Chromium also validates the Node 22
+        # build and development/HMR tooling. Browser assertions are unchanged.
+        include:
+          - node-version: '22'
+            browser: chromium
+          - node-version: '24'
+            browser: chromium
+          - node-version: '24'
+            browser: firefox
+          - node-version: '24'
+            browser: webkit
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -167,7 +193,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
-          package-manager-cache: false
+          check-latest: true
+          cache: npm
       - name: Install dependencies and build production bundle
         run: npm ci
       - name: Install the pinned browser and system dependencies
@@ -190,7 +217,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24
-          package-manager-cache: false
+          check-latest: true
+          cache: npm
       - name: Use npm 12
         run: npm install --global npm@12
       - name: Install dependencies and build production bundle
@@ -202,7 +230,7 @@ jobs:
 
   docker-build-pr:
     name: Validate Docker image (${{ matrix.arch }})
-    needs: [test, browser-test, maintained-mongo, replica-test]
+    # Independent validation can run immediately; all jobs still gate merging.
     if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -251,7 +279,7 @@ jobs:
 
   docker-build:
     name: Build Docker image (${{ matrix.arch }})
-    needs: [test, browser-test, maintained-mongo, replica-test]
+    needs: [test, browser-test, maintained-mongo, replica-test, npm12-build]
     if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') && github.repository_owner == 'nightscout'
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -160,6 +160,8 @@ For every completed item, replace its checkbox with a checked box and append: PR
 
 ## Integration workflow and current child PRs
 
+Current CI policy: [coverage and execution cost](../test-specs/ci-coverage.md). Per maintainer direction, PR jobs use floating Node 22/24 only. Full backend coverage retains MongoDB 5–8, with exact transitional MongoDB minimum patches pinned. Minimum Node patches stay in the support range and require actual release-candidate validation; version-string policy tests are not execution evidence. Historical per-PR matrix counts below describe their original validation.
+
 The user confirmed on 2026-09-05 that all implementation PRs target `chore/nightscout-modernization`, and may be merged there after validation. #8605 remains the only PR into dev. CI and CodeQL explicitly include the integration branch as a pull-request target; container publishing remains limited to dev/master.
 
 - M07: [#8606](https://github.com/nightscout/cgm-remote-monitor/pull/8606) merged as `dd90c19b` (head `1250f6c0`, parent `b1837c13`). [Integration-target CI](https://github.com/nightscout/cgm-remote-monitor/actions/runs/33981221755) passed all 12 Node/MongoDB jobs, npm 12, CodeQL and amd64/arm64 Docker startup. Local main suites passed 1,968 tests on both exact Node floors; core 283 and dependency 317. Azure/Heroku staging and release promotion remain gated in `docs/runtime-upgrade.md`.

--- a/docs/runtime-upgrade.md
+++ b/docs/runtime-upgrade.md
@@ -18,7 +18,9 @@ Do not deploy this release to a host that cannot provide a supported runtime in 
 
 ## Deployment validation and release gate
 
-The CI matrix tests 22.23.2, latest 22, 24.20.0, and latest 24 against MongoDB 5 and 6 (eight combinations). MongoDB 4.4 coverage has been removed. MongoDB 5/6 remain supported during the migration, but are not recommended for new deployments because they are upstream end-of-life; see the database notice below. Unsupported-Node-version tests verify early rejection through both entry points and the public boot API. Docker PR checks build and smoke-start the pruned image on native amd64 and arm64 runners.
+The PR backend matrix tests current Node 22 and 24 releases against MongoDB 5, 6, 7 and 8 (eight combinations). Node selectors use `check-latest: true`. Replica failover runs once per MongoDB release across the two Node majors; Chromium runs on both Node majors, with Firefox and WebKit on Node 24. npm 12 and native amd64/arm64 Docker checks remain. See [CI coverage and timing](test-specs/ci-coverage.md).
+
+The exact minimum versions in `package.json` and the early-rejection tests are unchanged. Those policy tests simulate version strings; they do not prove execution compatibility on an older patch. Once floating releases advance, PR CI no longer exercises the exact floors. Before release, record clean install/build, backend/client-core and pruned-startup results on actual Node 22.23.2 and 24.20.0 against the final release candidate. Do not claim exact-floor compatibility from floating CI alone. MongoDB 4.4 remains retired and 5/6 remain supported during migration.
 
 The following remain release checks until a maintainer records actual host evidence. Updating selectors alone does **not** establish hosted compatibility:
 

--- a/docs/test-specs/ci-coverage.md
+++ b/docs/test-specs/ci-coverage.md
@@ -1,0 +1,40 @@
+# CI coverage and execution cost
+
+The maintainer selected floating Node 22/24 only for PR CI. Keep the declared
+Node minimum patches and MongoDB 5/6 migration support unchanged.
+
+| Checks | Before | After | Coverage |
+| --- | ---: | ---: | --- |
+| Backend and client-core | 12 | 8 | Both Node majors on each MongoDB 5/6/7/8 |
+| Replica failover | 8 | 4 | MongoDB 5/7 on Node 22, MongoDB 6/8 on Node 24; two primary changes per job |
+| Browser | 6 | 4 | Chromium on both Node majors; Firefox/WebKit on Node 24 |
+| npm 12 | 1 | 1 | Clean install, production and development builds, dependency tests |
+| Native Docker | 2 | 2 | amd64 and arm64 build plus pruned startup |
+
+This reduces main-workflow PR jobs from 29 to 19 (34.5%). CodeQL is unchanged.
+No test assertions or test files are removed. The reduction does omit repeated
+failover for the other Node/MongoDB pairs and Firefox/WebKit harness execution
+on Node 22; all database pairs retain full backend coverage and all browser
+engines retain their complete suite. Node 22 still builds and exercises HMR in
+Chromium. This is selective environment coverage, not equivalent exhaustive
+cross-product coverage.
+
+Every setup-node step uses `check-latest: true` and npm download caching keyed
+by the lockfile. `npm ci` still creates fresh node_modules and runs builds;
+neither installed modules nor build outputs are restored. Cold cache runs can
+remain expensive. Docker PR validation starts alongside other tests; publishing
+still waits for all main test groups and now also waits for the npm 12 check.
+Superseded PR runs are cancelled within that PR only. Push/release runs are not
+cancelled by this policy.
+
+The support range and runtime-policy tests remain authoritative for admission,
+but simulated version strings do not prove actual minimum-patch compatibility.
+The [release gate](../runtime-upgrade.md) requires testing the exact supported
+floors on the final candidate outside this floating-only PR matrix. If a future
+dependency requires a higher patch, resolve the mismatch before release.
+
+Validate workflow syntax with actionlint and inspect the actual PR job set,
+results, Node versions and Docker start times. Compare job execution seconds
+and critical-path wall time with parent runs; fewer jobs are not automatically
+a proportional wall-time improvement. Keep runner variance and cold/warm cache
+conditions explicit. No runtime, database schema or UI behavior changes here.


### PR DESCRIPTION
CI currently repeats exact minimum and floating Node jobs even when they resolve to the same release, and waits for the longest browser job before starting independent Docker validation. Use floating Node 22/24 only, as requested, and reduce the main PR workflow from 29 to 19 executing jobs.

- Keep full backend/client-core/pruned-runtime coverage on both Node majors against MongoDB 5/6/7/8. Pin MongoDB 5/6 to the declared minimum patches.
- Exercise replica failover once per database release across both Node majors (four jobs). Keep Chromium on both Nodes, with Firefox/WebKit on Node 24 (four jobs). All existing commands/assertions remain.
- Enable latest-version resolution and npm download caching while retaining clean npm ci builds. Run both native Docker validations immediately, cancel superseded PR runs, and keep publication gated by the test groups plus npm 12.

Tradeoff: omitted Node/browser and Node/replica cross-products are no longer tested. Exact Node minimum patches remain in package.json and startup-policy tests, but floating PR CI cannot prove their execution compatibility once versions advance. The release documentation explicitly retains actual exact-floor validation on the final candidate. No production code, dependency, schema or UI changes.

Local validation: actionlint 1.7.12 passes (shellcheck disabled); all 23 runtime-policy cases pass on actual Node 22.23.2 and 24.20.0. Parsed workflow comparison confirms all shell test commands are unchanged and verifies the new matrices/publication dependencies. All required hosted checks passed on f44eb3cc; merged as 2a68ceb6 after verifying the actual merge tree. The first reduced run executed exactly 19 main-workflow jobs.

Targets chore/nightscout-modernization; #8605 remains draft into dev. See docs/test-specs/ci-coverage.md for coverage and limitations.

Observed timing: [baseline run](https://github.com/nightscout/cgm-remote-monitor/actions/runs/34040460320) versus [reduced run](https://github.com/nightscout/cgm-remote-monitor/actions/runs/34041527581): 29 → 19 successful main-workflow jobs, summed execution time 4,410 → 3,012 seconds (31.7% lower), earliest job start to final completion 502 → 434 seconds (13.5% lower). This is one sequential comparison with runner/cache variance, not a controlled benchmark or billing estimate. Docker starts concurrently and both architectures pass; all backend pairs, four failover jobs and four browser jobs pass.
