### PR TITLE
Consolidate compatible semver copies on 7.8.5

### DIFF
--- a/docs/audits/semver-copy-comparison.json
+++ b/docs/audits/semver-copy-comparison.json
@@ -1,0 +1,141 @@
+{
+  "scope": "Only installed semver package files; excludes tarballs, filesystem allocation, symlinks and runtime heap",
+  "before": {
+    "lockSha256": "659a1e7ca065f378035f76bd884d8d04abb29ec5eee0136dae01f872878d6503",
+    "copies": [
+      {
+        "path": "node_modules/@babel/core/node_modules/semver",
+        "version": "7.8.5",
+        "devOnly": true,
+        "installedBytes": 101065
+      },
+      {
+        "path": "node_modules/@babel/helper-compilation-targets/node_modules/semver",
+        "version": "7.8.5",
+        "devOnly": true,
+        "installedBytes": 101065
+      },
+      {
+        "path": "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver",
+        "version": "7.8.5",
+        "devOnly": true,
+        "installedBytes": 101065
+      },
+      {
+        "path": "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver",
+        "version": "7.8.5",
+        "devOnly": true,
+        "installedBytes": 101065
+      },
+      {
+        "path": "node_modules/@babel/preset-env/node_modules/semver",
+        "version": "7.8.5",
+        "devOnly": true,
+        "installedBytes": 101065
+      },
+      {
+        "path": "node_modules/@parse/node-apn/node_modules/semver",
+        "version": "7.8.0",
+        "devOnly": false,
+        "installedBytes": 100030
+      },
+      {
+        "path": "node_modules/eslint/node_modules/semver",
+        "version": "7.8.0",
+        "devOnly": true,
+        "installedBytes": 100030
+      },
+      {
+        "path": "node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/semver",
+        "version": "6.3.1",
+        "devOnly": true,
+        "installedBytes": 68343
+      },
+      {
+        "path": "node_modules/istanbul-lib-instrument/node_modules/@babel/helper-compilation-targets/node_modules/semver",
+        "version": "6.3.1",
+        "devOnly": true,
+        "installedBytes": 68343
+      },
+      {
+        "path": "node_modules/istanbul-lib-instrument/node_modules/semver",
+        "version": "7.8.0",
+        "devOnly": true,
+        "installedBytes": 100030
+      },
+      {
+        "path": "node_modules/istanbul-lib-report/node_modules/semver",
+        "version": "7.8.0",
+        "devOnly": true,
+        "installedBytes": 100030
+      },
+      {
+        "path": "node_modules/jsonwebtoken/node_modules/semver",
+        "version": "7.8.0",
+        "devOnly": false,
+        "installedBytes": 100030
+      },
+      {
+        "path": "node_modules/nodemon/node_modules/semver",
+        "version": "7.8.0",
+        "devOnly": true,
+        "installedBytes": 100030
+      },
+      {
+        "path": "node_modules/semver",
+        "version": "6.3.1",
+        "devOnly": false,
+        "installedBytes": 68343
+      },
+      {
+        "path": "node_modules/simple-update-notifier/node_modules/semver",
+        "version": "7.8.0",
+        "devOnly": true,
+        "installedBytes": 100030
+      }
+    ],
+    "totalCopies": 15,
+    "productionCopies": 3,
+    "totalInstalledBytes": 1410564,
+    "productionInstalledBytes": 268403
+  },
+  "after": {
+    "lockSha256": "0580ddadf916e7a77f86cea8bd3df03fdab0554cd296f32e43773deec6881d1a",
+    "copies": [
+      {
+        "path": "node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/semver",
+        "version": "6.3.1",
+        "devOnly": true,
+        "installedBytes": 68343
+      },
+      {
+        "path": "node_modules/istanbul-lib-instrument/node_modules/@babel/helper-compilation-targets/node_modules/semver",
+        "version": "6.3.1",
+        "devOnly": true,
+        "installedBytes": 68343
+      },
+      {
+        "path": "node_modules/make-dir/node_modules/semver",
+        "version": "6.3.1",
+        "devOnly": true,
+        "installedBytes": 68343
+      },
+      {
+        "path": "node_modules/semver",
+        "version": "7.8.5",
+        "devOnly": false,
+        "installedBytes": 101065
+      }
+    ],
+    "totalCopies": 4,
+    "productionCopies": 1,
+    "totalInstalledBytes": 306094,
+    "productionInstalledBytes": 101065
+  },
+  "delta": {
+    "totalCopies": -11,
+    "productionCopies": -2,
+    "totalInstalledBytes": -1104470,
+    "productionInstalledBytes": -167338
+  }
+}

--- a/docs/test-specs/semver-consolidation.md
+++ b/docs/test-specs/semver-consolidation.md
@@ -1,0 +1,39 @@
+# Consolidate semver on the maintained root release (M09 partial)
+
+The only direct runtime use of semver is the shared Node startup policy. Tests
+also use satisfies, valid and major. Keep the established range/prerelease
+parser rather than introducing a local parser for package.json engines.
+
+Upgrade the root from 6.3.1 to 7.8.5, the registry release checked on 2026-09-06.
+The Node floor is compatible (upstream requires Node >=10); Nightscout's accepted
+Node versions and package.json engine range do not change. The used CommonJS APIs
+remain available. Review reference: [upstream changelog](https://github.com/npm/node-semver/blob/main/CHANGELOG.md).
+
+This allows twelve private 7.x copies to use the root instance. One private 6.3.1
+copy remains for make-dir's declared 6.x range; do not force it across a major.
+No unrelated retained package version changes. The net reduction is eleven
+installed paths and two production semver copies.
+
+[Installed-file measurements](../audits/semver-copy-comparison.json) record
+1,104,470 fewer bytes across all semver copies and 167,338 fewer production bytes.
+These are file sizes from clean dependency trees, not filesystem allocation,
+compressed download sizes or a measurement of server RSS/heap.
+
+Validation:
+
+- Clean Node 22 install/production build passes.
+- 307 runtime-policy and dependency cases passed on Node 22; eight added JWT
+  signing/key-validation cases also passed. Node 24 passed all 315 together.
+- The startup tests exercise both server entry points and the public boot API,
+  rejecting Node 20, below-floor patches, prereleases and unsupported majors
+  before service initialization.
+- Both actual production jsonwebtoken consumers (Nightscout and APN) sign and
+  verify ES256, RS256 and PS256 tokens over two cycles; they reject incorrect
+  algorithms and mismatched EC curves. These exercise semver-dependent key
+  validation paths with owned keys and no network/provider traffic.
+- Existing dependency tests cover the build/test consumers now sharing semver.
+  Full current-head CI remains required before integration.
+
+There is no visual UI change or user configuration migration. Authentication and
+runtime startup behavior are relevant regression boundaries. Revert the root
+manifest and lockfile together if a consumer regression is discovered.

--- a/docs/test-specs/semver-consolidation.md
+++ b/docs/test-specs/semver-consolidation.md
@@ -9,8 +9,9 @@ The Node floor is compatible (upstream requires Node >=10); Nightscout's accepte
 Node versions and package.json engine range do not change. The used CommonJS APIs
 remain available. Review reference: [upstream changelog](https://github.com/npm/node-semver/blob/main/CHANGELOG.md).
 
-This allows twelve private 7.x copies to use the root instance. One private 6.3.1
-copy remains for make-dir's declared 6.x range; do not force it across a major.
+This allows twelve private 7.x copies to use the root instance. A new private
+6.3.1 copy serves make-dir's declared 6.x range; two existing private 6.3.1 copies
+remain under Istanbul's Babel consumers. Do not force these across a major.
 No unrelated retained package version changes. The net reduction is eleven
 installed paths and two production semver copies.
 

--- a/docs/test-specs/semver-consolidation.md
+++ b/docs/test-specs/semver-consolidation.md
@@ -32,7 +32,9 @@ Validation:
   algorithms and mismatched EC curves. These exercise semver-dependent key
   validation paths with owned keys and no network/provider traffic.
 - Existing dependency tests cover the build/test consumers now sharing semver.
-  Full current-head CI remains required before integration.
+- Full local Node 22.23.2/MongoDB 6 backend coverage run passes 1,947 tests with
+  one existing pending case. Full current-head hosted CI remains required
+  before integration.
 
 There is no visual UI change or user configuration migration. Authentication and
 runtime startup behavior are relevant regression boundaries. Revert the root

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "proxy-addr": "^2.0.7",
         "pushover-notifications": "^1.2.2",
         "sanitize-html": "2.17.7",
-        "semver": "^6.3.0",
+        "semver": "^7.8.5",
         "shiro-trie": "^0.4.9",
         "socket.io": "~4.8.3",
         "socks": "2.8.10",
@@ -499,19 +499,6 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
@@ -644,19 +631,6 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
@@ -679,19 +653,6 @@
         "@babel/core": "^8.0.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
@@ -708,19 +669,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^8.0.0"
-      }
-    },
-    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -2280,19 +2228,6 @@
         "@babel/core": "^8.0.0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@babel/preset-modules": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
@@ -3193,16 +3128,6 @@
     "node_modules/@parse/node-apn/node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
-    },
-    "node_modules/@parse/node-apn/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -5472,17 +5397,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint/node_modules/semver": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/espree": {
       "version": "7.3.1",
       "dev": true,
@@ -6857,17 +6771,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-processinfo": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-3.0.1.tgz",
@@ -6994,17 +6897,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/semver": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
@@ -7183,16 +7075,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.8.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "license": "MIT",
@@ -7362,6 +7244,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7946,17 +7838,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/nodemon/node_modules/semver": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/nodemon/node_modules/supports-color": {
@@ -9039,10 +8920,15 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -9289,17 +9175,6 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "proxy-addr": "^2.0.7",
     "pushover-notifications": "^1.2.2",
     "sanitize-html": "2.17.7",
-    "semver": "^6.3.0",
+    "semver": "^7.8.5",
     "shiro-trie": "^0.4.9",
     "socket.io": "~4.8.3",
     "socks": "2.8.10",

--- a/tests/dependency-semver-jwt.test.js
+++ b/tests/dependency-semver-jwt.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {generateKeyPairSync} = require('node:crypto');
+const {createRequire} = require('node:module');
+const fromAPN = createRequire(require.resolve('@parse/node-apn'));
+const consumers = [['Nightscout', require('jsonwebtoken')], ['APN', fromAPN('jsonwebtoken')]];
+
+// jsonwebtoken uses semver at module initialization to select supported key
+// validation paths. Exercise both installed production consumers with real keys.
+describe('semver-dependent JWT key validation', function () {
+  const ec = generateKeyPairSync('ec', {namedCurve: 'prime256v1'});
+  const rsa = generateKeyPairSync('rsa', {modulusLength: 2048});
+  const pss = generateKeyPairSync('rsa-pss', {modulusLength: 2048, hashAlgorithm: 'sha256', mgf1HashAlgorithm: 'sha256', saltLength: 32});
+  for (const [name, jwt] of consumers) {
+    for (const [algorithm, keys] of [['ES256', ec], ['RS256', rsa], ['PS256', pss]]) {
+      it(name + ' signs and validates ' + algorithm + ' while rejecting an incorrect algorithm', function () {
+        for (let cycle = 0; cycle < 2; cycle++) {
+          const token = jwt.sign({fixture: 'owned', cycle}, keys.privateKey, {algorithm, expiresIn: 60});
+          const verified = jwt.verify(token, keys.publicKey, {algorithms: [algorithm]});
+          assert.equal(verified.fixture, 'owned');
+          assert.equal(verified.cycle, cycle);
+          assert.throws(() => jwt.verify(token, keys.publicKey, {algorithms: ['HS256']}), /invalid algorithm/);
+        }
+      });
+    }
+    it(name + ' rejects a mismatched EC curve during signing', function () {
+      assert.throws(() => jwt.sign({fixture: 'owned'}, ec.privateKey, {algorithm: 'ES384'}), /curve/);
+    });
+  }
+});


### PR DESCRIPTION
The root semver 6 dependency prevents twelve private semver 7 copies from sharing one instance. Upgrade the root to 7.8.5 and consolidate compatible consumers, removing a net eleven installed paths (two production copies). Keep the three private semver 6 copies required by make-dir and Istanbul's Babel consumers.

The only direct runtime use remains Node startup range checking. The accepted Node versions are unchanged. No unrelated retained dependency version changes or UI/configuration migration is included.

Measurements record 1,104,470 fewer installed semver file bytes overall and 167,338 fewer production bytes. These are package file sizes, not a measured RSS or compressed image saving.

Validation:
- Clean Node 22 installation and production build pass.
- 315 focused startup/dependency/JWT cases pass on Node 24; Node 22 passes the same 307 existing and eight new cases.
- Both installed JWT consumers exercise ES256, RS256 and PS256 signing/verification, algorithm rejection and EC-curve validation with owned keys across repeated cycles.
- Full local Node 22.23.2/MongoDB 6 backend coverage: 1,947 passing, one existing pending case.
- Full hosted CI must pass on the final PR head before merge.

Targets chore/nightscout-modernization for M09. Parent #8605 remains draft; remaining modernization work and release gates are unchanged. Review notes and measured copy inventory are included in docs/test-specs/semver-consolidation.md and docs/audits/semver-copy-comparison.json.
