### PR TITLE
Update webpack and consolidate development HMR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ reconnection. The parser override does not rewrite the prebuilt browser
 client, so both paths remain required.
 
 The fast-uri dependency checks resolve Ajv through each installed consumer
-(webpack, webpack-dev-middleware, terser-webpack-plugin, ajv-formats and table).
+(webpack, webpack-dev-middleware, minimizer-webpack-plugin, ajv-formats and table).
 They exercise external references, escaped JSON pointers and case-sensitive
 schema IDs, as well as URI security boundaries. Keep the fast-uri override
 scoped to 3.x while these consumers require it; a 4.x migration changes Unicode
@@ -354,3 +354,9 @@ Also if you can't code, it's possible to contribute by improving the documentati
 | All active testers/documentors: | [@danamlewis] [@jamieowendexcom] [@mcdafydd] [@oteroos] [@rarneson] [@tynbendad] [@unsoluble]
 | All active translators: | [@apanasef] [@jizhongwen] [@viderehh] [@herzogmedia] [@LuminaryXion] [@OpossumGit]
 
+
+Development hot updates use webpack-dev-middleware for both assets and the
+`/__webpack_hmr` event stream. Compile errors use its overlay; successful updates
+preserve unsaved input without automatic reload fallback. See the
+[webpack/HMR review](docs/test-specs/webpack-refresh.md) for migration and
+regression coverage.

--- a/docs/audits/webpack-refresh-comparison.json
+++ b/docs/audits/webpack-refresh-comparison.json
@@ -1,0 +1,107 @@
+{
+  "scope": "Matched Node 22 production builds and installed file sizes. Excludes cache, tarballs, disk allocation, runtime heap/RSS and build-time claims. Candidate worktree has uncommitted changes identified by lock SHA256.",
+  "before": {
+    "commit": "96d462382af08dbe4d45d486b3ecb70948c60f89",
+    "lockSha256": "0580ddadf916e7a77f86cea8bd3df03fdab0554cd296f32e43773deec6881d1a",
+    "declarations": 62,
+    "packagePaths": 905,
+    "productionPaths": 294,
+    "installedFiles": {
+      "node": "v22.23.2",
+      "platform": "darwin",
+      "arch": "arm64",
+      "files": 24667,
+      "bytes": 203902127
+    },
+    "bundles": {
+      "runtime": {
+        "node": "22.23.2",
+        "zlib": "1.3.1-e00f703"
+      },
+      "bundles": {
+        "app": {
+          "bytes": 1029121,
+          "gzipBytes": 298667
+        },
+        "reports": {
+          "bytes": 170351,
+          "gzipBytes": 50579
+        },
+        "admin": {
+          "bytes": 32069,
+          "gzipBytes": 7933
+        },
+        "profile": {
+          "bytes": 18498,
+          "gzipBytes": 6665
+        },
+        "food": {
+          "bytes": 15868,
+          "gzipBytes": 5319
+        },
+        "clock": {
+          "bytes": 150640,
+          "gzipBytes": 61427
+        }
+      },
+      "allApplicationGzipBytes": 369163
+    },
+    "webpackConfigSha256": "8a4e37edc76777b6bf706bdc05c85896da5fb2a7bb444d72263901a09700a2be"
+  },
+  "after": {
+    "commit": "96d462382af08dbe4d45d486b3ecb70948c60f89",
+    "lockSha256": "84afe99b3acc1356e1aa5aea9e1c5b1acf817de3d7b16eca1a779f4b37f8a681",
+    "declarations": 61,
+    "packagePaths": 900,
+    "productionPaths": 294,
+    "installedFiles": {
+      "node": "v22.23.2",
+      "platform": "darwin",
+      "arch": "arm64",
+      "files": 24799,
+      "bytes": 208333694
+    },
+    "bundles": {
+      "runtime": {
+        "node": "22.23.2",
+        "zlib": "1.3.1-e00f703"
+      },
+      "bundles": {
+        "app": {
+          "bytes": 1041919,
+          "gzipBytes": 303753
+        },
+        "reports": {
+          "bytes": 170347,
+          "gzipBytes": 50577
+        },
+        "admin": {
+          "bytes": 32065,
+          "gzipBytes": 7930
+        },
+        "profile": {
+          "bytes": 18472,
+          "gzipBytes": 6660
+        },
+        "food": {
+          "bytes": 15864,
+          "gzipBytes": 5316
+        },
+        "clock": {
+          "bytes": 150606,
+          "gzipBytes": 61422
+        }
+      },
+      "allApplicationGzipBytes": 374236
+    },
+    "webpackConfigSha256": "0023a2484a120adb79f3e94bb54f24b062c58deeeca85340bd6f22c20d5f91a4"
+  },
+  "delta": {
+    "declarations": -1,
+    "packagePaths": -5,
+    "productionPaths": 0,
+    "installedBytes": 4431567,
+    "appGzipBytes": 5086,
+    "allApplicationGzipBytes": 5073
+  }
+}

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -79,6 +79,7 @@ At the audit baseline, completed foundations were: D3 7.9.0, jsdom-backed test t
 - [ ] **M09 — Review remaining maintained releases and security overrides** (after M07 where runtime requires it; ongoing).
   Files: manifests, each actual consumer and `tests/dependency-*.test.js`. Re-run production/full audits and `npm explain`; track each finding as reachable, build/test-only, mitigated or awaiting upstream work, with evidence. Prioritize reachable issues and unmaintained transitive chains; review Express/Helmet, MongoDB, loaders/lint/build tools and providers independently.
   Acceptance: highest compatible release per consumer, focused exploit/API regression where relevant, full CI and explicit engine/browser/DB compatibility. Remove an override only after every affected parent resolves safely. Do not use forced audit fixes or a bulk latest-version update; keep Dependabot's current target configuration.
+  The [webpack/HMR refresh](../test-specs/webpack-refresh.md) removes a separate hot-middleware dependency using the maintained development middleware, with repeated update/error recovery coverage and explicit installed/browser size costs. It does not complete the remaining dependency reviews.
 
 ## Phase 3 — reduce production installation and browser cost
 

--- a/docs/test-specs/webpack-refresh.md
+++ b/docs/test-specs/webpack-refresh.md
@@ -45,7 +45,9 @@ Regression coverage:
 - Full Node 22 Chromium suite passes 538 cases, including production asset and
   report/interaction coverage. Full Node 24/MongoDB 8 backend coverage passes
   1,947 tests with one existing pending case.
-- Full current-head hosted CI remains required before integration.
+- Nine focused Node 24 WebKit HMR/asset/cascade checks pass, including both
+  compile-error recovery cycles. Full current-head hosted CI remains required
+  before integration.
 
 [Matched measurements](../audits/webpack-refresh-comparison.json) show one fewer
 direct declaration and five fewer package paths, but **4,431,567 more installed

--- a/docs/test-specs/webpack-refresh.md
+++ b/docs/test-specs/webpack-refresh.md
@@ -1,0 +1,61 @@
+# Webpack and built-in development HMR (M09 partial)
+
+Update webpack 5.106.2 to 5.110.3 and webpack-dev-middleware 8.0.3 to 8.3.0,
+the registry releases checked on 2026-09-06. Both support Nightscout's Node
+22/24 floors; middleware requires webpack ^5.101.0. Review sources:
+[webpack releases](https://github.com/webpack/webpack/releases) and
+[middleware 8.3.0](https://github.com/webpack/webpack-dev-middleware/releases/tag/v8.3.0).
+
+The middleware now owns both development assets and HMR's `/__webpack_hmr`
+Server-Sent Events endpoint. Remove webpack-hot-middleware and use the bundled
+client in all six entries. Keep a one-second heartbeat, disable reload fallback
+and the new progress badge/runtime-error overlay, and retain compile-error
+reporting. Resolve the exported client path before appending query options:
+the direct package-subpath query failed resolution in this installed pair.
+The fixture closes middleware before its HTTP server so SSE clients and compiler
+watching are released before shutdown.
+
+Webpack's default JavaScript minifier moved from terser-webpack-plugin to
+minimizer-webpack-plugin. Remove the unused old override and exercise Ajv/fast-uri
+through the actual new consumer. The lockfile includes the updated resolver,
+watcher, sources, minifier and in-memory filesystem dependencies. No production
+package path changes are introduced.
+
+The first browser run detected that the original CSS sources moved from the JS
+source map into inline maps in injected styles. Original source content was not
+lost. The asset test now checks the maps actually delivered to the page and
+requires exact original CSS content plus nonempty mappings. CSS minification
+remains enabled. Existing mobile/desktop cascade and image URL checks remain.
+
+Regression coverage:
+
+- Existing page HMR test applies two changes to each page entry and shared app,
+  retaining draft input, public exports, widget functions and styles without a
+  page reload or external request.
+- An added browser test performs two compile-error/recovery cycles, requires the
+  error overlay to appear and disappear, and preserves unsaved input and report
+  exports without a page reload.
+- Existing asset tests validate CSS hot updates, source maps, stylesheet cascade
+  at mobile/desktop widths, and unchanged toolbar image bytes/URL.
+- Existing real-server HTTP asset tests exercise every development entry plus
+  production routes and response contracts. Production browser tests cover page
+  startup, reports/charts, editor interactions, tooltips and service workers.
+- All 292 dependency cases pass on Node 24. Clean Node 22 installation and
+  production build pass, with no known vulnerabilities reported by npm audit.
+- Full Node 22 Chromium suite passes 538 cases, including production asset and
+  report/interaction coverage. Full Node 24/MongoDB 8 backend coverage passes
+  1,947 tests with one existing pending case.
+- Full current-head hosted CI remains required before integration.
+
+[Matched measurements](../audits/webpack-refresh-comparison.json) show one fewer
+direct declaration and five fewer package paths, but **4,431,567 more installed
+file bytes** in the development tree. Production paths are unchanged. App gzip
+increases 5,086 bytes; the total app/page-entry gzip increase is 5,073 bytes.
+These are installed file and transfer measurements on Node 22, not image size,
+build-time or server heap/RSS results. The original-source inline CSS maps and
+new build-tool functionality have a cost; this update is not a size-saving claim.
+
+No deployment configuration change is required. Production rendering and
+interaction contracts remain required gates; development compilation errors
+use the new middleware's overlay. Restore the manifest, lockfile, development
+middleware/client wiring and associated consumer checks together to roll back.

--- a/lib/server/app.js
+++ b/lib/server/app.js
@@ -345,13 +345,11 @@ function create (env, ctx) {
     app.use(
       middleware(compiler, {
         // webpack-dev-middleware options
-        publicPath: webpack_conf.output.publicPath
+        publicPath: webpack_conf.output.publicPath,
+        hot: { heartbeat: 1000 }
       })
     );
 
-    app.use(require("webpack-hot-middleware")(compiler, {
-      heartbeat: 1000
-    }));
   }
 
   // Production bundling

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,11 +67,10 @@
         "should": "^13.2.3",
         "socket.io-client": "^4.8.3",
         "supertest": "^7.2.2",
-        "webpack": "^5.74.0",
+        "webpack": "^5.110.3",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.10.0",
-        "webpack-dev-middleware": "^8.0.3",
-        "webpack-hot-middleware": "^2.25.2",
+        "webpack-dev-middleware": "^8.3.0",
         "xml2js": "^0.5.0",
         "xss": "^1.0.15"
       },
@@ -2622,6 +2621,8 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2645,6 +2646,8 @@
     },
     "node_modules/@jsonjoy.com/base64": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2660,6 +2663,8 @@
     },
     "node_modules/@jsonjoy.com/buffers": {
       "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2675,6 +2680,8 @@
     },
     "node_modules/@jsonjoy.com/codegen": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2689,12 +2696,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.71.0.tgz",
+      "integrity": "sha512-9DFR/j+bm+tig1abs1CWS1/r0IVjNUdTp/+q6R/PXayXpO1rgbUh7tkanGYP40I0zdxbOreN3tmzBpVHgfMKzg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.71.0",
+        "@jsonjoy.com/fs-node-utils": "4.71.0",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -2709,13 +2718,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.71.0.tgz",
+      "integrity": "sha512-dRw5ojxzep3lntVGVBLzQUMYj1hXLH+DAz9sK0vKU+594x/zA2nYPOiitlyhYtOJ2nv1FXNq7c55rgwANknIWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-core": "4.71.0",
+        "@jsonjoy.com/fs-node-builtins": "4.71.0",
+        "@jsonjoy.com/fs-node-utils": "4.71.0",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -2730,15 +2741,17 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.71.0.tgz",
+      "integrity": "sha512-yt5Ak0otPdHPIlmMvF16aLG2qSZL52EYJ7HOkYpBcIPWw+kmT1FtTSj4oiV2OUkJbG8pLzA+RhMgrlRl85QuBw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "@jsonjoy.com/fs-print": "4.57.2",
-        "@jsonjoy.com/fs-snapshot": "4.57.2",
+        "@jsonjoy.com/fs-core": "4.71.0",
+        "@jsonjoy.com/fs-node-builtins": "4.71.0",
+        "@jsonjoy.com/fs-node-utils": "4.71.0",
+        "@jsonjoy.com/fs-print": "4.71.0",
+        "@jsonjoy.com/fs-snapshot": "4.71.0",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -2754,7 +2767,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.71.0.tgz",
+      "integrity": "sha512-BSzl+QFSxZF58BxGjV1wqCJ+qSn3b2IZnb+z3hDQq6goqOO5RuxF8gRihjsFx17AfpEpa7XjYcP8XpQtDU8RrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2769,13 +2784,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.71.0.tgz",
+      "integrity": "sha512-OlXBZKIeDx5bIGcQmn0w+nVkLheCiuQSepKiBAiWSWimSdn8Q6Yc9ih2y8zStcJk31fieqnov9V+o8XTWn/5Rw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2"
+        "@jsonjoy.com/fs-fsa": "4.71.0",
+        "@jsonjoy.com/fs-node-builtins": "4.71.0",
+        "@jsonjoy.com/fs-node-utils": "4.71.0"
       },
       "engines": {
         "node": ">=10.0"
@@ -2789,11 +2806,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.71.0.tgz",
+      "integrity": "sha512-YtzCL3jbKYx6LHxqS9ymJ9Ob7SO9cucI+kpNO3LijGNFEjFbvNsTlHkvFgocAMAjUk96TpQTCsYkzFQi1CdlAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.2"
+        "@jsonjoy.com/fs-node-builtins": "4.71.0",
+        "glob-to-regex.js": "^1.0.1"
       },
       "engines": {
         "node": ">=10.0"
@@ -2807,11 +2827,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.71.0.tgz",
+      "integrity": "sha512-OhfDSdvyO8uGV0U11OP+mOeVCPgjuP1HqCGR/TdBQLxHoDEWJAK3KOP5fPXo57H7i3G0x0Vmv8xPRHDle4XGzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.71.0",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -2826,12 +2848,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.71.0.tgz",
+      "integrity": "sha512-md+Wov365xa9A3nfW9YQTHLcweHHAee/e/0UoVRbldEHxboPJknuO3sEkNVVECO0dTqKra/ERaQylAMRrGWd0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.71.0",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -2848,6 +2872,8 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
       "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2863,6 +2889,8 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
       "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2878,6 +2906,8 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
       "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2903,6 +2933,8 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
       "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2921,6 +2953,8 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
       "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2940,6 +2974,8 @@
     },
     "node_modules/@jsonjoy.com/json-pack": {
       "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2965,6 +3001,8 @@
     },
     "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2980,6 +3018,8 @@
     },
     "node_modules/@jsonjoy.com/json-pointer": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2999,6 +3039,8 @@
     },
     "node_modules/@jsonjoy.com/util": {
       "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3018,6 +3060,8 @@
     },
     "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3242,15 +3286,6 @@
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -3520,17 +3555,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3948,6 +3972,8 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5115,7 +5141,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.3",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5981,6 +6009,8 @@
     },
     "node_modules/glob-to-regex.js": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5993,11 +6023,6 @@
       "peerDependencies": {
         "tslib": "2"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.1.4",
@@ -6147,21 +6172,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/html-entities": {
-      "version": "2.6.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "dev": true,
@@ -6247,6 +6257,8 @@
     },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7127,18 +7139,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/loader-runner": {
-      "version": "4.3.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -7271,18 +7271,20 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.57.2",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.71.0.tgz",
+      "integrity": "sha512-Zwrk7TpTXBkic7taZL+2QeppbauG0QOufRsT1zuXDYLW8jCajH0W1VSZ17+I7ODqiNbH9J1Vf1QJCqFlCfurDg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.2",
-        "@jsonjoy.com/fs-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node": "4.57.2",
-        "@jsonjoy.com/fs-node-builtins": "4.57.2",
-        "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
-        "@jsonjoy.com/fs-node-utils": "4.57.2",
-        "@jsonjoy.com/fs-print": "4.57.2",
-        "@jsonjoy.com/fs-snapshot": "4.57.2",
+        "@jsonjoy.com/fs-core": "4.71.0",
+        "@jsonjoy.com/fs-fsa": "4.71.0",
+        "@jsonjoy.com/fs-node": "4.71.0",
+        "@jsonjoy.com/fs-node-builtins": "4.71.0",
+        "@jsonjoy.com/fs-node-to-fsa": "4.71.0",
+        "@jsonjoy.com/fs-node-utils": "4.71.0",
+        "@jsonjoy.com/fs-print": "4.71.0",
+        "@jsonjoy.com/fs-snapshot": "4.71.0",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -7293,9 +7295,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
       }
     },
     "node_modules/memory-pager": {
@@ -7376,6 +7375,79 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.10.0.tgz",
+      "integrity": "sha512-2//60T4S0X1Ug/dqLDOgDaGlZsN1Lv8hf8oB0NOV/KIHSaXlPwXBBIbim79dE2Z7NEs52ES8YHoSv6Lmsk+XNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.3",
+        "terser": "^5.51.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@napi-rs/image": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "imagemin": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "sharp": {
+          "optional": true
+        },
+        "svgo": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/minipass": {
@@ -9303,6 +9375,8 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9682,6 +9756,8 @@
     },
     "node_modules/tapable": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9693,7 +9769,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.47.1",
+      "version": "5.51.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+      "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -9707,65 +9785,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@minify-html/node": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/css": {
-          "optional": true
-        },
-        "@swc/html": {
-          "optional": true
-        },
-        "clean-css": {
-          "optional": true
-        },
-        "cssnano": {
-          "optional": true
-        },
-        "csso": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "html-minifier-terser": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
       }
     },
     "node_modules/test-exclude": {
@@ -9853,7 +9872,9 @@
       "license": "MIT"
     },
     "node_modules/thingies": {
-      "version": "2.6.0",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+      "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9927,6 +9948,8 @@
     },
     "node_modules/tree-dump": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -10143,11 +10166,12 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -10164,34 +10188,31 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.106.2",
+      "version": "5.110.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
+      "integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
-        "eslint-scope": "5.1.1",
+        "enhanced-resolve": "^5.24.4",
+        "es-module-lexer": "^2.1.0",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.1",
         "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.7.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -10319,14 +10340,16 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "8.0.3",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-8.3.0.tgz",
+      "integrity": "sha512-jFNNMB29ugmkEUFW9cpWNqcWFQNwuMTMVoRpKVAiz/5nh3gA4x9x6DRPhNHGc/SLre7pEP9yrAPDAmCvdCblKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "memfs": "^4.56.10",
+        "ansi-html-community": "^0.0.8",
+        "memfs": "^4.68.2",
         "mime-types": "^3.0.2",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
+        "range-parser": "^1.3.0",
         "schema-utils": "^4.3.3"
       },
       "engines": {
@@ -10360,14 +10383,18 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/webpack-hot-middleware": {
-      "version": "2.26.1",
+    "node_modules/webpack-dev-middleware/node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-html-community": "0.0.8",
-        "html-entities": "^2.1.0",
-        "strip-ansi": "^6.0.0"
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/webpack-merge": {
@@ -10384,7 +10411,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.4.1",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -150,11 +150,10 @@
     "should": "^13.2.3",
     "socket.io-client": "^4.8.3",
     "supertest": "^7.2.2",
-    "webpack": "^5.74.0",
+    "webpack": "^5.110.3",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-middleware": "^8.0.3",
-    "webpack-hot-middleware": "^2.25.2",
+    "webpack-dev-middleware": "^8.3.0",
     "xml2js": "^0.5.0",
     "xss": "^1.0.15"
   },
@@ -183,7 +182,6 @@
       "diff": "8.0.3",
       "serialize-javascript": "7.0.5"
     },
-    "terser-webpack-plugin": "5.6.0",
     "nightscout-connect": {
       "axios": "1.20.0"
     },

--- a/tests/browser/assets.test.js
+++ b/tests/browser/assets.test.js
@@ -62,10 +62,19 @@ describe('Webpack image and CSS update contracts', function () {
       await assertImage(page, origin, '/bundle');
       assert.ok(requests.includes('/bundle' + imagePath));
       const map = JSON.parse(fs.readFileSync(path.join(root, 'node_modules/.cache/_ns_cache/public/js/bundle.app.js.map'), 'utf8'));
+      // Webpack may attach CSS maps to the injected styles instead of the JS
+      // map. Validate the original sources actually shipped to the browser.
+      const maps = [map];
+      for (const style of await page.locator('style[data-webpack]').allTextContents()) {
+        for (const match of style.matchAll(/sourceMappingURL=data:application\/json;charset=utf-8;base64,([A-Za-z0-9+/=]+)/g)) {
+          maps.push(JSON.parse(Buffer.from(match[1], 'base64').toString('utf8')));
+        }
+      }
       for (const file of ['drawer.css', 'dropdown.css', 'sgv.css']) {
-        const index = map.sources.findIndex(source => source.includes('static/css/' + file));
-        assert.ok(index >= 0, 'Missing CSS source map: ' + file);
-        assert.equal(map.sourcesContent[index], fs.readFileSync(path.join(root, 'static/css', file), 'utf8'));
+        const original = fs.readFileSync(path.join(root, 'static/css', file), 'utf8');
+        assert.ok(maps.some(sourceMap => sourceMap.mappings && sourceMap.sources.some((source, index) =>
+          source.includes('static/css/' + file) && sourceMap.sourcesContent[index] === original)),
+        'Missing original CSS source/mapping: ' + file);
       }
     });
   });

--- a/tests/browser/page-hmr-worker.js
+++ b/tests/browser/page-hmr-worker.js
@@ -35,9 +35,8 @@ app.use((request, response, next) => {
   next();
 });
 for (const [url, html] of documents) app.get(url, (request, response) => response.type('html').send(html));
-const development = require('webpack-dev-middleware')(compiler, {publicPath: config.output.publicPath, stats: false});
-const hot = require('webpack-hot-middleware')(compiler, {heartbeat: 1000, log: false});
-app.use(development); app.use(hot);
+const development = require('webpack-dev-middleware')(compiler, {publicPath: config.output.publicPath, stats: 'errors-only', hot: {heartbeat: 1000}});
+app.use(development);
 const server = http.createServer(app);
 let origin, latest, closing = false;
 function notify() {if (origin && latest && process.connected) process.send({...latest, origin});}
@@ -49,9 +48,8 @@ server.listen(0, '127.0.0.1', () => {origin = 'http://127.0.0.1:' + server.addre
 async function close() {
   if (closing) return;
   closing = true;
-  hot.close();
-  await new Promise(resolve => server.close(resolve));
   await new Promise(resolve => development.close(resolve));
+  await new Promise(resolve => server.close(resolve));
   await new Promise(resolve => compiler.close(resolve));
   fs.rmSync(directory, {recursive: true, force: true});
   process.exit(0);
@@ -60,6 +58,10 @@ process.on('disconnect', close);
 process.on('SIGTERM', close);
 process.on('message', message => {
   if (message.close) return close();
-  if (!sources.has(message.entry) || !Number.isInteger(message.version) || message.version < 1 || message.version > 2) throw new Error('Invalid HMR fixture update');
+  if (message.broken && sources.has(message.entry)) {
+    fs.writeFileSync(path.join(directory, 'bundle', names[message.entry]), sources.get(message.entry) + '\nconst ownedBrokenFixture = ;\n');
+    return;
+  }
+  if (!sources.has(message.entry) || !Number.isInteger(message.version) || message.version < 1 || message.version > 4) throw new Error('Invalid HMR fixture update');
   write(message.entry, message.version);
 });

--- a/tests/browser/page-hmr.test.js
+++ b/tests/browser/page-hmr.test.js
@@ -81,4 +81,33 @@ describe('Actual page entries with development hot middleware', function () {
       assert.deepEqual(external, [], 'Unexpected external HMR request');
     } finally {await context.close();}
   });
+
+  it('recovers from repeated compile errors without losing an unsaved draft or reloading', async function () {
+    this.timeout(120000);
+    const context = await getBrowser().newContext({serviceWorkers: 'block'});
+    try {
+      const page = await context.newPage();
+      let navigations = 0;
+      page.on('framenavigated', frame => {if (frame === page.mainFrame()) navigations++;});
+      await page.goto(origin + '/reports');
+      await page.waitForFunction(() => window.pageHotVersions && window.pageHotVersions.reports === 2);
+      await page.locator('#draft').fill('Retain through compilation failure');
+      for (const version of [3, 4]) {
+        const failed = assert.rejects(compiled(worker), /ownedBrokenFixture|Unexpected token/);
+        worker.send({entry: 'reports', broken: true});
+        await failed;
+        await page.locator('#webpack-dev-middleware-hot-overlay').waitFor({state: 'visible'});
+        assert.equal(await page.locator('#draft').inputValue(), 'Retain through compilation failure');
+        const recovered = compiled(worker);
+        worker.send({entry: 'reports', version});
+        await recovered;
+        await page.waitForFunction(version => window.pageHotVersions.reports === version, version);
+        await page.locator('#webpack-dev-middleware-hot-overlay').waitFor({state: 'detached'});
+        assert.equal(await page.locator('#draft').inputValue(), 'Retain through compilation failure');
+        assert.equal(navigations, 1);
+        assert.equal(await page.evaluate(() => typeof window.Nightscout.reportclient), 'function');
+      }
+    } finally {await context.close();}
+  });
+
 });

--- a/tests/dependency-fast-uri.test.js
+++ b/tests/dependency-fast-uri.test.js
@@ -80,7 +80,7 @@ describe('fast-uri dependency security and compatibility', function () {
 // Resolve Ajv through each installed consumer, rather than testing the root
 // Ajv 6 package (which uses uri-js and would not exercise this upgrade).
 describe('fast-uri compatibility with installed Ajv consumers', function () {
-  ['webpack', 'webpack-dev-middleware', 'terser-webpack-plugin', 'ajv-formats', 'table'].forEach(function (consumer) {
+  ['webpack', 'webpack-dev-middleware', 'minimizer-webpack-plugin', 'ajv-formats', 'table'].forEach(function (consumer) {
     it(consumer + ' resolves external and escaped local schema references', function () {
       const requireConsumer = createRequire(require.resolve(consumer));
       const Ajv = requireConsumer('ajv');

--- a/tests/fixtures/http-assets/worker.js
+++ b/tests/fixtures/http-assets/worker.js
@@ -155,7 +155,7 @@ async function run() {
       assert.match(built.headers['content-type'], /javascript/);
       if (entry === 'app') {
         assert.ok(built.text.includes('Nightscout bundle ready'));
-        assert.ok(built.text.includes('webpack-hot-middleware'));
+        assert.ok(built.text.includes('webpack-dev-middleware/client'));
       }
     }
     results.push('actual webpack development middleware');

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const pluginArray = [];
-// In dev mode, webpack-hot-middleware injects the HMR client into both
+// In dev mode, webpack-dev-middleware injects the HMR client into both
 // entries (app + clock). With devtool='source-map' the shared modules
 // emit .map files keyed by [name] and collide ("Multiple assets emit
 // different content to the same filename js/bundle.app.js.map").
@@ -135,7 +135,10 @@ if (process.env.NODE_ENV === 'development') {
   pluginArray.push(new webpack.HotModuleReplacementPlugin());
   pluginArray.push(new webpack.NoEmitOnErrorsPlugin());
 
-  const hot = 'webpack-hot-middleware/client?port=1337';
+  // Resolve the exported subpath before appending its resource query.
+  // Preserve HMR-only updates and avoid a new progress/runtime-error overlay.
+  const hot = require.resolve('webpack-dev-middleware/client') + '?reload=false&progress=false&overlay=' +
+    encodeURIComponent(JSON.stringify({runtimeErrors: false}));
 
   appEntry.unshift(hot);
   clockEntry.unshift(hot);


### PR DESCRIPTION
Update webpack to 5.110.3 and webpack-dev-middleware to 8.3.0, and use the middleware's built-in HMR implementation to remove webpack-hot-middleware. The same development endpoint and heartbeat remain, with reload fallback and new progress/runtime-error overlays disabled. Compile errors use the maintained overlay; repeated recovery preserves unsaved input.

Webpack now uses minimizer-webpack-plugin, so remove the obsolete terser-webpack-plugin override and validate Ajv/fast-uri through the new consumer. Resolve the exported HMR client before adding its resource query to avoid the package-subpath resolution failure observed in the initial test run. Original CSS sources now live in inline maps on injected styles; browser tests verify those exact sources and mappings while keeping CSS minification enabled.

Validation:
- Clean Node 22 installation/production build; full npm audit reports zero known vulnerabilities at validation time.
- 292 dependency checks on Node 24.
- All 538 Chromium browser cases on Node 22.
- Nine WebKit HMR/asset/cascade cases on Node 24, including two compile-error recovery cycles without reload or draft loss.
- Full Node 24/MongoDB 8 backend coverage: 1,947 passing, one existing pending case, including actual production/development HTTP asset contracts.
- Full hosted CI required before merge.

This removes one declaration and five development package paths. All production lock records are unchanged. The matched comparison increases installed build-tool files by 4,431,567 bytes and app gzip by 5,086 bytes (all app/page entries: +5,073 bytes). These costs are documented; no server-memory or image-size saving is claimed. Production UI is covered by the existing render/interaction suite; development error presentation uses the new overlay.

Targets chore/nightscout-modernization for M09. Review, rollback scope and measurements are in docs/test-specs/webpack-refresh.md and docs/audits/webpack-refresh-comparison.json. #8605 remains draft.
