### PR TITLE
Clean application lint findings and enforce the baseline in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+      - name: Lint application sources
+        if: matrix.node-version == '22' && matrix.mongodb-version == '5.0.32'
+        run: npm run lint
       - name: Validate dependency resolution
         run: npm ls brace-expansion postcss mocha nanoid js-yaml eslint nyc dompurify socket.io-parser fast-uri ip-address d3 d3-color express body-parser socket.io socket.io-client engine.io engine.io-client socket.io-adapter ws axios @babel/core @babel/preset-env babel-loader uuid --all
       - name: Run Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -365,3 +365,8 @@ Lint configuration is maintained in `eslint.config.cjs`. `npm run lint` reports
 CLI rule severities; development webpack builds display the same diagnostics as
 non-blocking warnings. Existing lint debt and the public-API integration are
 documented in the [ESLint modernization review](docs/test-specs/eslint-modernization.md).
+
+Application lint is now a required step in the existing Node 22/MongoDB 5.0.32
+CI job. Run `npm run lint` before submitting application changes. Errors fail
+the check; the remaining security warnings are retained for individual review.
+See the [lint cleanup evidence](docs/test-specs/lint-cleanup.md).

--- a/docs/audits/lint-cleanup-results.json
+++ b/docs/audits/lint-cleanup-results.json
@@ -1,0 +1,126 @@
+{
+  "scope": "Application sources under lib; maintained ESLint configuration unchanged. One intentional MongoDB retry loop is locally documented. Security warnings are retained, not suppressed.",
+  "before": {
+    "errors": 53,
+    "warnings": 47
+  },
+  "after": {
+    "files": 227,
+    "errors": 0,
+    "warnings": 16
+  },
+  "remainingWarnings": [
+    {
+      "file": "lib/api/entries/index.js",
+      "line": 595,
+      "column": 16,
+      "ruleId": "security/detect-non-literal-regexp",
+      "message": "Found non-literal argument to RegExp Constructor"
+    },
+    {
+      "file": "lib/middleware/express-extension-to-accept.js",
+      "line": 19,
+      "column": 16,
+      "ruleId": "security/detect-non-literal-regexp",
+      "message": "Found non-literal argument to RegExp Constructor"
+    },
+    {
+      "file": "lib/profilefunctions.js",
+      "line": 220,
+      "column": 30,
+      "ruleId": "security/detect-unsafe-regex",
+      "message": "Unsafe Regular Expression"
+    },
+    {
+      "file": "lib/server/app.js",
+      "line": 13,
+      "column": 7,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found existsSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/app.js",
+      "line": 15,
+      "column": 7,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found existsSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/app.js",
+      "line": 17,
+      "column": 7,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found existsSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/app.js",
+      "line": 173,
+      "column": 21,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/app.js",
+      "line": 298,
+      "column": 23,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/app.js",
+      "line": 299,
+      "column": 23,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/enclave.js",
+      "line": 23,
+      "column": 9,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found existsSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/enclave.js",
+      "line": 24,
+      "column": 14,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/env.js",
+      "line": 71,
+      "column": 12,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/env.js",
+      "line": 72,
+      "column": 15,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/env.js",
+      "line": 75,
+      "column": 16,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/env.js",
+      "line": 237,
+      "column": 14,
+      "ruleId": "security/detect-non-literal-fs-filename",
+      "message": "Found readFileSync from package \"fs\" with non literal argument at index 0"
+    },
+    {
+      "file": "lib/server/query.js",
+      "line": 242,
+      "column": 12,
+      "ruleId": "security/detect-non-literal-regexp",
+      "message": "Found non-literal argument to RegExp Constructor"
+    }
+  ]
+}

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -81,6 +81,7 @@ At the audit baseline, completed foundations were: D3 7.9.0, jsdom-backed test t
   Acceptance: highest compatible release per consumer, focused exploit/API regression where relevant, full CI and explicit engine/browser/DB compatibility. Remove an override only after every affected parent resolves safely. Do not use forced audit fixes or a bulk latest-version update; keep Dependabot's current target configuration.
   The [webpack/HMR refresh](../test-specs/webpack-refresh.md) removes a separate hot-middleware dependency using the maintained development middleware, with repeated update/error recovery coverage and explicit installed/browser size costs. It does not complete the remaining dependency reviews.
   The [ESLint refresh](../test-specs/eslint-modernization.md) replaces the webpack wrapper with a scoped public-API integration, preserves the prior non-blocking development policy, and records the remaining CLI diagnostics for separate cleanup. Production dependencies and bundle bytes are unchanged.
+  The [application lint cleanup](../test-specs/lint-cleanup.md) establishes a zero-error baseline and adds lint to one existing CI matrix job; sixteen security warnings and the separately identified API3 token-log issue remain for targeted review.
 
 ## Phase 3 — reduce production installation and browser cost
 

--- a/docs/test-specs/lint-cleanup.md
+++ b/docs/test-specs/lint-cleanup.md
@@ -1,0 +1,44 @@
+# Application lint baseline and CI gate (M09 partial)
+
+The ESLint 10 migration exposed 53 errors and 47 warnings in application code.
+This follow-up establishes a zero-error baseline without changing global rule
+severities or hiding security warnings. [Recorded results](../audits/lint-cleanup-results.json)
+show zero errors and sixteen security warnings across 227 files.
+
+Changes are limited to unused catch bindings/parameters, values overwritten
+before use, an unused private profile-editor wrapper, an unused websocket return
+binding, and obsolete lint directives. Keep the websocket initialization call
+and the basal translation call whose returned value was unused. Keep initial
+values that are still read, including Loopalyzer's interpolation coefficients.
+The intentionally unbounded MongoDB retry loop receives one local explanation:
+success returns, fatal errors throw, and retryable failures continue as before.
+No retry/timeout behavior is changed to satisfy lint.
+
+Add `npm run lint` to the existing Node 22/MongoDB 5.0.32 job. It runs once per
+matrix, after installation, and fails new application lint errors. This adds no
+job or environment. The sixteen security warnings remain visible and do not
+fail the gate; they need individual reachability review, not blanket suppression.
+
+Regression evidence:
+
+- `npm run lint` succeeds on Node 24 with zero errors; the Node 22 diagnostic run
+  also reports zero errors and sixteen warnings.
+- All 283 client-core tests pass on Node 22, including profile migration and
+  treatment/data selection contracts.
+- Added numerical raw-glucose fixtures cover calibration/display branches over
+  repeated calls. Basal fixtures preserve translation call order and selected
+  output for both normal and temporary basal over two cycles.
+- Production builds pass on Node 22 and Node 24.
+- Full local Node 22/MongoDB 6 backend coverage passes 1,924 tests with one
+  existing pending case. All 538 Chromium browser tests pass on Node 24.
+- Current-head hosted CI remains required before integration, including
+  verification that the lint step runs in exactly the intended existing job.
+
+No dependency is removed in this cleanup and no package-size, heap or RSS saving
+is claimed. Keep the unused-dataflow cleanup distinct from any change to therapy
+algorithms, report interpolation, authentication behavior or MongoDB lifecycle.
+
+Follow-up: during review, the existing API3 alarm subscription failure log was
+found to include the submitted access token. Track that as a separate security
+fix with a sentinel-token regression; this cleanup only removes the unused
+callback parameter and does not claim to fix that logging path.

--- a/lib/admin_plugins/daterangedelete.js
+++ b/lib/admin_plugins/daterangedelete.js
@@ -199,8 +199,8 @@ daterangedelete.actions[0].init = function init(client, callback) {
     var previewLimit = 10000;
 
     collectionsToPreview.forEach(function(col) {
-      var queryParams = '';
-      var dateField = '';
+      var queryParams;
+      var dateField;
 
       if (col === 'entries') {
         dateField = 'date';
@@ -394,8 +394,8 @@ daterangedelete.actions[0].code = function deleteRecordsInDateRange(client, call
     }
 
     var col = collections[colIndex];
-    var queryParams = '';
-    var dateField = '';
+    var queryParams;
+    var dateField;
 
     if (col === 'entries') {
       dateField = 'date';

--- a/lib/api/profile/index.js
+++ b/lib/api/profile/index.js
@@ -27,7 +27,7 @@ function configure (app, wares, ctx) {
    * db queries in a fairly regimented manner.
    * This middleware executes the query, returning the results as JSON
    */
-    function query_models (req, res, next) {
+    function query_models (req, res) {
         var query = req.query;
 
         // If "?count=" is present, use that number to decide how many to return.

--- a/lib/api3/alarmSocket.js
+++ b/lib/api3/alarmSocket.js
@@ -65,7 +65,7 @@ function AlarmSocket (app, env, ctx) {
 
     // Native client
     if (message && message.accessToken) {
-      return ctx.authorization.resolveAccessToken(message.accessToken, function resolveFinishForToken (err, auth) {
+      return ctx.authorization.resolveAccessToken(message.accessToken, function resolveFinishForToken (err) {
         if (err) {
           console.log(`${LOG_ERROR} Authorization failed for accessToken:`, message.accessToken);
 
@@ -170,7 +170,7 @@ function AlarmSocket (app, env, ctx) {
    * Emit alarm to subscribed clients
    * @param {Object} notofication to emit
    */
-   
+
   self.emitNotification = function emitNotification (notify) {
     if (notify.clear) {
       self.namespace.emit('clear_alarm', notify);

--- a/lib/api3/generic/history/operation.js
+++ b/lib/api3/generic/history/operation.js
@@ -64,9 +64,9 @@ function parseFilter (opCtx) {
 
   const { req, res } = opCtx;
 
-  let lastModified = null
+  let lastModified
     , lastModifiedParam = req.params.lastModified
-    , operator = null;
+    , operator;
 
   if (lastModifiedParam) {
 
@@ -91,7 +91,7 @@ function parseFilter (opCtx) {
 
     try {
       lastModified = dateTools.floorSeconds(new Date(lastModifiedHeader));
-    } catch (err) {
+    } catch {
       opTools.sendJSONStatus(res, apiConst.HTTP.BAD_REQUEST, apiConst.MSG.HTTP_400_BAD_LAST_MODIFIED);
       return null;
     }

--- a/lib/authorization/storage.js
+++ b/lib/authorization/storage.js
@@ -25,7 +25,7 @@ function init (env, ctx) {
 
     try {
       return { value: new ObjectID(id) };
-    } catch (err) {
+    } catch {
       return { error: 'Invalid _id format: ' + String(id) };
     }
   }

--- a/lib/client-core/careportal/event-types.js
+++ b/lib/client-core/careportal/event-types.js
@@ -27,11 +27,11 @@ var INPUT_KEYS = [
 function pick(obj, keys) {
   var out = {};
   keys.forEach(function (k) {
-    /* eslint-disable security/detect-object-injection */
+
     if (obj && Object.prototype.hasOwnProperty.call(obj, k)) {
       out[k] = obj[k];
     }
-    /* eslint-enable security/detect-object-injection */
+
   });
   return out;
 }
@@ -46,7 +46,7 @@ function buildInputMatrix(allEventTypes) {
   if (!Array.isArray(allEventTypes)) return matrix;
   allEventTypes.forEach(function (e) {
     if (e && e.val) {
-      /* eslint-disable-next-line security/detect-object-injection */
+
       matrix[e.val] = pick(e, INPUT_KEYS);
     }
   });
@@ -58,7 +58,7 @@ function buildSubmitHooks(allEventTypes) {
   if (!Array.isArray(allEventTypes)) return hooks;
   allEventTypes.forEach(function (e) {
     if (e && e.val) {
-      /* eslint-disable-next-line security/detect-object-injection */
+
       hooks[e.val] = e.submitHook;
     }
   });

--- a/lib/client-core/careportal/normalize-treatment.js
+++ b/lib/client-core/careportal/normalize-treatment.js
@@ -53,7 +53,7 @@ function normalize(raw, opts) {
   // Reason lookup → reasonDisplay
   var reasons = [];
   if (Object.prototype.hasOwnProperty.call(inputMatrix, raw.eventType)) {
-    /* eslint-disable-next-line security/detect-object-injection */
+
     reasons = inputMatrix[raw.eventType].reasons || [];
   }
   for (var i = 0; i < reasons.length; i++) {
@@ -109,11 +109,11 @@ function normalize(raw, opts) {
   // Strip empty / null fields — same predicate the original used.
   var cleaned = {};
   Object.keys(data).forEach(function (key) {
-    /* eslint-disable security/detect-object-injection */
+
     if (data[key] !== '' && data[key] !== null) {
       cleaned[key] = data[key];
     }
-    /* eslint-enable security/detect-object-injection */
+
   });
 
   return cleaned;

--- a/lib/client/adminnotifiesclient.js
+++ b/lib/client/adminnotifiesclient.js
@@ -68,7 +68,7 @@ function init (client, $) {
     if (messages && messages.length > 0) {
       html += '<p><b>' + translate('You have administration messages') + '</b></p>';
       for(var i = 0 ; i < messages.length; i++) {
-        /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+          // verified false positive
         var m = messages[i];
         const ago = Math.round((Date.now() - m.lastRecorded) / 60000);
         html += wrapmessage(translate(m.title), translate(m.message), m.count, ago, m.persistent);

--- a/lib/client/boluscalc.js
+++ b/lib/client/boluscalc.js
@@ -41,7 +41,7 @@ function init (client, $) {
   }
 
   function isTouch () {
-    try { document.createEvent('TouchEvent'); return true; } catch (e) { return false; }
+    try { document.createEvent('TouchEvent'); return true; } catch { return false; }
   }
 
   function setDateAndTime (time) {
@@ -250,7 +250,7 @@ function init (client, $) {
       var html = '<table  style="float:right;margin-right:20px;font-size:12px">';
       var carbs = 0;
       for (var fi = 0; fi < record.foods.length; fi++) {
-        /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+          // verified false positive
         var f = record.foods[fi];
         carbs += f.carbs * f.portions;
         html += '<tr>';
@@ -425,7 +425,7 @@ function init (client, $) {
     if (record.foods.length) {
       var gisum = 0;
       for (var fi = 0; fi < record.foods.length; fi++) {
-        /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+          // verified false positive
         var f = record.foods[fi];
         record.carbs += f.carbs * f.portions;
         gisum += f.carbs * f.portions * f.gi;
@@ -652,7 +652,7 @@ function init (client, $) {
     });
     $('#bc_quickpick').empty().append($('<option>').val(-1).text(translate('(none)')));
     for (var i = 0; i < records.length; i++) {
-      /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+        // verified false positive
       var r = records[i];
       $('#bc_quickpick').append($('<option>').val(i).text(htmlUtils.toTextContent(r.name + ' (' + r.carbs + ' g)')));
     }
@@ -697,7 +697,7 @@ function init (client, $) {
     }
     $('#bc_data').empty();
     for (var i = 0; i < foodlist.length; i++) {
-      /* eslint-disable security/detect-object-injection */ // verified false positive
+        // verified false positive
       if (filter.category !== '' && foodlist[i].category !== filter.category) { continue; }
       if (filter.subcategory !== '' && foodlist[i].subcategory !== filter.subcategory) { continue; }
       if (filter.name !== '' && foodlist[i].name.toLowerCase().indexOf(filter.name.toLowerCase()) < 0) { continue; }
@@ -707,7 +707,7 @@ function init (client, $) {
       o += foodlist[i].unit + ' | ';
       o += 'Carbs: ' + foodlist[i].carbs + ' g';
       $('#bc_data').append($('<option>').val(i).text(htmlUtils.toTextContent(o)));
-      /* eslint-enable security/detect-object-injection */ // verified false positive
+        // verified false positive
     }
     $('#bc_addportions').val('1');
 
@@ -732,10 +732,10 @@ function init (client, $) {
             var portions = parseFloat($('#bc_addportions').val().replace(',', '.'));
             if (index !== null && !isNaN(portions) && portions > 0) {
               index = parseInt(index);
-              /* eslint-disable security/detect-object-injection */ // verified false positive
+                // verified false positive
               foodlist[index].portions = portions;
               foods.push(JSON.parse(JSON.stringify(foodlist[index])));
-              /* eslint-enable security/detect-object-injection */ // verified false positive
+                // verified false positive
               $(this).dialog('close');
               boluscalc.calculateInsulin();
             }

--- a/lib/client/browser-settings.js
+++ b/lib/client/browser-settings.js
@@ -216,7 +216,7 @@ function init (client, serverSettings, $) {
 
       function storeInBrowser (data) {
         Object.keys(data).forEach(k => {
-          /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+            // verified false positive
           storage.set(k, data[k]);
         });
       }
@@ -281,7 +281,7 @@ function init (client, serverSettings, $) {
   try {
     settings.eachSetting(function setEach (name) {
       var stored = storage.get(name);
-      /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+        // verified false positive
       return stored !== undefined && stored !== null ? stored : serverSettings.settings[name];
     });
 

--- a/lib/client/browser-utils.js
+++ b/lib/client/browser-utils.js
@@ -40,7 +40,7 @@ function init ($) {
   }
 
   function isTouch () {
-    try { document.createEvent('TouchEvent'); return true; } catch (e) { return false; }
+    try { document.createEvent('TouchEvent'); return true; } catch { return false; }
   }
 
   function closeLastOpenedDrawer (callback) {

--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -101,7 +101,7 @@ function init (client, $) {
       return;
     }
 
-    /* eslint-disable security/detect-object-injection */ // verified false positive by check above
+      // verified false positive by check above
     var reasons = inputMatrix[eventType]['reasons'];
     $('#reasonLabel').css('display', displayType(reasons && reasons.length > 0));
     $('#targets').css('display', displayType(inputMatrix[eventType]['targets']));
@@ -159,7 +159,7 @@ function init (client, $) {
     resetIfHidden(inputMatrix[eventType]['prebolus'], '#preBolus');
     resetIfHidden(inputMatrix[eventType]['split'], '#insulinSplitNow');
     resetIfHidden(inputMatrix[eventType]['split'], '#insulinSplitExt');
-    /* eslint-enable security/detect-object-injection */ // verified false positive
+      // verified false positive
 
     maybePrevent(event);
   };

--- a/lib/client/chart.js
+++ b/lib/client/chart.js
@@ -702,7 +702,7 @@ function init (client, d3, $) {
     var pointTypes = client.settings.showForecast.split(' ');
 
     var points = pointTypes.reduce( function (points, type) {
-      /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+        // verified false positive
       return points.concat(client.sbx.pluginBase.forecastPoints[type] || []);
     }, [] );
 

--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -124,13 +124,13 @@ client.render = function render () {
 
   for (let param in faceParams) {
     if (param === '0') {
-      /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+        // verified false positive
       let faceParam = faceParams[param];
       bgColor = (faceParam.substr(0, 1) === 'c'); // do we want colorful background?
       alwaysShowTime = (faceParam.substr(1, 1) === 'y'); // always show "stale time" text?
       staleMinutes = (faceParam.substr(2, 2) - 0 >= 0) ? faceParam.substr(2, 2) : 13; // threshold value (0=never)
     } else if (!clockCreated) {
-      /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+        // verified false positive
       let faceParam = faceParams[param];
       appendClockFaceParam($inner, faceParam);
     }
@@ -270,7 +270,7 @@ client.render = function render () {
   }
 
   updateClock();
-  
+
 };
 
 function updateClock () {

--- a/lib/client/d3locales.js
+++ b/lib/client/d3locales.js
@@ -237,11 +237,11 @@ d3locales.locale = function locale (language) {
 
   // validate the eventType input before getting the reasons list
   if (Object.prototype.hasOwnProperty.call(mapper, language)) {
-    /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+      // verified false positive
     loc = mapper[language];
   }
 
-  /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+    // verified false positive
   return d3locales[loc];
 };
 

--- a/lib/client/hashauth.js
+++ b/lib/client/hashauth.js
@@ -364,7 +364,7 @@ hashauth.init = function init (client, $) {
   hashauth.inlineCode = function inlineCode () {
     var translate = client.translate;
 
-    var status = null;
+    var status;
 
     if (!hashauth.isAdmin) {
       $('.needsadminaccess').hide();

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -371,7 +371,7 @@ client.load = function load (serverSettings, callback) {
   }
 
   function getTimeFormat (isForScale, compact) {
-    var timeFormat = FORMAT_TIME_12;
+    var timeFormat;
     if (client.settings.timeFormat === 24) {
       timeFormat = isForScale ? FORMAT_TIME_24_SCALE : FORMAT_TIME_24;
     } else {
@@ -907,12 +907,12 @@ client.load = function load (serverSettings, callback) {
     var alarm = null;
     // validate the key before getting the alarm
     if (Object.prototype.hasOwnProperty.call(clientAlarms, key)) {
-      /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+        // verified false positive
       alarm = clientAlarms[key];
     }
     if (!alarm) {
       alarm = { level: level, group: group };
-      /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+        // verified false positive
       clientAlarms[key] = alarm;
     }
     return alarm;
@@ -1002,7 +1002,7 @@ client.load = function load (serverSettings, callback) {
 
     document.addEventListener(visibilityChange, function visibilityChanged () {
       var prevHidden = client.documentHidden;
-      /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+        // verified false positive
       client.documentHidden = document[hidden];
 
       if (prevHidden && !client.documentHidden) {
@@ -1042,7 +1042,7 @@ client.load = function load (serverSettings, callback) {
 
   $('.bgButton').click(function(e) {
     if (alarmingNow()) {
-      /* eslint-disable-next-line security/detect-non-literal-fs-filename */ // verified false positive
+        // verified false positive
       silenceDropdown.open(e);
     }
   });
@@ -1057,7 +1057,7 @@ client.load = function load (serverSettings, callback) {
       Storages.localStorage.set('focusHours', hours);
       refreshChart();
     } else {
-      /* eslint-disable-next-line security/detect-non-literal-fs-filename */ // verified false positive
+        // verified false positive
       viewDropdown.open(e);
     }
   });

--- a/lib/client/receiveddata.js
+++ b/lib/client/receiveddata.js
@@ -10,11 +10,11 @@ function mergeDataUpdate (isDelta, cachedDataArray, receivedDataArray, maxAge) {
     var l = oldArray.length;
 
     for (var i = 0; i < l; i++) {
-      /* eslint-disable security/detect-object-injection */ // verified false positive
+        // verified false positive
       if (oldArray[i] !== null) {
         knownMills.push(oldArray[i].mills);
       }
-      /* eslint-enable security/detect-object-injection */ // verified false positive
+        // verified false positive
     }
 
     var result = {
@@ -24,7 +24,7 @@ function mergeDataUpdate (isDelta, cachedDataArray, receivedDataArray, maxAge) {
 
     l = newArray.length;
     for (var j = 0; j < l; j++) {
-      /* eslint-disable security/detect-object-injection */ // verified false positive
+        // verified false positive
       var item = newArray[j];
       var millsSeen = knownMills.includes(item.mills);
 
@@ -54,7 +54,7 @@ function mergeDataUpdate (isDelta, cachedDataArray, receivedDataArray, maxAge) {
   var i;
 
   for (i = cachedDataArray.length -1; i >= 0; i--) {
-    /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+      // verified false positive
     var element = cachedDataArray[i];
     if (element !== null && element !== undefined && element.mills <= twoDaysAgo) {
       cachedDataArray.splice(i, 1);
@@ -98,14 +98,14 @@ function mergeTreatmentUpdate (isDelta, cachedDataArray, receivedDataArray) {
   var l = receivedDataArray.length;
   var m = cachedDataArray.length;
   for (var i = 0; i < l; i++) {
-    /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+      // verified false positive
     var no = receivedDataArray[i];
     if (!no.action) {
       cachedDataArray.push(no);
       continue;
     }
     for (var j = 0; j < m; j++) {
-      /* eslint-disable security/detect-object-injection */ // verified false positive
+        // verified false positive
       if (no._id === cachedDataArray[j]._id) {
         if (no.action === 'remove') {
           cachedDataArray.splice(j, 1);

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -622,7 +622,7 @@ function init (client, d3) {
       if (treatment.boluscalc.foods && treatment.boluscalc.foods.length) {
         html += '<table><tr><td><strong>' + translate('Food') + '</strong></td></tr>';
         for (var fi = 0; fi < treatment.boluscalc.foods.length; fi++) {
-          /* eslint-disable-next-line security/detect-object-injection */ // verified false positive
+            // verified false positive
           var f = treatment.boluscalc.foods[fi];
           html += '<tr>';
           html += '<td>' + e(f.name) + '</td>';
@@ -1070,7 +1070,7 @@ function init (client, d3) {
       window.alert(translate('Redirecting you to the Profile Editor to create a new profile.'));
       try {
         window.location.href = '/profile';
-      } catch (err) {
+      } catch {
         //doesn't work when running tests, so catch and ignore
       }
       return;

--- a/lib/client/storage.js
+++ b/lib/client/storage.js
@@ -5,7 +5,7 @@
 const own = (object, key) => object != null && Object.prototype.hasOwnProperty.call(object, key);
 const put = (object, key, value) => Object.defineProperty(object, key, {value, writable: true, enumerable: true, configurable: true});
 const plain = value => value !== null && typeof value === 'object' && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
-const decode = raw => {try {return JSON.parse(raw);} catch (_) {return raw;}};
+const decode = raw => {try {return JSON.parse(raw);} catch {return raw;}};
 const empty = value => plain(value) ? Object.keys(value).length === 0 : Array.isArray(value) ? value.length === 0 : typeof value !== 'boolean' && !value;
 
 function backend(name) {
@@ -18,7 +18,7 @@ function backend(name) {
     storage.setItem(key, previous === null ? '1' : previous);
     if (previous === null) storage.removeItem(key);
     return storage;
-  } catch (_) {return null;}
+  } catch {return null;}
 }
 
 const local = backend('localStorage'), session = backend('sessionStorage');
@@ -106,7 +106,7 @@ function adapter(storage, namespace = '') {
       try {
         const value = get(path(args));
         return Array.isArray(args[args.length - 1]) ? Object.values(value).every(item => item != null) : value != null;
-      } catch (_) {return false;}
+      } catch {return false;}
     },
     isEmpty(...args) {
       if (!storage) return null;
@@ -115,7 +115,7 @@ function adapter(storage, namespace = '') {
       try {
         const value = get(path(args));
         return Array.isArray(args[args.length - 1]) ? Object.values(value).every(empty) : empty(value);
-      } catch (_) {return true;}
+      } catch {return true;}
     },
     removeAll(reinitialize) {
       if (!storage) return null;

--- a/lib/data/dataloader.js
+++ b/lib/data/dataloader.js
@@ -35,7 +35,7 @@ function mergeProcessSort(oldData, newData, ageLimit) {
 
   // Merge old and new data, preferring the new objects
 
-  let merged = [];
+  let merged;
   if (oldData && filtered) {
     merged = filtered; // Start with the new / updated data
     for (let i = 0; i < oldData.length; i++) {

--- a/lib/language.js
+++ b/lib/language.js
@@ -142,7 +142,7 @@ function init (fs) {
   language.loadLocalization = function loadLocalization (fs, path) {
     let filename = './translations/' + this.getFilename(this.lang);
     if (path) filename = path.resolve(__dirname, filename);
-    /* eslint-disable-next-line security/detect-non-literal-fs-filename */ // verified false positive; well defined set of values
+      // verified false positive; well defined set of values
     const l = fs.readFileSync(filename);
     this.offerTranslations(JSON.parse(l));
   }

--- a/lib/plugins/ar2.js
+++ b/lib/plugins/ar2.js
@@ -157,7 +157,7 @@ function init (ctx) {
           maxForecastMills = forecast[i].mills;
         }
       }
-      var response = '';
+      var response;
       if (min === max) {
         response = translate('virtAsstAR2ForecastAround', {
           params: [

--- a/lib/plugins/basalprofile.js
+++ b/lib/plugins/basalprofile.js
@@ -113,7 +113,9 @@ function init (ctx) {
 
   function basalMessage(slots, sbx) {
         var basalValue = sbx.data.profile.getTempBasal(sbx.time);
-        var response = translate('virtAsstUnknown');
+        // Preserve translation call order while discarding the unused initial value.
+        translate('virtAsstUnknown');
+        var response;
         var pwd = slots?.pwd?.value;
         var preamble = pwd ? translate('virtAsstPreamble3person', {
             params: [

--- a/lib/plugins/boluswizardpreview.js
+++ b/lib/plugins/boluswizardpreview.js
@@ -166,7 +166,7 @@ function init (ctx) {
 
     results.effect = iob * profile.getSensitivity(sbx.time);
     results.outcome = scaled - results.effect;
-    var delta = 0;
+    var delta;
     var recentCarbs = sbx.data.treatments.slice().reverse().find(function eachTreatment (treatment) {
       return treatment.mills <= sbx.time &&
         sbx.time - treatment.mills < times.mins(60).msecs &&

--- a/lib/plugins/cob.js
+++ b/lib/plugins/cob.js
@@ -196,7 +196,7 @@ var selectCOB = require('../client-core/devicestatus/cob');
   cob.cobCalc = function cobCalc (treatment, profile, lastDecayedBy, time, spec_profile) {
 
     var delay = 20;
-    var isDecaying = 0;
+    var isDecaying;
     var initialCarbs;
 
     if (treatment.carbs) {
@@ -267,7 +267,7 @@ var selectCOB = require('../client-core/devicestatus/cob');
     });
   };
   function virtAsstCOBHandler (next, slots, sbx) {
-    var response = '';
+    var response;
     var cob = sbx?.properties?.cob?.cob;
     var pwd = slots?.pwd?.value;
     var value = cob ? cob : 0;

--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -472,7 +472,7 @@ function init (ctx) {
             min = forecast[i];
           }
         }
-        var response = '';
+        var response;
         if (min === max) {
           response = translate('virtAsstLoopForecastAround', {
             params: [

--- a/lib/plugins/pluginbase.js
+++ b/lib/plugins/pluginbase.js
@@ -30,7 +30,7 @@ function init (majorPills, minorPills, statusPills, bgStatus, tooltip) {
   pluginBase.forecastPoints = {};
 
   function findOrCreatePill (plugin) {
-    var container = null;
+    var container;
 
     if (plugin.pluginType === 'pill-major') {
       container = majorPills;

--- a/lib/plugins/pushover.js
+++ b/lib/plugins/pushover.js
@@ -12,7 +12,7 @@ function init (env, ctx) {
   var pushoverAPI = setupPushover(env);
 
   function selectKeys (notify) {
-    var keys = null;
+    var keys;
 
     if (notify.isAnnouncement) {
       keys = pushoverAPI.announcementKeys;

--- a/lib/plugins/rawbg.js
+++ b/lib/plugins/rawbg.js
@@ -54,7 +54,7 @@ function init (ctx) {
   };
 
   rawbg.calc = function calc(sgv, cal, sbx) {
-    var raw = 0;
+    var raw;
     var cleaned = cleanValues(sgv, cal);
 
     var prefs = rawbg.getPrefs(sbx);

--- a/lib/plugins/xdripjs.js
+++ b/lib/plugins/xdripjs.js
@@ -217,7 +217,7 @@ function init(ctx) {
   sensorState.updateVisualisation = function updateVisualisation (sbx) {
 
     var sensor = sbx.properties.sensorState;
-    var sessionDuration = 'Unknown';
+    var sessionDuration;
     var info = [];
     Object.values(sensor.seenDevices).forEach((device) => {
       info.push( { label: 'Seen: ', value: device.name } );

--- a/lib/profile/profileeditor.js
+++ b/lib/profile/profileeditor.js
@@ -96,14 +96,6 @@ var init = function init () {
     }
   }).done(initeditor);
 
-  // convert simple values to ranges if needed (delegates to pure core)
-  function convertToRanges(profile) {
-    var res = coreMigrate.convertToRanges(profile, defaultprofile);
-    if (res.rangesMismatch) {
-      window.alert(translate('Time ranges of target_low and target_high don\'t  match. Values are restored to defaults.'));
-    }
-  }
-
   function initeditor() {
     $('#pe_history').toggle(client.settings.extendedSettings.profile && client.settings.extendedSettings.profile.history);
     $('#pe_multiple').toggle(client.settings.extendedSettings.profile && client.settings.extendedSettings.profile.multiple);

--- a/lib/report_plugins/glucosedistribution.js
+++ b/lib/report_plugins/glucosedistribution.js
@@ -369,7 +369,7 @@ glucosedistribution.report = function report_glucosedistribution (datastorage, s
   var events = 0;
 
   var GVITotal = 0;
-  var GVIIdeal = 0;
+  var GVIIdeal;
   var GVIIdeal_Time = 0;
 
   var RMSTotal = 0;

--- a/lib/report_plugins/loopalyzer.js
+++ b/lib/report_plugins/loopalyzer.js
@@ -196,7 +196,7 @@ loopalyzer.getIOBs = function(datastorage, daysToShow, profile, client, treatmen
 
       // Loop thru these entries and where no IOB has been found, interpolate between nearby to get a continuous array
       var startIndex = 0
-        , stopIndex = 0;
+        , stopIndex;
       while (startIndex < iobs.length && isNaN(iobs[startIndex])) {
         startIndex++; // Advance start to the first real number
       }
@@ -259,9 +259,9 @@ loopalyzer.getCOBs = function(datastorage, daysToShow, profile, client, treatmen
 
       // Loop thru these entries and where no COB has been found, interpolate between nearby to get a continuous array
       var startIndex = 0
-        , stopIndex = 0
-        , k = 0
-        , m = 0;
+        , stopIndex
+        , k
+        , m;
 
       while (startIndex < cobs.length && isNaN(cobs[startIndex])) {
         startIndex++; // Advance start to the first real number
@@ -533,7 +533,7 @@ loopalyzer.addArrayToBins = function(bins, values) {
 /* Fill all NaNs in an array by interpolating between adjacent values */
 loopalyzer.interpolateArray = function(values, allowNegative) {
   var startIndex = 0
-    , stopIndex = 0
+    , stopIndex
     , k = 0
     , m = 0;
 

--- a/lib/report_plugins/weektoweek.js
+++ b/lib/report_plugins/weektoweek.js
@@ -60,7 +60,7 @@ function init (ctx) {
     legend += '<td><svg width="16" height="16"><circle fill="' + dayColors[colorIdx++] + '" r="40"></circle></g></svg></td><td>' + translate('Wednesday') + '</td></tr>';
     legend += '<tr><td><svg width="16" height="16"><circle fill="' + dayColors[colorIdx++] + '" r="40"></circle></g></svg></td><td>' + translate('Thursday') + '</td>';
     legend += '<td><svg width="16" height="16"><circle fill="' + dayColors[colorIdx++] + '" r="40"></circle></g></svg></td><td>' + translate('Friday') + '</td>';
-    legend += '<td><svg width="16" height="16"><circle fill="' + dayColors[colorIdx++] + '" r="40"></circle></g></svg></td><td>' + translate('Saturday') + '</td></tr>';
+    legend += '<td><svg width="16" height="16"><circle fill="' + dayColors[colorIdx] + '" r="40"></circle></g></svg></td><td>' + translate('Saturday') + '</td></tr>';
     legend += '</table>';
 
     $('#weektoweekcharts').append($(legend));

--- a/lib/server/activity.js
+++ b/lib/server/activity.js
@@ -13,7 +13,7 @@ function storage (env, ctx) {
   function normalizeObjectId(id) {
     try {
       return new ObjectID(id);
-    } catch (err) {
+    } catch {
       return new ObjectID();
     }
   }
@@ -124,7 +124,7 @@ function storage (env, ctx) {
       ).toArray();
     }, fn);
   }
-  
+
   function remove (_id, fn) {
     var objId = new ObjectID(_id);
     return runWithCallback(function () {
@@ -135,7 +135,7 @@ function storage (env, ctx) {
   function api ( ) {
     return ctx.store.collection(env.activity_collection);
   }
-  
+
   api.list = list;
   api.create = create;
   api.query_for = query_for;

--- a/lib/server/app.js
+++ b/lib/server/app.js
@@ -36,7 +36,7 @@ function getFrameSources (settings) {
       if (isHttp && !hasCredentials && frameUrl.origin !== 'null') {
         sources.add(frameUrl.origin);
       }
-    } catch (err) {
+    } catch {
       // Relative URLs are already covered by 'self'; malformed URLs fail closed.
     }
   }

--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -68,7 +68,7 @@ function boot (env, language) {
     if (configURL) {
       try {
         href = url.parse(configURL).href;
-      } catch (e) {
+      } catch {
         console.error('Parsing config URL from IMPORT_CONFIG failed');
       }
     }

--- a/lib/server/enclave.js
+++ b/lib/server/enclave.js
@@ -63,7 +63,7 @@ const init = function init () {
   enclave.verifyJWT = function verifyJWT(tokenString) {
     try {
       return jwt.verify(tokenString, secrets[jwtKey]);
-    } catch(err) {
+    } catch {
       return null;
     }
   }

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -273,7 +273,7 @@ function isContainerRuntime () {
   try {
     var cgroup = fs.readFileSync('/proc/1/cgroup', 'utf8');
     return /docker|kubepods|containerd|libpod|podman/.test(cgroup);
-  } catch (err) {
+  } catch {
     return false;
   }
 }

--- a/lib/server/food.js
+++ b/lib/server/food.js
@@ -10,7 +10,7 @@ function storage (env, ctx) {
   function normalizeObjectId(id) {
     try {
       return new ObjectID(id);
-    } catch (err) {
+    } catch {
       return new ObjectID();
     }
   }
@@ -142,19 +142,19 @@ function storage (env, ctx) {
       return api().find({ }, READ_OPTIONS).toArray();
     }, fn);
   }
-  
+
   function listquickpicks (fn) {
     return runWithCallback(function () {
       return api().find({ $and: [ { 'type': 'quickpick'} , { 'hidden' : 'false' } ] }, READ_OPTIONS).sort({'position': 1}).toArray();
     }, fn);
   }
-  
+
   function listregular (fn) {
     return runWithCallback(function () {
       return api().find( { 'type': 'food'}, READ_OPTIONS).toArray();
     }, fn);
   }
-  
+
   function remove (_id, fn) {
     var objId = new ObjectID(_id);
     return runWithCallback(function () {
@@ -167,7 +167,7 @@ function storage (env, ctx) {
   function api ( ) {
     return ctx.store.collection(env.food_collection);
   }
-  
+
   api.list = list;
   api.listquickpicks = listquickpicks;
   api.listregular = listregular;

--- a/lib/server/profile.js
+++ b/lib/server/profile.js
@@ -70,7 +70,7 @@ function storage (collection, ctx) {
 
     try {
       obj._id = new ObjectID(obj._id);
-    } catch (err) {
+    } catch {
       obj._id = new ObjectID();
     }
     if (!Object.prototype.hasOwnProperty.call(obj, 'created_at')) {
@@ -212,7 +212,7 @@ function storage (collection, ctx) {
   function api () {
     return ctx.store.collection(collection);
   }
-  
+
   api.list = list;
   api.list_query = list_query;
   api.create = create;

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -53,7 +53,7 @@ function create (app) {
 require('./bootevent')(env, language).boot(function booted (ctx) {
 
     console.log('Boot event processing completed');
-    
+
     var app = require('./app')(env, ctx);
     var server = create(app).listen(PORT, HOSTNAME);
     console.log(translate('Listening on port'), PORT, HOSTNAME);
@@ -71,7 +71,7 @@ require('./bootevent')(env, language).boot(function booted (ctx) {
     ///////////////////////////////////////////////////
     // setup socket io for data and message transmission
     ///////////////////////////////////////////////////
-    var websocket = require('./websocket')(env, ctx, server);
+    require('./websocket')(env, ctx, server);
 
     //after startup if there are no alarms send all clear
     let sendStartupAllClearTimer = setTimeout(function sendStartupAllClear () {

--- a/lib/server/treatments.js
+++ b/lib/server/treatments.js
@@ -102,7 +102,7 @@ function storage (env, ctx) {
             objOrArray[index]._id = bulkResult.upsertedIds[index];
           });
         }
-        
+
         // REQ-SYNC-072: For docs that were updated (not inserted) via identifier,
         // fetch their _id from the database (only identifier field, not others)
         var docsNeedingId = objOrArray.filter(function(obj) {
@@ -125,7 +125,7 @@ function storage (env, ctx) {
                 }
               });
             }
-          } catch (findErr) {
+          } catch {
             // Preserve existing behavior: still report success even if the id lookup fails.
           }
         }
@@ -173,7 +173,7 @@ function storage (env, ctx) {
               if (existing) {
                 obj._id = existing._id;
               }
-            } catch (findErr) {
+            } catch {
               // Preserve existing behavior: update success does not fail if the lookup fails.
             }
           }
@@ -317,7 +317,7 @@ function storage (env, ctx) {
           if (existing) {
             obj._id = existing._id;
           }
-        } catch (findErr) {
+        } catch {
           // Preserve existing behavior: update success does not fail if the lookup fails.
         }
       }

--- a/lib/server/websocket.js
+++ b/lib/server/websocket.js
@@ -105,7 +105,7 @@ function init (env, ctx, server) {
       });
       io.close();
     });
-        
+
     ctx.bus.on('data-processed', function() {
       update();
     });
@@ -189,7 +189,7 @@ function init (env, ctx, server) {
 
         try {
           return Number.isFinite(new Date(document.created_at).getTime());
-        } catch (err) {
+        } catch {
           return false;
         }
       }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -343,7 +343,7 @@ function init () {
   }
 
   function isEnabled (feature) {
-    var enabled = false;
+    var enabled;
 
     if (settings.enable && typeof feature === 'object' && feature.length !== undefined) {
       enabled = feature.find(f => settings.enable.includes(f)) !== undefined;

--- a/lib/storage/mongo-storage.js
+++ b/lib/storage/mongo-storage.js
@@ -53,11 +53,11 @@ function getPoolOptions(env) {
   const poolSize = env.mongo_pool_size 
     ? parseInt(env.mongo_pool_size, 10) 
     : DEFAULT_POOL_SIZE;
-  
+
   const minPoolSize = env.mongo_min_pool_size 
     ? parseInt(env.mongo_min_pool_size, 10) 
     : 0;
-  
+
   const maxIdleTimeMS = env.mongo_max_idle_time_ms 
     ? parseInt(env.mongo_max_idle_time_ms, 10) 
     : 30000;
@@ -123,7 +123,7 @@ function init(env, cb, forceNewConnection) {
 
       const poolOptions = getPoolOptions(env);
       console.log('Setting up new connection to MongoDB with pool options:', poolOptions);
-      
+
       const options = {
         ...poolOptions,
       };
@@ -138,6 +138,7 @@ function init(env, cb, forceNewConnection) {
           await closeClient(previousClient);
         }
 
+        // eslint-disable-next-line no-constant-condition -- Success returns; fatal errors throw; retryable failures keep retrying.
         while (true) {
           let client = null;
 

--- a/lib/utils/cloneShallow.js
+++ b/lib/utils/cloneShallow.js
@@ -125,7 +125,7 @@ function cloneShallow(value) {
     } else if (typeof Ctor === 'function') {
       try {
         result = new Ctor();
-      } catch (e) {
+      } catch {
         result = Object.create(proto);
       }
     } else {

--- a/tests/lint-cleanup-contracts.test.js
+++ b/tests/lint-cleanup-contracts.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+describe('plugin outputs across lint cleanup', function () {
+  it('preserves raw glucose results across calibration and display branches over repeated calls', function () {
+    const rawbg = require('../lib/plugins/rawbg')({language: {translate: key => key}});
+    const reading = {unfiltered: 120, filtered: 100, mgdl: 80};
+    const calibration = {slope: 2, intercept: 20, scale: 1};
+    const cases = [
+      [{}, {}, 'unsmoothed', 100],
+      [{}, {}, 'unfiltered', 50],
+      [{}, {}, 'filtered', 40],
+      [{filtered: 0}, {}, 'unsmoothed', 50],
+      [{mgdl: 30}, {}, 'unsmoothed', 50],
+      [{}, {slope: 0}, 'unsmoothed', 0],
+      [{}, {scale: 0}, 'unsmoothed', 0],
+      [{unfiltered: 0}, {}, 'unsmoothed', 0]
+    ];
+    for (let cycle = 0; cycle < 2; cycle++) {
+      for (const [sgv, cal, display, expected] of cases) {
+        assert.equal(rawbg.calc({...reading, ...sgv}, {...calibration, ...cal}, {extendedSettings: {display}}), expected);
+      }
+    }
+  });
+
+  it('preserves basal translation call order and selected output for normal and temporary basal', function () {
+    const calls = [];
+    const basal = require('../lib/plugins/basalprofile')({moment: require('moment'), language: {translate(key) {calls.push(key); return key;}}});
+    const time = 1700000000000;
+    for (let cycle = 0; cycle < 2; cycle++) {
+      for (const temporary of [false, true]) {
+        calls.length = 0;
+        const sbx = {time, data: {profile: {getTempBasal() {return {totalbasal: 0.175, treatment: temporary ? {endmills: time + 1800000} : null};}}}};
+        let response;
+        basal.virtAsst.rollupHandlers[0].rollupHandler([], sbx, (error, result) => {assert.ifError(error); response = result;});
+        const key = temporary ? 'virtAsstBasalTemp' : 'virtAsstBasal';
+        assert.deepEqual(calls, ['virtAsstUnknown', 'virtAsstPreamble', key]);
+        assert.deepEqual(response, {results: key, priority: 1});
+      }
+    }
+  });
+});


### PR DESCRIPTION
Establish a zero-error application lint baseline after the ESLint 10 upgrade, then run `npm run lint` in the existing Node 22/MongoDB 5.0.32 CI job. This adds no job or environment. Findings fall from 53 errors/47 warnings to zero errors/sixteen security warnings; the security warnings remain visible for individual review.

Remove unused catch bindings/parameters, overwritten initial values, an unused private profile-editor wrapper and obsolete lint directives. Preserve the websocket initialization call, basal translation call order, and initialization values still read by report interpolation. Document the existing intentional MongoDB retry loop locally; do not change its retry behavior or global lint rules.

Validation:
- Lint succeeds on Node 22 and 24. Workflow parsing confirms the existing job set is unchanged and one selected job runs lint.
- Production builds pass on both Node floors.
- All 283 client-core tests pass on Node 22.
- Raw-glucose branch fixtures and basal translation-order fixtures pass against both pre-cleanup and updated implementations over repeated calls.
- Full Node 22/MongoDB 6 backend coverage: 1,924 passing, one existing pending case.
- All 538 Chromium browser tests pass on Node 24, including reports, profile/editor interactions, storage, tooltips, HMR and page lifecycle.
- Full hosted CI and the actual lint-step execution remain required before merge.

No dependency or measured memory saving is attributed to this cleanup. The remaining security warnings and a separately identified existing API3 access-token logging path are recorded for follow-up; this PR does not claim to fix that logging issue.

Targets chore/nightscout-modernization for M09. See docs/test-specs/lint-cleanup.md and docs/audits/lint-cleanup-results.json. #8605 stays draft.
