### PR TITLE
Refresh DOMPurify sanitizer comparator to 3.4.15

### DIFF
--- a/docs/test-specs/dompurify-reference-refresh.md
+++ b/docs/test-specs/dompurify-reference-refresh.md
@@ -1,0 +1,17 @@
+# DOMPurify reference refresh
+
+DOMPurify 3.4.15 replaces 3.4.14 in development dependencies. It remains an
+independent browser sanitizer comparator; production uses the local sanitizer.
+Only the root development range and DOMPurify lock record change. This does not
+remove a runtime package or claim server-memory savings.
+
+The upstream release hardens XML/form clobbering and attribute/subtree cleanup:
+https://github.com/cure53/DOMPurify/releases/tag/3.4.15
+
+The existing 316-case DOMPurify and differential sanitizer corpus passes on
+Node 22/Chromium and Node 24/WebKit. An additional real-browser regression passes
+an XML-derived form with a mixed-case event attribute and a named child that
+shadows attribute removal through DOMPurify's actual DOM-node API. It requires
+that the event attribute cannot survive. The expanded DOMPurify file has 16
+passing cases on both combinations. Hosted Firefox and full current-head CI
+remain merge requirements. No production sanitizer or UI behavior is changed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@types/tough-cookie": "^4.0.0",
         "babel-loader": "^10.1.1",
         "csv-parse": "^7.0.2",
-        "dompurify": "^3.4.14",
+        "dompurify": "^3.4.15",
         "eslint": "^10.10.0",
         "eslint-plugin-security": "^4.0.1",
         "expose-loader": "^2.0.0",
@@ -5074,9 +5074,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
-      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.15.tgz",
+      "integrity": "sha512-EUBjM+B+lkDE41iE82DDSCfkoPGfXx8IxFxPMjNzm/Uk4xDet77rTN9wqlxlVg71kK7XGuUMv6wUxJUwwv+Xyw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@types/tough-cookie": "^4.0.0",
     "babel-loader": "^10.1.1",
     "csv-parse": "^7.0.2",
-    "dompurify": "^3.4.14",
+    "dompurify": "^3.4.15",
     "eslint": "^10.10.0",
     "eslint-plugin-security": "^4.0.1",
     "expose-loader": "^2.0.0",

--- a/tests/browser/dompurify.test.js
+++ b/tests/browser/dompurify.test.js
@@ -61,6 +61,19 @@ describe('DOMPurify reference in a real browser', function () {
     });
   }
 
+  it('removes mixed-case XML handlers even when a form shadows attribute removal', async function () {
+    const clean = await withPage(origin, async ({page}) => {
+      await page.goto(origin);
+      await page.addScriptTag({url: origin + '/purify.js'});
+      return page.evaluate(() => {
+        const xml = '<section xmlns="http://www.w3.org/1999/xhtml"><form ONCLICK="alert(1)"><input name="removeAttributeNode"/></form></section>';
+        const parsed = new DOMParser().parseFromString(xml, 'application/xhtml+xml');
+        return window.DOMPurify.sanitize(document.importNode(parsed.documentElement, true));
+      });
+    });
+    assert.doesNotMatch(clean, /onclick/i);
+  });
+
   const attacks = {
     'event handlers': '<img src=x onerror=alert(1)>',
     'encoded script URL': '<a href="java&#x09;script:alert(1)">link</a>',


### PR DESCRIPTION
Update the development-only DOMPurify sanitizer comparator from 3.4.14 to 3.4.15, including upstream XML/form-clobbering and cleanup hardening. Production sanitizer code and dependency records are unchanged.

Add a real-browser regression for XML-derived mixed-case event attributes on a form whose child shadows attribute removal. Existing 316-case comparator/differential corpus passes on Node 22/Chromium and Node 24/WebKit; expanded DOMPurify tests pass all 16 cases on both. Full hosted CI, including Firefox, remains required before merge.

Part of M09 and #8605; target `chore/nightscout-modernization`. Documentation records scope and validation; no runtime-memory or UI change is claimed.
