### PR TITLE
Fix integration CodeQL findings around status credentials and verify deletion guards

### DIFF
--- a/docs/test-specs/status-credentials-codeql.md
+++ b/docs/test-specs/status-credentials-codeql.md
@@ -1,0 +1,30 @@
+# Integration CodeQL review: status credentials and entry deletion
+
+The #8605 integration scan at ff5480ed reported two sensitive-GET findings
+(status routing and the owned page fixture) and one query-injection finding
+at entries.deleteMany. These require separate dispositions.
+
+Browser startup now sends the existing API-secret hash or subject access token
+in the existing `api-secret` header. Status URLs contain only the cache-buster.
+The status response uses credentials already extracted by permission middleware,
+including the signed token created for a legacy token query. Existing external
+clients using query credentials remain compatible; this does not claim that all
+legacy URL-based authentication has been retired. New clients should use headers.
+The owned fixture requires the same header as production startup.
+
+The actual-page regression covers all five pages, stored-secret and dialog
+bootstrap, repeated reconnects, and absence of credential query parameters.
+The status API regression verifies equivalent subject authorization for headers
+and both legacy query parameter forms over two cycles.
+
+The entry deletion endpoint deliberately accepts authorized MongoDB predicates;
+wrapping the whole filter in $eq would break its public bulk-delete contract.
+The existing api:entries:delete permission gate precedes the storage adapter,
+and query_for uses the query builder's recursive executable-operator rejection.
+The additional real-Mongo regression monitors delete commands: direct/nested
+$where and $function requests fail without a delete command or lost records;
+authorized ordinary comparison predicates delete only matching fixture records.
+Existing tests verify that read-only roles cannot delete, including broad filters.
+These checks distinguish intentional predicate support from operator injection
+into a supposedly scalar identifier. Any alert dismissal must be limited to
+this reviewed location and rule; no CodeQL query or directory is excluded.

--- a/lib/api/status.js
+++ b/lib/api/status.js
@@ -19,7 +19,8 @@ function configure (app, wares, env, ctx) {
     let extended = env.settings.filteredSettings(app.extendedClientSettings);
     let settings = env.settings.filteredSettings(env.settings);
 
-    var authToken = req.query.token || req.query.secret || '';
+    // The permission middleware has already extracted legacy or header credentials.
+    var authToken = req.auth_token || req.api_secret || '';
 
     var date = new Date();
     var info = { status: 'ok'

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -60,16 +60,15 @@ client.init = function init (callback) {
 
   var src = '/api/v1/status.json?t=' + new Date().getTime();
 
-  if (secret) {
-    src += '&secret=' + secret;
-  } else if (token) {
-    src += '&token=' + token;
-  }
+  // Bootstrap credentials travel in headers, never in the status URL.
+  // The existing API-secret header accepts both hashes and subject tokens.
+  var statusHeaders = client.headers();
+  if (secret || token) statusHeaders['api-secret'] = secret || token;
 
   $.ajax({
     method: 'GET'
     , url: src
-    , headers: client.headers()
+    , headers: statusHeaders
   }).done(function success (serverSettings) {
     if (serverSettings.runtimeState !== 'loaded') {
       console.log('Server is still loading data');

--- a/tests/api.status.test.js
+++ b/tests/api.status.test.js
@@ -19,6 +19,7 @@ describe('Status REST api', function ( ) {
     this.app.enable('api');
     var self = this;
     require('../lib/server/bootevent')(env, language).boot(function booted (ctx) {
+      self.ctx = ctx;
       self.app.use('/api', api(env, ctx));
       done();
     });
@@ -90,6 +91,27 @@ describe('Status REST api', function ( ) {
       });
   });
 
+
+  it('returns the same subject authorization for header and legacy query credentials', async function () {
+    const crypto = require('node:crypto');
+    const auth = this.ctx.authorization;
+    const previous = auth.storage.subjects;
+    const token = 'fixture-0123456789abcdef';
+    auth.storage.subjects = [{name:'Status fixture', accessToken:token,
+      digest:'0123456789abcdef0123456789abcdef',
+      accessTokenDigest:crypto.createHash('sha1').update(token).digest('hex'), roles:['readable']}];
+    try {
+      for (let cycle = 0; cycle < 2; cycle++) {
+        for (const transport of ['header', 'token', 'secret']) {
+          let call = request(this.app).get('/api/status.json');
+          call = transport === 'header' ? call.set('api-secret', token) : call.query({[transport]:token});
+          const result = await call.expect(200);
+          result.body.authorized.sub.should.equal('Status fixture');
+          result.body.authorized.permissionGroups.should.be.an.Array();
+        }
+      }
+    } finally { auth.storage.subjects = previous; }
+  });
 
 });
 

--- a/tests/browser/page-startup.test.js
+++ b/tests/browser/page-startup.test.js
@@ -64,6 +64,8 @@ describe('Complete page template startup', function () {
   for (const [url, , , entry] of pages) {
     it('boots ' + entry + ' with ' + (authenticate ? 'the authentication dialog' : 'stored authentication') + ' and reconnects twice', async function () {
       await withPage(origin, async ({page}) => {
+        const statusUrls = [];
+        page.on('request', request => {if (new URL(request.url()).pathname === '/api/v1/status.json') statusUrls.push(request.url());});
         if (!authenticate) await page.addInitScript(hash => localStorage.setItem('apisecrethash', hash), hash);
         try {
           await page.goto(origin + url);
@@ -110,6 +112,12 @@ describe('Complete page template startup', function () {
             await page.waitForFunction(() => document.querySelector('#fe_status').textContent === 'OK' && window.$.active === 0);
             assert.equal(fixtureState.foodWrites.length, 1, 'One save action must create exactly one record after reconnects');
             assert.equal(fixtureState.foodWrites[0].name, draftValue);
+          }
+          assert(statusUrls.length > 0);
+          for (const url of statusUrls) {
+            const params = new URL(url).searchParams;
+            assert.equal(params.has('secret'), false);
+            assert.equal(params.has('token'), false);
           }
         } finally {
           await page.evaluate(() => {

--- a/tests/entries-query-permissions.test.js
+++ b/tests/entries-query-permissions.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict');
 const {randomUUID} = require('node:crypto');
+const {EventEmitter} = require('node:events');
 const {MongoClient} = require('mongodb');
 const express = require('express');
 const request = require('supertest');
@@ -10,7 +11,7 @@ const qs = require('qs');
 describe('Entries predicate permission boundary', function () {
   this.timeout(15000);
   const name = 'owned_entries_query_' + randomUUID().replaceAll('-', '');
-  let client, collection, server, authorization, reads = 0, cacheReads = 0;
+  let client, collection, server, authorization, reads = 0, cacheReads = 0, deletes = 0;
   before(async function () {
     client = new MongoClient(process.env.CUSTOMCONNSTR_mongo || 'mongodb://127.0.0.1:27017/test', {monitorCommands:true});
     await client.connect();
@@ -19,9 +20,10 @@ describe('Entries predicate permission boundary', function () {
     await collection.insertMany([1, 2, 3].map(i => ({date:1700000000000 + i * 300000, sgv:100 + i, type:'sgv'})));
     client.on('commandStarted', event => {
       if (event.commandName === 'find' && event.command.find === name) reads++;
+      if (event.commandName === 'delete' && event.command.delete === name) deletes++;
     });
     const env = {settings:{authDefaultRoles:'owned-role', authFailDelay:0}, authentication_collections_prefix:name + '_auth_'};
-    const ctx = Object.assign({}, require('./inithelper')().ctx, {store:db,
+    const ctx = Object.assign({}, require('./inithelper')().ctx, {store:db, bus:new EventEmitter(),
       cache:{entries:[], getData:() => {cacheReads++; return [];}}, ddata:{sgvs:[]}});
     authorization = ctx.authorization = require('../lib/authorization')(env, ctx);
     authorization.storage.roles = [{name:'owned-role', permissions:[]}];
@@ -74,4 +76,24 @@ describe('Entries predicate permission boundary', function () {
       assert.equal(await collection.countDocuments(), 3);
     }
   });
+  it('guards executable delete filters while preserving authorized predicate deletion twice', async function () {
+    authorization.storage.roles[0].permissions = ['api:entries:read', 'api:entries:delete'];
+    for (let cycle = 0; cycle < 2; cycle++) {
+      for (const find of [{$where:'true'}, {$or:[{$where:'true'}]},
+        {$expr:{$function:{body:'function(){return true}',args:[],lang:'js'}}}]) {
+        const before = deletes;
+        const result = await request(server).delete(url(find));
+        assert(result.status >= 400 && result.status < 600);
+        assert.notEqual(result.status, 401, 'Authorized requests must reach query validation');
+        assert.equal(deletes, before, 'No executable predicate reaches MongoDB');
+        assert.equal(await collection.countDocuments(), 3);
+      }
+      await collection.insertOne({date:1700000000000, sgv:250, type:'sgv'});
+      const before = deletes;
+      await request(server).delete(url({date:{$gte:0}, sgv:{$gte:250}})).expect(200);
+      assert.equal(deletes, before + 1);
+      assert.equal(await collection.countDocuments(), 3);
+    }
+  });
+
 });

--- a/tests/fixtures/page-startup/server.js
+++ b/tests/fixtures/page-startup/server.js
@@ -51,7 +51,7 @@ async function createPageFixture(options = {}) {
   const worker = fs.readFileSync(path.join(root, 'views/service-worker.js'), 'utf8');
   app.get('/sw.js', (request, response) => response.type('js').set('Cache-Control', 'no-store').send(ejs.render(worker, {locals: {cachebuster: state.workerVersion}})));
   app.get('/api/v1/status.json', (request, response) => {
-    if (request.query.secret !== hash) {state.challenges++; return response.status(401).json({message: 'Authentication required'});}
+    if (request.headers['api-secret'] !== hash) {state.challenges++; return response.status(401).json({message: 'Authentication required'});}
     if (state.loadingResponses > 0) {state.loadingResponses--; return response.json({...settings, runtimeState: 'loading'});}
     response.json(settings);
   });


### PR DESCRIPTION
#8605's integration CodeQL scan reports browser status credentials in GET URLs and a bulk-delete predicate finding. Browser startup now sends the existing API-secret hash or subject token in the existing header; the status route reuses credentials extracted by authorization middleware. Legacy token/secret query clients retain their authorization response. The page fixture uses headers too.

Actual-page regressions assert credential-free status URLs across five pages, stored/dialog bootstrap and repeated reconnects. API regressions preserve subject authorization across header and legacy query transports. A real-Mongo test verifies authorized predicate deletion and rejects executable filters before any delete command; the endpoint intentionally supports query predicates behind read/delete permissions. The database alert needs a separately documented, location-specific false-positive disposition, not a query exclusion.

Validation: clean Node 22 install/build and changed-source lint pass; all 23 focused API/query cases pass on Node 22 and 24, and all 549 Chromium browser cases pass. The initial full Node 22 backend run passed 1,963 cases with one existing pending case and one new-fixture failure (missing read permission/event bus); that fixture is corrected and the complete focused set passes on both Node versions. Hosted full-suite validation is required before merge. Alert #110 has a location-specific false-positive disposition linked to this proof; no CodeQL queries are disabled. This fixes integration CI and does not promote #8605 or change the remaining modernization release gates.
