### PR TITLE
Upgrade Helmet to 8.3 with explicit compatible security policies

### DIFF
--- a/docs/audits/helmet-header-comparison.json
+++ b/docs/audits/helmet-header-comparison.json
@@ -1,0 +1,83 @@
+{
+  "cases": 24,
+  "differences": [
+    {
+      "opts": {
+        "insecureUseHttp": false,
+        "secureHstsHeader": true,
+        "allowUnrestrictedFrameEmbedding": false,
+        "secureCsp": false,
+        "secureCspReportOnly": false
+      },
+      "header": "expect-ct",
+      "old": "max-age=0",
+      "candidate": null
+    },
+    {
+      "opts": {
+        "insecureUseHttp": false,
+        "secureHstsHeader": true,
+        "allowUnrestrictedFrameEmbedding": false,
+        "secureCsp": true,
+        "secureCspReportOnly": false
+      },
+      "header": "expect-ct",
+      "old": "max-age=0",
+      "candidate": null
+    },
+    {
+      "opts": {
+        "insecureUseHttp": false,
+        "secureHstsHeader": true,
+        "allowUnrestrictedFrameEmbedding": false,
+        "secureCsp": true,
+        "secureCspReportOnly": true
+      },
+      "header": "expect-ct",
+      "old": "max-age=0",
+      "candidate": null
+    },
+    {
+      "opts": {
+        "insecureUseHttp": false,
+        "secureHstsHeader": true,
+        "allowUnrestrictedFrameEmbedding": true,
+        "secureCsp": false,
+        "secureCspReportOnly": false
+      },
+      "header": "expect-ct",
+      "old": "max-age=0",
+      "candidate": null
+    },
+    {
+      "opts": {
+        "insecureUseHttp": false,
+        "secureHstsHeader": true,
+        "allowUnrestrictedFrameEmbedding": true,
+        "secureCsp": true,
+        "secureCspReportOnly": false
+      },
+      "header": "expect-ct",
+      "old": "max-age=0",
+      "candidate": null
+    },
+    {
+      "opts": {
+        "insecureUseHttp": false,
+        "secureHstsHeader": true,
+        "allowUnrestrictedFrameEmbedding": true,
+        "secureCsp": true,
+        "secureCspReportOnly": true
+      },
+      "header": "expect-ct",
+      "old": "max-age=0",
+      "candidate": null
+    }
+  ],
+  "baseline": "c4eb117ba88ab293901c2b89b9298e36d01af082",
+  "versions": {
+    "old": "4.6.0",
+    "candidate": "8.3.0",
+    "node": "22.23.2"
+  }
+}

--- a/docs/test-specs/helmet-modernization.md
+++ b/docs/test-specs/helmet-modernization.md
@@ -1,0 +1,40 @@
+# Helmet 8 migration (M09)
+
+Upgrade Helmet 4.6.0 to 8.3.0. Node 18+ is required by Helmet; both supported
+Nightscout Node floors exceed this. Only the root range and Helmet lock record
+change. No transitive dependency is added or removed.
+
+## Explicit existing security policy
+
+Helmet 5 changed CSP useDefaults and enabled cross-origin policies. An unchanged
+Nightscout configuration on Helmet 8 failed four existing framing tests by
+injecting script restrictions and upgrade-insecure-requests into a frame-only
+CSP. Both Nightscout CSP configurations now explicitly set useDefaults:false.
+The full Helmet invocation disables newly defaulted COEP/COOP/CORP and
+Origin-Agent-Cluster to preserve existing embedding/resource behaviour. This
+retains the prior policy, rather than weakening an enabled Nightscout setting.
+HSTS, same-origin frame protection and full/report-only CSP remain configurable.
+
+Helmet 7 removed Expect-CT. We do not add a dependency or local implementation
+just to restore that retired header. The [upstream changelog](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md)
+records the defaults, removal and runtime requirements.
+
+## Evidence
+
+- All 34 server security-header cases pass on Node 22.23.2 and 24.20.0. The
+  expanded suite also passes against the original Helmet 4 implementation.
+- The 24-mode [complete header comparison](../audits/helmet-header-comparison.json)
+  covers HTTP/HSTS/embedding and off/enforced/report-only CSP. The only observed
+  header change is removal of Expect-CT in six HSTS-enabled configurations.
+- Three browser regressions use the actual server middleware serving owned
+  static HTML. Cross-origin frames and inline controls work twice in each CSP
+  mode, under Chromium/Node 24 and WebKit/Node 22. Existing real-page tests alone
+  use fixture headers and would not establish this middleware compatibility.
+- Clean install/build passes; all six production JS bundles are byte-identical.
+  Helmet installed file bytes increase from 73,751 to 105,555 (+31,804). No
+  package-count, browser transfer or server-memory saving is claimed.
+- Changed-source lint reports zero errors and six existing filesystem warnings.
+
+Full backend/browser, CodeQL, native Docker and pruned-runtime CI must pass on
+the current base before merge. This slice does not complete M09 or the live
+hosting/proxy release gates.

--- a/lib/server/app.js
+++ b/lib/server/app.js
@@ -82,7 +82,8 @@ function create (env, ctx) {
     };
 
     cspPolicy = {
-      directives: directives
+      useDefaults: false
+      , directives: directives
       , reportOnly: secureCspReportOnly
     };
 
@@ -93,7 +94,8 @@ function create (env, ctx) {
 
   if (!allowUnrestrictedFrameEmbedding && !enforcedCspPolicy) {
     enforcedCspPolicy = {
-      directives: {
+      useDefaults: false
+      , directives: {
         defaultSrc: helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc
         , frameAncestors: ["'self'"]
       }
@@ -114,7 +116,13 @@ function create (env, ctx) {
       var includeSubDomainsValue = env.secureHstsHeaderIncludeSubdomains;
       var preloadValue = env.secureHstsHeaderPreload;
       app.use(helmet({
-        hsts: {
+        // Keep cross-origin embedding and resource access under Nightscout's
+        // existing settings rather than adopting new Helmet defaults implicitly.
+        crossOriginEmbedderPolicy: false
+        , crossOriginOpenerPolicy: false
+        , crossOriginResourcePolicy: false
+        , originAgentCluster: false
+        , hsts: {
           maxAge: 31536000
           , includeSubDomains: includeSubDomainsValue
           , preload: preloadValue

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "express": "4.22.2",
         "fast-password-entropy": "^1.1.1",
         "flot": "^0.8.3",
-        "helmet": "^4.0.0",
+        "helmet": "^8.3.0",
         "jquery": "^3.5.1",
         "jquery-ui": "^1.14.2",
         "jsonwebtoken": "^9.0.0",
@@ -6185,10 +6185,15 @@
       }
     },
     "node_modules/helmet": {
-      "version": "4.6.0",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/hookified": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "express": "4.22.2",
     "fast-password-entropy": "^1.1.1",
     "flot": "^0.8.3",
-    "helmet": "^4.0.0",
+    "helmet": "^8.3.0",
     "jquery": "^3.5.1",
     "jquery-ui": "^1.14.2",
     "jsonwebtoken": "^9.0.0",

--- a/tests/browser/helmet-policy.test.js
+++ b/tests/browser/helmet-policy.test.js
@@ -1,0 +1,55 @@
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const express = require('express');
+const createApp = require('../../lib/server/app');
+const {getBrowser} = require('./hooks');
+
+function listen(app) {
+  return new Promise(resolve => {const server=app.listen(0,'127.0.0.1',()=>resolve(server));});
+}
+function close(server) {return server ? new Promise(resolve=>server.close(resolve)) : Promise.resolve();}
+
+describe('Actual server security headers in browser frames', function () {
+  for (const mode of ['off','enforced','report-only']) {
+    it('preserves cross-origin embedding and inline controls with CSP '+mode+' twice', async function () {
+      const dir=await fs.mkdtemp(path.join(os.tmpdir(),'nightscout-helmet-'));
+      let child,parent,context;
+      try {
+        await fs.writeFile(path.join(dir,'probe.html'),'<button id="control" onclick="this.textContent=Number(this.textContent)+1">0</button>');
+        const env={name:'owned-helmet',version:'fixture',trustProxy:'127.0.0.1,::1',insecureUseHttp:false,
+          secureHstsHeader:true,secureHstsHeaderIncludeSubdomains:false,secureHstsHeaderPreload:false,
+          secureCsp:mode!=='off',secureCspReportOnly:mode==='report-only',allowUnrestrictedFrameEmbedding:true,
+          static_files:dir,settings:require('../../lib/settings')()};
+        child=await listen(createApp(env,{bootErrors:[{desc:'fixture',err:'fixture'}]}));
+        const childOrigin='http://127.0.0.1:'+child.address().port;
+        const parentApp=express();
+        parentApp.get('/',(req,res)=>res.send('<iframe src="'+childOrigin+'/probe.html"></iframe>'));
+        parent=await listen(parentApp);
+        const parentOrigin='http://127.0.0.1:'+parent.address().port;
+        context=await getBrowser().newContext({extraHTTPHeaders:{'x-forwarded-proto':'https'}});
+        const blocked=[];
+        await context.route('**/*',route=>{
+          if (![parentOrigin,childOrigin].includes(new URL(route.request().url()).origin)) {
+            blocked.push(route.request().url());return route.abort();
+          }
+          return route.continue();
+        });
+        const page=await context.newPage();
+        for(let cycle=0;cycle<2;cycle++) {
+          await page.goto(parentOrigin);
+          const control=page.frameLocator('iframe').locator('#control');
+          await control.click();await control.click();
+          assert.equal(await control.textContent(),'2');
+        }
+        assert.deepEqual(blocked,[]);
+      } finally {
+        if(context)await context.close();
+        await close(parent);await close(child);
+        await fs.rm(dir,{recursive:true,force:true});
+      }
+    });
+  }
+});

--- a/tests/server.security-headers.test.js
+++ b/tests/server.security-headers.test.js
@@ -200,4 +200,33 @@ describe('server security headers', function () {
     res.headers['content-security-policy'].should.not.containEql('frame-ancestors');
     should.not.exist(res.headers['strict-transport-security']);
   });
+  for (const insecureUseHttp of [false, true]) {
+    for (const secureHstsHeader of [false, true]) {
+      for (const allowUnrestrictedFrameEmbedding of [false, true]) {
+        for (const cspMode of ['off', 'enforced', 'report-only']) {
+          it(`keeps explicit policies for HTTP=${insecureUseHttp}, HSTS=${secureHstsHeader}, embedding=${allowUnrestrictedFrameEmbedding}, CSP=${cspMode}`, async function () {
+            for (let cycle = 0; cycle < 2; cycle++) {
+              const app = securityApp({insecureUseHttp, secureHstsHeader, allowUnrestrictedFrameEmbedding,
+                secureCsp: cspMode !== 'off', secureCspReportOnly: cspMode === 'report-only'});
+              const res = await (insecureUseHttp ? getRobotsOverHttp(app) : getRobots(app));
+              for (const name of ['cross-origin-embedder-policy', 'cross-origin-opener-policy',
+                'cross-origin-resource-policy', 'origin-agent-cluster']) should.not.exist(res.headers[name]);
+              for (const name of ['content-security-policy', 'content-security-policy-report-only']) {
+                const value = res.headers[name] || '';
+                value.should.not.containEql('upgrade-insecure-requests');
+                value.should.not.containEql('script-src-attr');
+              }
+              if (insecureUseHttp || !secureHstsHeader) should.not.exist(res.headers['strict-transport-security']);
+              else res.headers['strict-transport-security'].should.equal('max-age=31536000');
+              if (allowUnrestrictedFrameEmbedding) should.not.exist(res.headers['x-frame-options']);
+              else res.headers['x-frame-options'].should.equal('SAMEORIGIN');
+              if (cspMode === 'enforced') res.headers['content-security-policy'].should.containEql("script-src 'self' 'unsafe-inline'");
+              if (cspMode === 'report-only') res.headers['content-security-policy-report-only'].should.containEql("script-src 'self' 'unsafe-inline'");
+            }
+          });
+        }
+      }
+    }
+  }
+
 });


### PR DESCRIPTION
Helmet 8's defaults add CSP and cross-origin restrictions that Nightscout did not previously enable, breaking frame-only security configurations. Upgrade 4.6.0 to 8.3.0 with explicit existing CSP and cross-origin policies, preserving configured HSTS, embedding and report-only behaviour. The retired Expect-CT header is no longer emitted.

Validation: 34 HTTP security cases pass on both Node floors and against the old implementation. A complete 24-mode header comparison finds only the documented Expect-CT removal. Three actual-server browser regressions pass in Chromium/Node 24 and WebKit/Node 22, verifying repeated cross-origin embedding and inline controls under all CSP modes. Clean install/build and lint pass (existing warnings only). All six production JS bundles are unchanged; Helmet package files increase by 31,804 bytes, with no memory-saving claim.

The full local Node 22/MongoDB 6 backend suite passes 1,999 tests, with one existing pending case. Required hosted backend/browser, CodeQL, Docker and pruned-runtime checks must pass before merge. This is one M09 slice; remaining dependency reviews and deployment gates remain open.

Merged as 19bd2191d118ad095d0056f96aaf78d5e51b8f00 after every required hosted check passed. The actual merge tree matches independently verified tree a77b96031542d474a79d80c79d3ffe75e958a490. All four formatting artifacts match this tree and retain only the three previously documented historical timezone differences.
