### PR TITLE
fix: prevent failed treatments queries from crashing the server

### DIFF
--- a/lib/api/treatments/index.js
+++ b/lib/api/treatments/index.js
@@ -25,6 +25,9 @@ function configure (app, wares, ctx, env) {
   api.use(ctx.authorization.isPermitted('api:treatments:read'));
 
   function serveTreatments(req,res, err, results) {
+    if (err) {
+      return res.sendJSONStatus(res, constants.HTTP_INTERNAL_ERROR, 'Query Error', err.message || String(err));
+    }
 
     var ifModifiedSince = req.get('If-Modified-Since');
 

--- a/lib/server/query.js
+++ b/lib/server/query.js
@@ -64,7 +64,8 @@ function enforceDateFilter (query, opts) {
     Object.keys(dateValue).forEach(function(key) {
       let dateString = dateValue[key];
       if (isNaN(dateString)) {
-        dateString = dateString.replace(' ', '+'); // some clients don't excape the plus
+        // Repair an unescaped positive UTC offset without changing the date/time separator.
+        dateString = dateString.replace(/([T ]\d[\d:.,]*) (\d{2}:\d{2}|\d{4}|\d{2})$/, '$1+$2');
 
         const validDate = moment(dateString).isValid();
 

--- a/tests/api.treatments-query-errors.test.js
+++ b/tests/api.treatments-query-errors.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const assert = require('assert');
+const express = require('express');
+const request = require('supertest');
+const query = require('../lib/server/query');
+const runWithCallback = require('../lib/storage/run-with-callback');
+
+describe('Treatment API query errors', function () {
+  let app;
+  let ctx;
+  let storageError;
+  let lastQuery;
+
+  beforeEach(function () {
+    app = express();
+    storageError = null;
+    lastQuery = null;
+    const env = { settings: {} };
+    ctx = {
+      authorization: { isPermitted: () => (req, res, next) => next() },
+      cache: { treatments: [] },
+      treatments: {
+        list: (params, callback) => runWithCallback(function () {
+          lastQuery = query(params, { dateField: 'created_at', walker: {} });
+          if (storageError) { throw storageError; }
+          return [];
+        }, callback)
+      }
+    };
+    app.use('/api/v1', require('../lib/api/treatments')(app,
+      require('../lib/middleware')(env), ctx, env));
+  });
+
+  it('returns JSON for rejected date queries and continues serving requests', async function () {
+    const invalidDate = '2026-99-05T00:00:00Z';
+    await request(app)
+      .get('/api/v1/treatments?count=1&find[created_at][$gte]=' + invalidDate)
+      .expect('Content-Type', /json/)
+      .expect(500, {
+        status: 500,
+        message: 'Query Error',
+        description: 'Cannot parse ' + invalidDate + ' as a valid ISO-8601 date'
+      });
+    await request(app).get('/api/v1/treatments').expect(200, []);
+  });
+
+  [new Error('Database unavailable'), 'Database unavailable'].forEach(function (error) {
+    it('handles a rejected query with ' + (error instanceof Error ? 'an Error' : 'a string'), async function () {
+      storageError = error;
+      await request(app).get('/api/v1/treatments').expect(500, {
+        status: 500, message: 'Query Error', description: 'Database unavailable'
+      });
+    });
+  });
+
+  it('accepts the reported URL-encoded space separator', async function () {
+    await request(app)
+      .get('/api/v1/treatments?count=1&find[created_at][$gte]=2026-09-05%2000:00:00-04:00')
+      .expect(200, []);
+    assert.strictEqual(lastQuery.created_at.$gte, '2026-09-05T04:00:00.000Z');
+  });
+
+  it('repairs an unescaped positive offset after a space separator', async function () {
+    await request(app)
+      .get('/api/v1/treatments?count=1&find[created_at][$gte]=2026-09-05%2000:00:00+02:00')
+      .expect(200, []);
+    assert.strictEqual(lastQuery.created_at.$gte, '2026-09-04T22:00:00.000Z');
+  });
+
+  it('preserves cached treatment normalization and conditional responses', async function () {
+    ctx.cache.treatments = [{ created_at: '2026-09-05T00:00:00.000Z', carbs: '10', insulin: '2' }];
+    await request(app).get('/api/v1/treatments?count=1')
+      .expect('Last-Modified', 'Sat, 05 Sep 2026 00:00:00 GMT')
+      .expect(200, [{ created_at: '2026-09-05T00:00:00.000Z', carbs: 10, insulin: 2 }]);
+    await request(app).get('/api/v1/treatments?count=1')
+      .set('If-Modified-Since', 'Sat, 05 Sep 2026 00:00:00 GMT').expect(304);
+    assert.strictEqual(lastQuery, null);
+  });
+});

--- a/tests/query.test.js
+++ b/tests/query.test.js
@@ -49,4 +49,32 @@ describe('query', function ( ) {
 
     opts._id.toString().should.equal(objectId);
   });
+  describe('date filter normalization', function () {
+    const cases = [
+      ['2026-09-05 00:00:00-04:00', '2026-09-05T04:00:00.000Z'],
+      ['2026-09-05 00Z', '2026-09-05T00:00:00.000Z'],
+      ['2026-09-05 00:00:00Z', '2026-09-05T00:00:00.000Z'],
+      ['2026-09-05 00:00:00+02:00', '2026-09-04T22:00:00.000Z'],
+      ['2026-09-05T00:00:00+02:00', '2026-09-04T22:00:00.000Z'],
+      ['2026-09-05T00:00:00 02:00', '2026-09-04T22:00:00.000Z'],
+      ['2026-09-05 00:00:00 02:00', '2026-09-04T22:00:00.000Z'],
+      ['2026-09-05T00:00:00 0230', '2026-09-04T21:30:00.000Z'],
+      ['2026-09-05 00:00:00.123 02', '2026-09-04T22:00:00.123Z']
+    ];
+
+    cases.forEach(function (testCase) {
+      it('normalizes ' + testCase[0], function () {
+        const result = query({ find: { created_at: { $gte: testCase[0] } } }, {
+          dateField: 'created_at', walker: {}
+        });
+        result.created_at.$gte.should.equal(testCase[1]);
+      });
+    });
+
+    it('still rejects invalid dates', function () {
+      (() => query({ find: { created_at: { $gte: '2026-99-05T00:00:00Z' } } }, {
+        dateField: 'created_at', walker: {}
+      })).should.throw(/Cannot parse/);
+    });
+  });
 }); 


### PR DESCRIPTION
A failed `GET /api/v1/treatments` query currently passes null results to `forEach`, causing an uncaught exception. Return HTTP 500 with the existing JSON status format before processing results, so subsequent requests can still be served.

Also restrict the unescaped-positive-offset repair to a trailing offset after a time component. The reported `2026-09-05 00:00:00-04:00` filter now normalizes to `2026-09-05T04:00:00.000Z`; space-separated timestamps with an unescaped positive offset work too.

Closes #8675.

Validation:
- 21 focused tests pass on Node 22.23.2 and Node 25.2.1: `node --unhandled-rejections=strict node_modules/mocha/bin/mocha.js --exit --timeout 5000 tests/query.test.js tests/api.treatments-query-errors.test.js`.
- Regression tests reproduce the original null-results exception and date corruption against the unmodified base.
- HTTP tests use the real treatments router, query parser, and promise-to-callback adapter with a stubbed storage operation; cover invalid dates, Error/string failures, subsequent successful requests, the reported encoded URL, positive-offset repair, cached normalization, and 304 responses.
- ESLint reports no errors and only the existing non-literal RegExp warning in `query.js`; `git diff --check` passes.
- Full MongoDB-backed integration, Docker, and CI matrix validation are left to PR CI.
