### PR TITLE
fix: show worried emoji for low and falling clock readings

### DIFF
--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -191,6 +191,9 @@ client.render = function render () {
   // Insert the BG value text, toggle stale if necessary.
   $('.sg').toggleClass('stale', thresholdReached).text(toTextContent(displayValue));
 
+  let direction = normalizeDirection(rec.direction);
+  let falling = ['FortyFiveDown', 'SingleDown', 'DoubleDown', 'TripleDown'].includes(direction);
+
   var em;  
   if (thresholdReached) {
     em='🤷';
@@ -200,6 +203,8 @@ client.render = function render () {
     em='🥶';
   } else if (bgNum <= 72) { //4
     em='😱';
+  } else if (falling && bgNum < client.settings.thresholds.bgTargetBottom) {
+    em='😟';
   } else if (bgNum <= 97) {  //5,4
     em='😊';
   } else if (displayValue == '100' || displayValue == '5.5') { //5,5
@@ -257,7 +262,6 @@ client.render = function render () {
   }
 
   // Insert the trend arrow.
-  let direction = normalizeDirection(rec.direction);
   let arrow = $('<img alt="arrow">').attr('src', '/images/' + (!direction || direction === 'NOT COMPUTABLE' ? 'NONE' : direction) + '.svg');
 
   // Restyle body bg

--- a/tests/clock-client.test.js
+++ b/tests/clock-client.test.js
@@ -35,7 +35,7 @@ describe('clock client', function() {
     done();
   }
 
-  function renderProperties(serverUnits, browserUnits, properties) {
+  function renderProperties(serverUnits, browserUnits, properties, lowerTarget) {
     window.serverSettings = {
       settings: {
         units: serverUnits
@@ -49,7 +49,7 @@ describe('clock client', function() {
       , thresholds: {
         bgHigh: 260
         , bgLow: 55
-        , bgTargetBottom: 80
+        , bgTargetBottom: lowerTarget === undefined ? 80 : lowerTarget
         , bgTargetTop: 180
       }
       , timeFormat: 12
@@ -83,6 +83,58 @@ describe('clock client', function() {
 
   beforeEach(setupClockClient);
   afterEach(teardownClockClient);
+
+  describe('low and falling emoji', function() {
+    function renderEmoji(bg, direction, lowerTarget, browserUnits, stale) {
+      $('#inner').attr('data-face', 'bn10-sg40-em40-ar25');
+      var properties = propertiesWithUnits(bg, '-5');
+      properties.bgnow.sgvs[0].mgdl = bg;
+      properties.bgnow.sgvs[0].direction = direction;
+      if (stale) {
+        properties.bgnow.sgvs[0].mills = Date.now() - 20 * 60 * 1000;
+      }
+      renderProperties('mg/dl', browserUnits || 'mg/dl', properties, lowerTarget);
+      return $('.em').text();
+    }
+
+    ['FortyFiveDown', 'SingleDown', 'DoubleDown', 'TripleDown', 'down', 'slightdown'].forEach(function(direction) {
+      it('shows concern at 74 with direction ' + direction, function() {
+        renderEmoji(74, direction).should.equal('😟');
+      });
+    });
+
+    ['Flat', 'SingleUp', 'NONE', 'NOT COMPUTABLE', undefined].forEach(function(direction) {
+      it('preserves the existing face without a falling trend: ' + direction, function() {
+        renderEmoji(74, direction).should.equal('😊');
+      });
+    });
+
+    it('uses the configured lower target and its boundary', function() {
+      renderEmoji(89, 'SingleDown', 90).should.equal('😟');
+      renderEmoji(90, 'SingleDown', 90).should.equal('😊');
+      renderEmoji(89, 'SingleDown', 80).should.equal('😊');
+    });
+
+    it('preserves the existing low-value faces', function() {
+      renderEmoji(72, 'SingleDown').should.equal('😱');
+      renderEmoji(54, 'DoubleDown').should.equal('🥶');
+      renderEmoji(40, 'DoubleDown').should.equal('❌');
+    });
+
+    it('uses mg/dL internally when the browser displays mmol/L', function() {
+      renderEmoji(74, 'SingleDown', 80, 'mmol').should.equal('😟');
+      $('.sg').text().should.equal('4.1');
+    });
+
+    it('keeps stale data ahead of the trend warning', function() {
+      renderEmoji(74, 'SingleDown', 80, 'mg/dl', true).should.equal('🤷');
+    });
+
+    it('uses the same normalized direction for the arrow', function() {
+      renderEmoji(74, 'down').should.equal('😟');
+      $('.ar img').attr('src').should.equal('/images/SingleDown.svg');
+    });
+  });
 
   it('constructs every supported face component with bounded numeric sizing', function() {
     $('#inner').attr('data-face', 'bn0-sg40-dt14-nl-ar25-ag6-tm10-em40');


### PR DESCRIPTION
The Simple Views clock currently shows a smiling face at 74 mg/dL even when the trend arrow points down. Show 😟 when a falling reading is below the configured lower target (`bgTargetBottom`, default 80 mg/dL), while retaining the existing low-value faces at 72 mg/dL and below and the stale-data override.

Use the existing direction normalizer for both emoji selection and the arrow, including uploader aliases and all four downward trends. Stable, rising, and unknown trends retain their existing faces. Comparisons use the raw mg/dL value regardless of display units.

Fixes #8638.

Validation:
- All 21 clock-client tests pass on Node 22.23.2: `node node_modules/mocha/bin/mocha.js --exit --timeout 5000 tests/clock-client.test.js`.
- The reported 74/SingleDown regression fails against the unmodified base (😊 instead of 😟) and passes with this change.
- Coverage includes custom threshold boundaries, direction aliases, low-value and stale-data precedence, mmol/L display, and arrow consistency.
- ESLint for `lib/client/clock-client.js` and `git diff --check` pass.
- Full CI validation is pending.
