### PR TITLE
fix: preprocess schedules imported by profile switches

### DIFF
--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -399,6 +399,7 @@ var moment = ctx.moment;
                     if (treatment.profile.indexOf("@@@@@") < 0)
                       treatment.profile += "@@@@@" + treatment.mills;
                     let json = JSON.parse(treatment.profileJson);
+                    profile.preprocessProfileOnLoad(json);
                     pdataActive.store[treatment.profile] = json;
                   }
               }
@@ -409,6 +410,7 @@ var moment = ctx.moment;
                     if (treatment.profile.indexOf("@@@@@") < 0)
                       treatment.profile += "@@@@@" + treatment.mills;
                   let json = JSON.parse(treatment.profileJson);
+                  profile.preprocessProfileOnLoad(json);
                   pdataActive.store[treatment.profile] = json;
                 }
               }

--- a/tests/profile-switch-preprocessing.test.js
+++ b/tests/profile-switch-preprocessing.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const assert = require('assert');
+const moment = require('moment-timezone');
+const createProfile = require('../lib/profilefunctions');
+
+describe('Embedded profile switch schedules', function () {
+  [0, 180].forEach(function (duration) {
+    [false, true].forEach(function (preprocessed) {
+      it('normalizes ' + (preprocessed ? 'preprocessed' : 'time-only') +
+        ' schedules for a ' + (duration ? 'temporary' : 'permanent') + ' switch', function () {
+        const profile = createProfile([{
+          defaultProfile: 'Default',
+          startDate: '2026-01-01T00:00:00Z',
+          store: { Default: {
+            timezone: 'Asia/Seoul',
+            basal: [{ time: '00:00', value: 0.5 }],
+            sens: [{ time: '00:00', value: 50 }],
+            carbratio: [{ time: '00:00', value: 10 }]
+          } }
+        }], { moment });
+        const embedded = {
+          timezone: 'Asia/Seoul',
+          basal: [['00:00', 0.55], ['04:00', 0.77], ['08:00', 0.87],
+            ['10:00', 0.93], ['13:00', 0.97], ['17:00', 0.75], ['20:00', 0.61]]
+            .map(([time, value]) => ({ time, value })),
+          sens: [{ time: '00:00', value: 40 }, { time: '10:00', value: 35 }],
+          carbratio: [{ time: '00:00', value: 8 }, { time: '10:00', value: 7 }]
+        };
+        if (preprocessed) {
+          profile.preprocessProfileOnLoad(embedded);
+        }
+        const switchTime = Date.parse('2026-08-08T00:00:00Z'); // 09:00 KST
+        const treatment = {
+          eventType: 'Profile Switch', mills: switchTime, duration,
+          profile: 'Changed', profileJson: JSON.stringify(embedded)
+        };
+        const originalJson = treatment.profileJson;
+        profile.updateTreatments([treatment], [], []);
+
+        const from = profile.parseInTimezone('2026-08-08');
+        const to = from.clone().add(1, 'day');
+        const samples = profile.getBasalRenderTimes(+from, +to, 5 * 60 * 1000);
+        samples.forEach(function (time) {
+          const active = time >= switchTime && (!duration || time < switchTime + duration * 60000);
+          const hour = moment.tz(time, 'Asia/Seoul').hour();
+          let expected = 0.5;
+          if (active) {
+            embedded.basal.forEach(function (entry) {
+              if (hour >= Number(entry.time.slice(0, 2))) { expected = entry.value; }
+            });
+          }
+          assert.strictEqual(profile.getTempBasal(time).totalbasal, expected,
+            'basal at ' + moment.tz(time, 'Asia/Seoul').format());
+        });
+
+        const tenAM = +profile.parseInTimezone('2026-08-08T10:00:00');
+        assert.strictEqual(profile.getSensitivity(tenAM), 35);
+        assert.strictEqual(profile.getCarbRatio(tenAM), 7);
+        assert.strictEqual(treatment.profileJson, originalJson);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Profiles imported from a Profile Switch treatment's `profileJson` bypass the schedule preprocessing used for ordinary profile records. When schedule entries contain `time` and `value` without `timeAsSeconds`, basal calculations become `NaN` after the switch activates. Apply the existing preprocessing routine before storing embedded profiles in both temporary and permanent switch paths.

Found while investigating #8584. A synthetic switch at 09:00 Asia/Seoul reproduces valid basal values before the switch and `NaN` afterward, which could explain the reported graph cutoff. **We have not confirmed that the author's records trigger this defect, so this PR is not a confirmed resolution of #8584.** The missing preprocessing also predates the reported August 7 onset; changed input data could expose it without a new Nightscout deployment.

After this PR is merged into `dev`, we encourage the author to test that build against the affected historical dates and report whether the full basal graph is restored. Keep #8584 open pending that confirmation.

Validation:
- New time-only schedule tests fail before the fix for both permanent and temporary switches, returning `NaN` instead of 0.87 at 09:00 KST.
- 49 profile tests pass on Node 22.23.2: `node node_modules/mocha/bin/mocha.js --exit --timeout 5000 tests/profile-switch-preprocessing.test.js tests/profile.test.js`.
- Regression coverage spans a full local day, temporary-switch expiry, already-preprocessed input, sensitivity/carbohydrate-ratio schedules, and preservation of the original JSON payload.
- ESLint reports no errors and one existing regex warning; `git diff --check` passes.
- Full CI is pending.
