### PR TITLE
fix: preserve valid unnamed profiles in conversion and editor

### DIFF
--- a/lib/client-core/profile-editor/profiles.js
+++ b/lib/client-core/profile-editor/profiles.js
@@ -30,7 +30,7 @@ function addProfile (record, defaults, baseName) {
 
 function removeProfile (record, currentName) {
   var next = getFirstAvailableProfile(record, currentName);
-  if (!next) {
+  if (next === null) {
     return { record: record, currentProfile: currentName, removed: false };
   }
   delete record.store[currentName];

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -1066,7 +1066,7 @@ function init (client, d3) {
 
     var lastbasal = 0;
 
-    if (!profile?.activeProfileToTime(from)) {
+    if (profile?.activeProfileToTime(from) == null) {
       window.alert(translate('Redirecting you to the Profile Editor to create a new profile.'));
       try {
         window.location.href = '/profile';

--- a/lib/profile/profileeditor.js
+++ b/lib/profile/profileeditor.js
@@ -186,14 +186,24 @@ var init = function init () {
 
     for (var key in record.store) {
       if (Object.prototype.hasOwnProperty.call(record.store,key)) {
-        $('#pe_profiles').append($('<option>').val(key).text(toTextContent(key)));
+        $('#pe_profiles').append($('<option>').val(key).text(key === '' ? translate('(unnamed)') : toTextContent(key)));
       }
     }
 
     $('#pe_profiles').val(currentprofile);
     $('#pe_profile_name').val(currentprofile);
 
-    c_profile = mongorecords[currentrecord].store[currentprofile];
+    const validSelection = typeof currentprofile === 'string'
+      && Object.prototype.hasOwnProperty.call(record.store, currentprofile);
+    $('#pe_form').find('button').prop('disabled', !validSelection);
+    if (!validSelection) {
+      c_profile = null;
+      $('#pe_basal_placeholder, #pe_ic_placeholder, #pe_isf_placeholder, #pe_targetbg_placeholder').empty();
+      $('#pe_dia, #pe_hr').val('');
+      window.alert(translate('The selected profile is missing. Select a profile before saving.'));
+      return;
+    }
+    c_profile = record.store[currentprofile];
     mongorecords[currentrecord].defaultProfile = currentprofile;
     // Set values from profile to html
     fillTimeRanges();
@@ -273,15 +283,23 @@ var init = function init () {
   function profileChange (event) {
     var record = mongorecords[currentrecord];
     var newpr = $('#pe_profiles').val();
+    if (!c_profile) {
+      currentprofile = newpr;
+      initProfile();
+      maybePreventDefault(event);
+      return false;
+    }
     // copy values from html to c_profile
     GUIToObject();
 
     var newname = $('#pe_profile_name').val();
-    if (!isNaN(newname)) newname = 'Profile' + newname;
+    // Preserve existing unnamed profiles; do not create new blank names.
+    if (!newname.trim()) newname = currentprofile;
+    if (newname !== '' && !isNaN(newname)) newname = 'Profile' + newname;
 
     if (currentprofile !== newname) {
       // rename if already exists
-      while (record.store[newname]) {
+      while (Object.prototype.hasOwnProperty.call(record.store, newname)) {
         newname += '1';
       }
       record.store[newname] = record.store[currentprofile];
@@ -531,6 +549,7 @@ var init = function init () {
 
   // Grab values from html GUI to object
   function GUIToObject() {
+    if (!c_profile) return;
     var oldProfile = cloneDeep(c_profile);
 
     c_profile.units = client.settings.units;
@@ -595,6 +614,10 @@ var init = function init () {
   }
 
   function profileSubmit(event) {
+    if (!c_profile) {
+      maybePreventDefault(event);
+      return false;
+    }
     if (!client.hashauth.isAuthenticated()) {
       window.alert(translate('Your device is not authenticated yet'));
       return false;

--- a/lib/profilefunctions.js
+++ b/lib/profilefunctions.js
@@ -58,7 +58,7 @@ var moment = ctx.moment;
     /** @type {Array<Object>} */
     var convertedProfiles = [];
     dataArray?.forEach(function(profile) {
-      if (!profile?.defaultProfile) {
+      if (!profile?.store || typeof profile.store !== 'object' || Array.isArray(profile.store)) {
         /** @type {{defaultProfile: string, store: {[key: string]: Object}, startDate: string, _id: string, convertedOnTheFly: boolean}} */
         var newObject = {};
         newObject.defaultProfile = 'Default';
@@ -190,7 +190,8 @@ var moment = ctx.moment;
     var pdataActive = profile.profileFromTime(time);
     var data = profile.hasData() ? pdataActive : null;
     var timeprofile = profile.activeProfileToTime(time);
-    returnValue = data && data.store[timeprofile] ? data.store[timeprofile] : {};
+    returnValue = data && timeprofile !== null && Object.prototype.hasOwnProperty.call(data.store, timeprofile)
+      ? data.store[timeprofile] : {};
 
     cache.put(cacheKey, returnValue, cacheTTL);
     return returnValue;
@@ -368,10 +369,12 @@ var moment = ctx.moment;
       var timeprofile = pdataActive.defaultProfile;
       var treatment = profile.activeProfileTreatmentToTime(time);
 
-      if (treatment && pdataActive.store && pdataActive.store[treatment.profile]) {
+      if (treatment && typeof treatment.profile === 'string' && pdataActive.store
+          && Object.prototype.hasOwnProperty.call(pdataActive.store, treatment.profile)) {
         timeprofile = treatment.profile;
       }
-      return timeprofile;
+      return typeof timeprofile === 'string' && pdataActive.store
+        && Object.prototype.hasOwnProperty.call(pdataActive.store, timeprofile) ? timeprofile : null;
     }
     return null;
   };

--- a/tests/fixtures/unnamed-profile.json
+++ b/tests/fixtures/unnamed-profile.json
@@ -1,0 +1,83 @@
+{
+  "defaultProfile": "",
+  "startDate": "2026-01-01T00:00:00.000Z",
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "enteredBy": "test-reproduction",
+  "units": "mmol/L",
+  "store": {
+    "": {
+      "dia": 6,
+      "carbs_hr": 20,
+      "delay": 20,
+      "timezone": "UTC",
+      "units": "mmol/L",
+      "basal": [
+        {
+          "time": "00:00",
+          "value": 0.5
+        }
+      ],
+      "carbratio": [
+        {
+          "time": "00:00",
+          "value": 10
+        }
+      ],
+      "sens": [
+        {
+          "time": "00:00",
+          "value": 2.5
+        }
+      ],
+      "target_low": [
+        {
+          "time": "00:00",
+          "value": 5
+        }
+      ],
+      "target_high": [
+        {
+          "time": "00:00",
+          "value": 6
+        }
+      ]
+    },
+    "Named": {
+      "dia": 5,
+      "carbs_hr": 15,
+      "delay": 15,
+      "timezone": "UTC",
+      "units": "mmol/L",
+      "basal": [
+        {
+          "time": "00:00",
+          "value": 0.7
+        }
+      ],
+      "carbratio": [
+        {
+          "time": "00:00",
+          "value": 12
+        }
+      ],
+      "sens": [
+        {
+          "time": "00:00",
+          "value": 3
+        }
+      ],
+      "target_low": [
+        {
+          "time": "00:00",
+          "value": 5.5
+        }
+      ],
+      "target_high": [
+        {
+          "time": "00:00",
+          "value": 6.5
+        }
+      ]
+    }
+  }
+}

--- a/tests/profile-empty-name.test.js
+++ b/tests/profile-empty-name.test.js
@@ -1,0 +1,66 @@
+'use strict';
+const assert = require('assert');
+const moment = require('moment-timezone');
+const create = require('../lib/profilefunctions');
+const fixture = require('./fixtures/unnamed-profile.json');
+const clone = value => JSON.parse(JSON.stringify(value));
+
+describe('Unnamed profile stores', function () {
+  it('preserves the empty selection, all settings, and metadata', function () {
+    const input = clone(fixture);
+    const p = create([input], { moment });
+    assert.strictEqual(p.data[0].defaultProfile, '');
+    assert.deepStrictEqual(Object.keys(p.data[0].store), ['', 'Named']);
+    assert.strictEqual(p.data[0].convertedOnTheFly, undefined);
+    assert.strictEqual(p.data[0].created_at, fixture.created_at);
+    assert.strictEqual(p.activeProfileToTime(), '');
+    assert.strictEqual(p.getDIA(), 6);
+    assert.strictEqual(p.getBasal(), 0.5);
+    assert.strictEqual(p.getSensitivity(), 2.5);
+    assert.strictEqual(p.getCarbRatio(), 10);
+    assert.strictEqual(p.getLowBGTarget(), 5);
+    assert.strictEqual(p.getHighBGTarget(), 6);
+    assert.strictEqual(p.getTimezone(), 'UTC');
+    assert.strictEqual(p.getUnits(), 'mmol');
+  });
+  [undefined, null, 'Missing', 'toString'].forEach(function (name) {
+    it('does not wrap or select a fallback for invalid pointer ' + name, function () {
+      const record = clone(fixture);
+      record.defaultProfile = name;
+      record.store.null = clone(record.store.Named);
+      const p = create([record], { moment });
+      assert.strictEqual(p.data[0].convertedOnTheFly, undefined);
+      assert.strictEqual(p.data[0].defaultProfile, name);
+      assert.strictEqual(p.activeProfileToTime(), null);
+      assert.deepStrictEqual(p.getCurrentProfile(), {});
+      assert.strictEqual(p.getBasal(), undefined);
+    });
+  });
+  it('retains named and legacy compatibility', function () {
+    const named = clone(fixture);
+    named.defaultProfile = 'Named';
+    assert.strictEqual(create([named], { moment }).getDIA(), 5);
+    const legacy = create([clone(fixture.store[''])], { moment });
+    assert.strictEqual(legacy.activeProfileToTime(), 'Default');
+    assert.strictEqual(legacy.getDIA(), 6);
+  });
+  it('can remove a named profile and select its unnamed sibling', function () {
+    const record = clone(fixture);
+    const result = require('../lib/client-core/profile-editor/profiles').removeProfile(record, 'Named');
+    assert.strictEqual(result.removed, true);
+    assert.strictEqual(result.currentProfile, '');
+    assert.deepStrictEqual(Object.keys(record.store), ['']);
+  });
+  it('continues basal rendering for an unnamed active profile', function () {
+    const p = create([clone(fixture)], { moment });
+    const reachedSampling = new Error('reached basal sampling');
+    p.getBasalRenderTimes = () => { throw reachedSampling; };
+    const client = {
+      settings: { isEnabled: () => true, extendedSettings: { basal: { render: 'default' } } },
+      sbx: { data: { profile: p } },
+      chart: { createAdjustedRange: () => [new Date(), new Date()] }
+    };
+    assert.throws(() => require('../lib/client/renderer')(client, {}).addBasals(client),
+      error => error === reachedSampling);
+  });
+});

--- a/tests/profileeditor.empty-name.test.js
+++ b/tests/profileeditor.empty-name.test.js
@@ -1,0 +1,110 @@
+'use strict';
+const assert = require('assert');
+const moment = require('moment-timezone');
+const createSecureDOM = require('./fixtures/secure-jsdom').createSecureDOM;
+const globals = require('./fixtures/dom-globals');
+const fixture = require('./fixtures/unnamed-profile.json');
+const clone = value => JSON.parse(JSON.stringify(value));
+
+describe('Unnamed profile editor', function () {
+  let state, env, $, writes, record;
+  function openEditor(pointer) {
+    record = clone(fixture);
+    if (pointer !== undefined) record.defaultProfile = pointer;
+    delete global.window;
+    delete global.document;
+    env = createSecureDOM('<html><body><form id="pe_form"><button type="button">Save</button></form>' +
+      '<select id="pe_profiles"></select><select id="pe_timezone"></select>' +
+      '<select id="pe_databaserecords"></select>' +
+      ['pe_time', 'pe_date', 'pe_profile_name', 'pe_dia', 'pe_hr'].map(id => '<input id="' + id + '">').join('') +
+      ['pe_basal_placeholder', 'pe_ic_placeholder', 'pe_isf_placeholder', 'pe_targetbg_placeholder'].map(id => '<div id="' + id + '"></div>').join('') +
+      '</body></html>');
+    state = globals.installDomGlobals(env);
+    $ = env.window.$;
+    $.fx.off = true;
+    writes = [];
+    env.window.alert = () => {};
+    env.window.Nightscout = { client: {
+      ctx: { moment, timezones: ['UTC'] },
+      headers: () => ({}), init: callback => callback(),
+      hashauth: { isAuthenticated: () => true },
+      profilefunctions: require('../lib/profilefunctions')(null, { moment }),
+      settings: { customTitle: 'Test', units: 'mmol', timeFormat: 24,
+        extendedSettings: { profile: { history: true, multiple: true } } },
+      translate: value => value,
+      utils: { cloneDeep: clone, mergeInputTime: (time, date) => date + 'T' + time + ':00Z' }
+    } };
+    $.ajax = function (url, options) {
+      if (typeof url === 'object') {
+        assert.strictEqual(url.method, 'PUT');
+        writes.push(JSON.parse(url.data));
+        return { done: function () { return this; }, fail: function () { return this; } };
+      }
+      options.success([clone(record)]);
+      return { done: function (callback) { callback(); return this; } };
+    };
+    require('../lib/profile/profileeditor')();
+  }
+  afterEach(function () {
+    delete require.cache[require.resolve('../lib/profile/profileeditor')];
+    globals.restoreDomGlobals(state);
+  });
+  it('loads the unnamed selection and correct values without writing', function () {
+    openEditor();
+    assert.deepStrictEqual($('#pe_profiles option').map(function () { return this.value; }).get(), ['', 'Named']);
+    assert.strictEqual($('#pe_profiles').val(), '');
+    assert.strictEqual($('#pe_profiles option').first().text(), '(unnamed)');
+    assert.strictEqual($('#pe_dia').val(), '6');
+    assert.strictEqual($('#pe_basal_val_0').val(), '0.5');
+    assert.strictEqual($('#pe_isf_val_0').val(), '2.5');
+    assert.strictEqual(writes.length, 0);
+    assert.deepStrictEqual(record, fixture);
+  });
+  it('preserves the empty key and settings when saved unchanged', function () {
+    openEditor();
+    $('#pe_form button').trigger('click');
+    assert.strictEqual(writes.length, 1);
+    assert.strictEqual(writes[0].defaultProfile, '');
+    assert.deepStrictEqual(Object.keys(writes[0].store), ['', 'Named']);
+    assert.strictEqual(writes[0].store[''].dia, 6);
+    assert.strictEqual(writes[0].store[''].basal[0].value, 0.5);
+    assert.strictEqual(writes[0].store[''].units, 'mmol');
+  });
+  it('renames explicitly without overwriting an existing profile', function () {
+    openEditor();
+    $('#pe_profile_name').val('Named');
+    $('#pe_form button').trigger('click');
+    assert.strictEqual(writes[0].defaultProfile, 'Named1');
+    assert.deepStrictEqual(Object.keys(writes[0].store), ['Named', 'Named1']);
+    assert.strictEqual(writes[0].store.Named.dia, 5);
+    assert.strictEqual(writes[0].store.Named1.dia, 6);
+  });
+  it('does not turn a named profile into a blank name', function () {
+    openEditor('Named');
+    $('#pe_profile_name').val('');
+    $('#pe_form button').trigger('click');
+    assert.strictEqual(writes[0].defaultProfile, 'Named');
+    assert.deepStrictEqual(Object.keys(writes[0].store), ['', 'Named']);
+    assert.strictEqual(writes[0].store.Named.dia, 5);
+  });
+  it('keeps both raw profiles in the Profile report', function () {
+    openEditor();
+    $('body').append('<select id="profiles-databaserecords"></select><span id="profiles-default"></span><div id="profiles-chart"></div>');
+    env.window.moment = moment;
+    env.window.Nightscout.client.sbx = { data: {
+      profile: env.window.Nightscout.client.profilefunctions
+    } };
+    require('../lib/report_plugins/profiles')().report({ profiles: [clone(fixture)] });
+    assert.strictEqual($('#profiles-chart > table > tr > td').length, 2);
+    assert.ok($('#profiles-chart').text().includes('Named'));
+    assert.strictEqual(writes.length, 0);
+  });
+  it('requires explicit selection for a dangling default pointer', function () {
+    openEditor('Missing');
+    assert.strictEqual($('#pe_form button').prop('disabled'), true);
+    assert.strictEqual(writes.length, 0);
+    $('#pe_profiles').val('').trigger('change');
+    assert.strictEqual($('#pe_dia').val(), '6');
+    assert.strictEqual($('#pe_form button').prop('disabled'), false);
+  });
+});


### PR DESCRIPTION
A modern profile store with `defaultProfile: ""` and a matching `store[""]` is currently wrapped as a legacy profile. The editor then substitutes defaults (for the issue fixture: DIA 3 instead of 6, basal 0.1 instead of 0.5, and I:C 30 instead of 10) and removes the nested original profiles from its working copy.

Detect the profile format from the store structure and resolve selections by own-key membership. Preserve the valid empty name through basal rendering and editor loading/saving, display it as `(unnamed)`, and allow explicit renaming without overwriting an existing profile. Removing a named profile can select an unnamed sibling. Blank rename input preserves the current name.

Malformed modern stores with missing, null, or dangling default pointers are not legacy-converted or assigned an arbitrary profile. The editor warns, clears the displayed ranges, and blocks saving until the user explicitly selects a profile.

Fixes #8562.

Validation:
- Reproduced the original conversion and editor failures using the issue's synthetic fixture; both regressions fail on the unmodified base.
- 75 tests pass on Node 22.23.2: `node node_modules/mocha/bin/mocha.js --exit --timeout 5000 tests/profile-empty-name.test.js tests/profileeditor.empty-name.test.js tests/profile.test.js tests/profileeditor.records.test.js tests/profile-sinks.test.js tests/client.renderer.test.js`.
- All 283 client-core tests pass with `TZ=UTC` on Node 22.23.2.
- DOM tests verify correct values, no writes on load, preservation on save, collision-safe renaming, invalid-selection recovery, and unchanged Profile report access to both profiles. Renderer regression verifies that an unnamed active profile reaches basal sampling rather than redirecting.
- `git diff --check` passes. Changed-file ESLint retains the existing unused `convertToRanges` error in `profileeditor.js` (verified on the base) and existing regex warning in `profilefunctions.js`; no new lint findings.
- Full PR CI is pending. No database migration or stricter ingestion validation is introduced.
