### PR TITLE
Upgrade EJS and retire the Jake FileList dependency chain

### DIFF
--- a/docs/audits/ejs-render-comparison.json
+++ b/docs/audits/ejs-render-comparison.json
@@ -1,0 +1,73 @@
+{
+  "baseline": "3.1.10",
+  "candidate": "6.0.1",
+  "results": [
+    {
+      "file": "index.html",
+      "bytes": 44934,
+      "sha256": "670d890de5d3d7fb32d2eb2ab547eeede4f7d1314b862567fa3d68713897a873"
+    },
+    {
+      "file": "reportindex.html",
+      "bytes": 13071,
+      "sha256": "222f44e5b1012db614c32e1e2c02fc0dd941fc4f0c907c74a09b3e227c3817d8"
+    },
+    {
+      "file": "adminindex.html",
+      "bytes": 9317,
+      "sha256": "6564204f21307dba60e2d88496adac03d08e8552278dd4b682c2dfa680451b4b"
+    },
+    {
+      "file": "profileindex.html",
+      "bytes": 21265,
+      "sha256": "fee668f771ad4095e978581b7837f0edba234f778f78c9f3820f29edf03a9502"
+    },
+    {
+      "file": "foodindex.html",
+      "bytes": 13267,
+      "sha256": "34ee16502364e043625650319d19bbede8b78e7a464a38292b64c0009659fae4"
+    },
+    {
+      "file": "clockviews/clock.html",
+      "bytes": 4570,
+      "sha256": "544e988212938e799d7a8d641eb485dc731dcf6aecdf72e67594956e168aafe3"
+    },
+    {
+      "file": "clockviews/clock.html",
+      "bytes": 7901,
+      "sha256": "a8739c512c5d230f5c6fdc5eeeb82f419da4444ab641663a082a8926364f0f84"
+    },
+    {
+      "file": "error.html",
+      "bytes": 1946,
+      "sha256": "2920d1fd799c7b2181574d5b2ed0f693b6b052b2627301eddc140b3205ba52fd"
+    },
+    {
+      "file": "frame.html",
+      "bytes": 686,
+      "sha256": "eee12ff91d726d975151f492ec0bda28c0cae64a5c77a8be67d69d5a0a58645e"
+    },
+    {
+      "file": "frame.html",
+      "bytes": 1383,
+      "sha256": "59ae5f43107d26b31257225bcbe06f89d255e3114c809226db9a7db691259331"
+    },
+    {
+      "file": "frame.html",
+      "bytes": 2219,
+      "sha256": "4466d38700899ae8225086ba59c9aff809cd7cb2d52ed9c346a32030ee7c8c12"
+    },
+    {
+      "file": "service-worker.js",
+      "bytes": 4933,
+      "sha256": "285bfd9893c3392e9909037a6f6aa905c0655d467e07c44b41452d85b9ef0469"
+    },
+    {
+      "file": "service-worker.js",
+      "bytes": 4946,
+      "sha256": "c76b8abcb9d692d8315823624f8527661ed17f8953066578a8c09910ea7719e3"
+    }
+  ],
+  "baselineCommit": "25a87cea0663a418f71af33827e3f9e5fab31060",
+  "notes": "13 actual Nightscout page/worker fixtures with encoded labels, clock include branches, multiframe counts 1/4/8 and two service-worker identities; outputs byte-identical."
+}

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -98,6 +98,10 @@ The [SASLprep review](../test-specs/saslprep-modernization.md) removes its redun
 root declaration because driver 7.6 declares it as required, resolves 1.5.0,
 and adds Unicode SCRAM authentication checks to existing runtime CI jobs.
 
+The [EJS review](../test-specs/ejs-modernization.md) upgrades the template engine
+to dependency-free 6.0.1, removes Jake/filelist and the unused filelist override,
+and covers actual rendered pages, escaping, cache freshness and inherited locals.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/test-specs/ejs-modernization.md
+++ b/docs/test-specs/ejs-modernization.md
@@ -52,8 +52,8 @@ Socket.IO assets, and Unicode SCRAM authentication pass on both Node floors.
 The initial backend run passed 2,021 cases with one existing pending case; its
 only failure invoked the removed Jake dependency. That obsolete test is now
 removed and the 26 combined template/brace-expansion cases pass on both Node
-floors. A clean backend rerun and hosted final-head CI remain required before
-merge.
+floors. The subsequent clean backend run passes all 2,021 cases with one
+existing pending case. Hosted final-head CI remains required before merge.
 
 Sources: [EJS 6.0.1](https://github.com/mde/ejs/releases/tag/v6.0.1),
 [EJS 5 migration notes](https://github.com/mde/ejs/blob/main/RELEASE_NOTES_v5.md).

--- a/docs/test-specs/ejs-modernization.md
+++ b/docs/test-specs/ejs-modernization.md
@@ -1,0 +1,59 @@
+# EJS 6 template review (M09)
+
+Upgrade EJS 3.1.10 to 6.0.1. Nightscout still needs a template engine for page
+includes, conditional clock views, multiframe pages, boot errors and its service
+worker. Reimplementing those semantics locally would add maintenance. The newer
+EJS release has no runtime dependencies: Jake, filelist, their nested async and
+minimatch/brace-expansion records disappear. Remove the now-unused filelist
+minimatch override; other consumers retain their own reviewed overrides.
+
+## Compatibility decisions
+
+The major releases change package exports, remove the legacy `client` option,
+and make template locals own-property-only by default. Nightscout uses public
+CommonJS `render` and `renderFile`, not private EJS files or client compilation.
+Keep the safer locals default; do not enable `unsafePrototypeLocals` to recreate
+inherited data access. Actual page locals and relative includes work unchanged.
+This is not a claim that EJS can sandbox arbitrary untrusted templates.
+
+Ten regression cases cover five page templates with repeated cached renders,
+escaped labels and fresh build identities; multiframe text/attribute escaping;
+actual clock HTTP routes and conditional includes; the actual Express boot-error
+view engine; parseable service-worker output; and exclusion of inherited locals.
+The first nine also pass with EJS 3.1.10. The inherited-locals test intentionally
+fails on that baseline and passes on 6.0.1. Both supported Node floors pass all ten;
+Node 24 also passes all 34 existing security-header cases. The old test invoking
+EJS/Jake/FileList file selection is retired with that removed dependency chain;
+the graph-driven brace-expansion and minimatch checks still cover all remaining
+consumers.
+
+Thirteen renders of actual page/worker templates are byte-identical to EJS 3.1.10,
+including both clock branches, 1/4/8 frames and escaped/Unicode values. Their
+output hashes are recorded in [the comparison artifact](../audits/ejs-render-comparison.json).
+Full browser and HTTP startup coverage are still required; this comparison does
+not prove every possible user setting equivalent.
+
+## Measurements and validation
+
+Compared with Express integration `25a87cea`, the refreshed EJS candidate has
+286 production package records versus 292. Installed production package files
+on ARM64 total 61,943,591 bytes versus 62,941,572, a reduction of 997,981 bytes.
+The sum excludes nested node_modules in each package to avoid double counting.
+Five records disappear entirely and balanced-match becomes development-only.
+All six production browser bundles are byte-identical. These are installed file
+and bundle measurements, not Docker-image or server-memory savings.
+
+A clean Node 22 install/build passes with optional dependencies omitted and reports
+zero audit vulnerabilities. An earlier broad test attempt had no generated
+production bundles and was stopped; it is not counted as compatibility evidence.
+The corrected Chromium run passes all 552 cases. After pruning development
+and optional packages, startup, config import, six pages/bundles, static and
+Socket.IO assets, and Unicode SCRAM authentication pass on both Node floors.
+The initial backend run passed 2,021 cases with one existing pending case; its
+only failure invoked the removed Jake dependency. That obsolete test is now
+removed and the 26 combined template/brace-expansion cases pass on both Node
+floors. A clean backend rerun and hosted final-head CI remain required before
+merge.
+
+Sources: [EJS 6.0.1](https://github.com/mde/ejs/releases/tag/v6.0.1),
+[EJS 5 migration notes](https://github.com/mde/ejs/blob/main/RELEASE_NOTES_v5.md).

--- a/docs/test-specs/ejs-modernization.md
+++ b/docs/test-specs/ejs-modernization.md
@@ -53,7 +53,10 @@ The initial backend run passed 2,021 cases with one existing pending case; its
 only failure invoked the removed Jake dependency. That obsolete test is now
 removed and the 26 combined template/brace-expansion cases pass on both Node
 floors. The subsequent clean backend run passes all 2,021 cases with one
-existing pending case. Hosted final-head CI remains required before merge.
+existing pending case. After refreshing onto Axios merge `fdad2805`, a clean
+install/build, all 66 combined EJS/brace-expansion/Axios/SASLprep/Connect cases
+and the complete pruned runtime checks pass on both supported Node floors.
+Hosted final-head CI remains required before merge.
 
 Sources: [EJS 6.0.1](https://github.com/mde/ejs/releases/tag/v6.0.1),
 [EJS 5 migration notes](https://github.com/mde/ejs/blob/main/RELEASE_NOTES_v5.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "csv-stringify": "^6.8.3",
         "d3": "^7.9.0",
         "easyxml": "^2.0.1",
-        "ejs": "^3.1.8",
+        "ejs": "6.0.1",
         "entities": "^6.0.1",
         "errorhandler": "^1.5.1",
         "events": "^3.3.0",
@@ -3915,6 +3915,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64id": {
@@ -5150,16 +5151,15 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "3.1.10",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-6.0.1.tgz",
+      "integrity": "sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
       "bin": {
         "ejs": "bin/cli.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.12.18"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5735,32 +5735,6 @@
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^6.1.23"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.8",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -6988,25 +6962,6 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
-    },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/async": {
-      "version": "3.2.6",
-      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "csv-stringify": "^6.8.3",
     "d3": "^7.9.0",
     "easyxml": "^2.0.1",
-    "ejs": "^3.1.8",
+    "ejs": "6.0.1",
     "entities": "^6.0.1",
     "errorhandler": "^1.5.1",
     "events": "^3.3.0",
@@ -170,9 +170,6 @@
     "ajv@^6.0.0": "6.15.0",
     "ajv@^8.0.0": "8.18.0",
     "socket.io-parser": "4.2.7",
-    "filelist": {
-      "minimatch": "5.1.8"
-    },
     "schema-utils@^4.0.0": {
       "ajv": "8.18.0"
     },

--- a/tests/dependency-brace-expansion.test.js
+++ b/tests/dependency-brace-expansion.test.js
@@ -81,15 +81,6 @@ describe('brace-expansion dependency regressions', function () {
       });
     });
 
-  it('preserves file selection through the production EJS/Jake/FileList chain', function () {
-    const ejsRequire = createRequire(require.resolve('ejs'));
-    const jakeRequire = createRequire(ejsRequire.resolve('jake'));
-    const { FileList } = jakeRequire('filelist');
-    const files = new FileList();
-    files.include(path.join(__dirname, '{api,api3}.security.test.js'));
-    assert.deepStrictEqual(files.toArray().sort(), [
-      path.join(__dirname, 'api.security.test.js'),
-      path.join(__dirname, 'api3.security.test.js')
-    ]);
-  });
+  // EJS 6 no longer installs Jake/FileList. Remaining consumers are exercised
+  // from the committed dependency graph above.
 });

--- a/tests/dependency-ejs.test.js
+++ b/tests/dependency-ejs.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const ejs = require('ejs');
+const request = require('supertest');
+const views = path.join(__dirname, '../views');
+
+function renderFile(file, data) {
+  return new Promise((resolve, reject) => {
+    ejs.renderFile(path.join(views, file), data, {cache: true}, (error, html) => {
+      if (error) reject(error);
+      else resolve(html);
+    });
+  });
+}
+
+describe('EJS application template contracts', function () {
+  afterEach(() => ejs.clearCache());
+
+  for (const [file, type, entry] of [
+    ['index.html', 'index', 'app'], ['reportindex.html', 'reports', 'reports'],
+    ['adminindex.html', 'admin', 'admin'], ['profileindex.html', 'profile', 'profile'],
+    ['foodindex.html', 'food', 'food']
+  ]) {
+    it(file + ' retains includes, escaped labels and fresh locals with cached templates', async function () {
+      for (const revision of ['first & revision', 'second 💉 revision']) {
+        const data = {type, title: 'Café <test> & "quotes"', bundle: '/bundle', cachebuster: revision};
+        const html = await renderFile(file, data);
+        assert.ok(html.includes('Café &lt;test&gt; &amp; &#34;quotes&#34;'));
+        assert.ok(!html.includes('Café <test>'));
+        assert.ok(html.includes('/bundle/js/bundle.' + entry + '.js?v=' + encodeURIComponent(revision)));
+        assert.ok(html.includes('id="page-load-error"'));
+        assert.ok(html.includes('id="page-load-retry"'));
+        assert.ok(!html.includes('<%'));
+      }
+    });
+  }
+
+  it('escapes multiframe labels and attribute values', async function () {
+    const html = await renderFile('frame.html', {settings: {
+      frameUrl1: 'https://fixture.invalid/?a=1&b="quoted"', frameName1: '<b>Not markup</b>',
+      frameUrl2: 'https://fixture.invalid/second', frameName2: 'Second 💉'
+    }});
+    assert.ok(html.includes('&lt;b&gt;Not markup&lt;/b&gt;'));
+    assert.ok(html.includes('src="https://fixture.invalid/?a=1&amp;b=&#34;quoted&#34;"'));
+    assert.ok(html.includes('Second 💉'));
+    assert.equal((html.match(/<iframe /g) || []).length, 2);
+  });
+
+  it('renders actual clock routes and conditional CSS includes repeatedly', async function () {
+    const app = require('../lib/server/clocks')();
+    app.set('view cache', true);
+    for (const revision of ['first build', 'second build']) {
+      app.setLocals({bundle: '/bundle', cachebuster: revision});
+      for (const face of ['clock-digital', 'config']) {
+        const response = await request(app).get('/' + face).expect(200);
+        assert.ok(response.text.includes('data-face="' + face + '"'));
+        assert.ok(response.text.includes('/bundle/js/bundle.clock.js?v=' + encodeURIComponent(revision)));
+        assert.equal(response.text.includes('data-face-config="cy10"'), face === 'config');
+        assert.ok(!response.text.includes('<%'));
+      }
+    }
+  });
+
+  it('preserves formatted boot-error output through the actual Express view engine', async function () {
+    const app = require('../lib/server/booterror')({}, {bootErrors: [{desc: 'Fixture failure', err: 'First\\nSecond'}]});
+    const response = await request(app).get('/unavailable').expect(500);
+    assert.ok(response.text.includes('<dt><b>Fixture failure</b></dt><dd>First<br/>Second</dd>'));
+  });
+
+  it('renders parseable service workers with the current build identity', function () {
+    const source = fs.readFileSync(path.join(views, 'service-worker.js'), 'utf8');
+    for (const cachebuster of ['first-build', 'second-build']) {
+      const rendered = ejs.render(source, {locals: {cachebuster}});
+      assert.ok(rendered.includes("var CACHE = '" + cachebuster + "';"));
+      assert.doesNotThrow(() => new vm.Script(rendered));
+    }
+  });
+
+  it('does not expose inherited locals to templates', function () {
+    const data = Object.create({inheritedTemplateValue: 'unexpected'});
+    data.ownedTemplateValue = 'expected';
+    assert.equal(ejs.render('<%= typeof inheritedTemplateValue %>:<%= ownedTemplateValue %>', data), 'undefined:expected');
+  });
+});


### PR DESCRIPTION
Nightscout's EJS 3 installation pulls Jake and FileList into production even though the application only renders templates. Upgrade to EJS 6.0.1, which has no runtime dependencies, and remove the unused FileList minimatch override. Keep the existing template engine rather than reimplementing includes and rendering locally.

The application uses supported CommonJS render/renderFile APIs. The old client-compilation option is unused. Keep EJS 6's safer own-property-only locals default; a regression demonstrates the deliberate difference from EJS 3. Nine other new template cases pass on both versions, covering page includes, escaping, cached render freshness, actual clock/boot-error routes and service-worker output. Retire the obsolete test invoking the removed EJS/Jake/FileList chain; graph-driven checks still exercise all remaining brace-expansion consumers.

Validation and measurements are recorded in docs/test-specs/ejs-modernization.md. Thirteen representative template outputs and all six production browser bundles are byte-identical. Installed production files decrease by 997,981 bytes against the recorded baseline; no Docker-image or server-memory saving is claimed. The clean backend suite passes 2,021 cases with one existing pending; all 552 Chromium cases pass. After refreshing onto Axios merge fdad2805, a clean install/build, all 66 combined dependency/transport tests and the full pruned production startup checks pass on Node 22.23.2 and 24.20.0. All required hosted final-head checks passed, including eight Node/MongoDB backend jobs, four replica-set jobs, four browser jobs, npm 12, CodeQL and both Docker architectures.

Part of M09 in #8605; targets chore/nightscout-modernization. The integration PR remains draft and M09 remains open for other dependency families.

Merged by AndyLow91 as `8a07bfb6d726063522e0f202d61f38d3cf94b2e9`. Post-merge verification confirms the actual tree `41f8f72bd8de8082369fd7e2fadf97dc72eeaeb8` equals the tested head and expected merge. All four browser artifacts match that tree; their three historical-timezone differences are unchanged from the baseline.
