### PR TITLE
Consolidate entities 8 and preserve HTML decoding contracts

### DIFF
--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -108,6 +108,12 @@ follow-redirects overrides. Explicit redaction, actual import authentication and
 client isolation have regression coverage; measured installed production files
 shrink by approximately 1 MB, with no measured RAM-saving claim.
 
+The [entities consolidation](../test-specs/entities-consolidation.md) upgrades the
+shared decoder to 8.0.0 and consolidates three installed copies into one, without
+an override. HTML decoding/escaping and sanitization remain required; measured
+package files shrink by 776,553 bytes, with no runtime memory-saving claim.
+This scoped review does not complete M09.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/test-specs/entities-consolidation.md
+++ b/docs/test-specs/entities-consolidation.md
@@ -1,0 +1,57 @@
+# Entities consolidation (M09)
+
+## Change and compatibility
+
+Upgrade the direct `entities` dependency from 6.0.1 to 8.0.0. The existing
+`htmlparser2` and `dom-serializer` consumers already require 8.0.0; npm now
+resolves all three consumers to one installed copy without an override.
+No other retained package version changes.
+
+The [upstream release notes](https://github.com/fb55/entities/releases)
+identify version 8 as ESM-only, requiring Node >=20.19.0 and removing deprecated
+exports. Nightscout uses the public `entities/decode` (`decodeHTML`) and
+`entities/escape` (`escapeText`) exports. These remain available through
+synchronous `require` on our supported Node 22.23.2 and 24.20.0 floors and
+through webpack's browser bundling. The removed deprecated exports are not
+used by Nightscout's direct consumers.
+
+Retain this dependency: the application needs HTML named/numeric reference
+decoding, including malformed-reference rules, on both server and browser.
+A local replacement would duplicate standards data and security-sensitive
+parsing logic. Consolidation reduces duplication without taking on that parser.
+
+## Regression requirements
+
+- `tests/utils.test.js` covers nullish values, named and numeric references,
+  multi-codepoint and supplementary Unicode, Windows-1252 numeric mapping,
+  invalid scalar values, unknown references, missing semicolons, single-layer
+  decoding and inert HTML text output for encoded markup.
+- Existing API/websocket purification and browser sanitizer/rendering suites
+  must preserve stored identifiers, allowed markup and escaping at output.
+- Clean production and development builds must support the ESM exports.
+- Run core tests on both supported Node floors and the existing hosted
+  backend, real-browser, database and Docker matrix before merge.
+
+An isolated 2026-09-06 comparison against integration `07b4389e`'s unchanged
+HTML helpers and purifier used all 2,231 Python HTML5 reference keys in three
+contexts (alone, embedded text and paragraph markup), plus six malformed or
+hostile inputs. All 6,699 inputs matched across `toTextContent`, `textAsHtml`
+and `sanitizeString`: 20,097 comparisons with zero differences on each Node
+floor. This is additional compatibility evidence, not proof for all inputs.
+
+## Measured scope of savings
+
+Summing regular-file sizes in the installed entities package directories:
+
+| Package files | Before | After |
+| --- | ---: | ---: |
+| Root entities | 540,551 bytes (6.0.1) | 236,002 bytes (8.0.0) |
+| Nested entities under dom-serializer | 236,002 bytes | 0 |
+| Nested entities under htmlparser2 | 236,002 bytes | 0 |
+| Total | 1,012,555 bytes | 236,002 bytes |
+
+This removes two installed package paths and 776,553 bytes (about 758 KiB).
+The baseline installation is the preceding integration tree `ad4a8cd5`;
+`07b4389e` changed only documentation. These are uncompressed package-file
+bytes, not filesystem allocation, Docker image, browser transfer or runtime
+memory measurements. No server RAM saving is claimed.

--- a/docs/test-specs/entities-consolidation.md
+++ b/docs/test-specs/entities-consolidation.md
@@ -55,3 +55,24 @@ The baseline installation is the preceding integration tree `ad4a8cd5`;
 `07b4389e` changed only documentation. These are uncompressed package-file
 bytes, not filesystem allocation, Docker image, browser transfer or runtime
 memory measurements. No server RAM saving is claimed.
+
+## Browser resource tradeoff
+
+A fresh production build on Node 22.23.2 compared the unchanged baseline with
+this upgrade. Direct property imports in `lib/utils/html.js` let webpack retain
+only the used ESM exports; destructuring after Babel otherwise retained unused
+decoder exports and exceeded the clock budget. Existing resource limits remain
+unchanged.
+
+| Entry | Baseline gzip bytes | Candidate gzip bytes | Change |
+| --- | ---: | ---: | ---: |
+| App | 303,816 | 305,212 | +1,396 |
+| Clock | 61,301 | 62,703 | +1,402 |
+| All application entries (excluding independent clock) | 374,508 | 375,904 | +1,396 |
+
+Reports, admin, profile and food entry sizes are unchanged. Accept this bounded
+browser transfer increase for package consolidation; do not describe this change
+as a browser-size reduction. Validate output and startup with the real-browser
+suite, including existing page-resource checks. The first local browser run and
+first backend run overlapped an unrelated development build and are not accepted
+as final production validation; final checks use stable production assets.

--- a/lib/utils/html.js
+++ b/lib/utils/html.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const { decodeHTML } = require('entities/decode');
-const { escapeText } = require('entities/escape');
+// Direct property access lets webpack omit unused ESM decoder exports.
+const decodeHTML = require('entities/decode').decodeHTML;
+const escapeText = require('entities/escape').escapeText;
 
 function asString (value) {
   return value === null || typeof value === 'undefined' ? '' : String(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "d3": "^7.9.0",
         "easyxml": "^2.0.1",
         "ejs": "6.0.1",
-        "entities": "^6.0.1",
+        "entities": "8.0.0",
         "errorhandler": "^1.5.1",
         "events": "^3.3.0",
         "express": "^5.2.1",
@@ -5035,18 +5035,6 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/domelementtype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
@@ -5261,10 +5249,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.1",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -6253,18 +6243,6 @@
       },
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-cookie-agent": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "d3": "^7.9.0",
     "easyxml": "^2.0.1",
     "ejs": "6.0.1",
-    "entities": "^6.0.1",
+    "entities": "8.0.0",
     "errorhandler": "^1.5.1",
     "events": "^3.3.0",
     "express": "^5.2.1",

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -151,6 +151,18 @@ describe('utils', function ( ) {
       html.toTextContent('<img src=x onerror="alert(1)">').should.equal('<img src=x onerror="alert(1)">');
     });
 
+    it('preserves named, numeric and malformed character-reference behavior', function () {
+      html.toTextContent('&NotEqualTilde; &#x1F355; &#128;').should.equal('\u2242\u0338 🍕 €');
+      html.toTextContent('&#0; &#xD800; &#x110000;').should.equal('\uFFFD \uFFFD \uFFFD');
+      html.toTextContent('&unknown; &#xZZ; &amp').should.equal('&unknown; &#xZZ; &');
+    });
+
+    it('keeps decoded numeric markup inert in HTML text output', function () {
+      html.textAsHtml('&#60;img src=x onerror=alert(1)&#62;')
+        .should.equal('&lt;img src=x onerror=alert(1)&gt;');
+      html.toTextContent('&amp;#60;script&amp;#62;').should.equal('&#60;script&#62;');
+    });
+
     it('decodes one layer before escaping for an HTML text-node context', function () {
       html.textAsHtml('Already &#60;tag&#62; & raw').should.equal('Already &lt;tag&gt; &amp; raw');
       html.textAsHtml('&amp;lt;script&amp;gt;').should.equal('&amp;lt;script&amp;gt;');


### PR DESCRIPTION
Nightscout currently installs entities 6.0.1 alongside two copies of 8.0.0. Upgrade the direct dependency to 8.0.0 so the application, htmlparser2 and dom-serializer share one copy without overrides. This removes 776,553 bytes of installed package files; no runtime RAM saving is claimed.

Direct property imports let webpack omit unused ESM decoder exports and keep the clock within its existing resource budget. Compared with a fresh baseline build, the dashboard grows by 1,396 gzip bytes and clock by 1,402; other page entries are unchanged. This is an explicit browser-transfer tradeoff, not a browser-size saving.

The public decoding/escaping exports remain compatible with synchronous CommonJS loading on Node 22.23.2 and 24.20.0 and webpack. Retain the maintained parser rather than reimplementing HTML character-reference rules. Added regression cases preserve malformed/numeric/named reference behavior, Unicode and inert output for encoded markup. Documentation records compatibility, measurements and the remaining M09 scope.

Validation so far: clean Node 22 install/production build; Node 24 development build; 296 helper/core tests on each Node floor; 20,097 actual helper/sanitizer comparisons per runtime with zero differences; lint has zero errors and 16 existing warnings. The final production build passes all 574 Chromium tests and the unchanged bundle budgets. The final Node 22 backend run passes 2,060 tests with one existing pending test. All required hosted CI/CodeQL checks passed after a targeted retry of jobs affected by Docker Hub's pull-rate limit. The actual merge into chore/nightscout-modernization is f43d8576; its tree and all four browser comparison artifacts match the verified candidate.

Targets chore/nightscout-modernization for integration through #8605. No intentional UI/UX or security-policy change.
