### PR TITLE
Upgrade MIME lookup while preserving JavaScript status responses

### DIFF
--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -114,6 +114,12 @@ an override. HTML decoding/escaping and sanitization remain required; measured
 package files shrink by 776,553 bytes, with no runtime memory-saving claim.
 This scoped review does not complete M09.
 
+The [mime-types maintenance review](../test-specs/mime-types-upgrade.md) aligns
+direct lookup with Express's 3.0.2 release and preserves v1 JavaScript status
+negotiation. Legacy accepts/form-data consumers retain compatible 2.x copies;
+this is a maintenance upgrade with a measured installation-size increase, not
+a memory-saving claim.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/test-specs/mime-types-upgrade.md
+++ b/docs/test-specs/mime-types-upgrade.md
@@ -1,0 +1,43 @@
+# MIME types maintenance review (M09)
+
+Upgrade Nightscout's direct `mime-types` from 2.1.35 to 3.0.2, the release
+already used by Express 5, send, type-is and development middleware. Keep the
+maintained database rather than implementing broad extension lookup locally.
+The [upstream major release](https://github.com/jshttp/mime-types/releases/tag/v3.0.0)
+changes conflict resolution and requires Node >=18, within our supported floors.
+
+## API compatibility
+
+Version 3 maps `js` to `text/javascript`, while Nightscout's v1 status route
+explicitly negotiates `application/javascript`. The v1 extension middleware
+retains that established mapping. Static-file MIME behavior already uses v3
+through Express and does not change. V3's supported JSON/CSV/XML aliases remain
+unchanged; unsupported JavaScript requests still return 406.
+
+Comparing the 1,180 old lookup extensions finds 12 changed mappings: es, js,
+mjs, xfdf, fdf, prc, sql, wav, aac, hsj2, mts and jpgm. None changes V3's
+supported response formats. None of the 59 added extensions maps to its accepted
+application/json, application/xml or text/csv types. The existing negotiation
+test retains every configured v1 mapping and extends V3 rejection checks to
+all changed mappings. The actual status API test now awaits request errors,
+checks both extension and explicit Accept negotiation twice, and parses the
+returned settings payload.
+
+## Installed dependency tradeoff
+
+The update consolidates five `mime-types` installations into three. Version
+2.1.35 remains required by accepts 1.x and form-data, with separate copies of
+its 1.52.0 MIME database. Their majors are not forced through an override.
+
+Summing each package's own regular files, excluding nested node_modules to
+avoid double counting, across mime-types and mime-db:
+
+| Scope | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| All installed files | 540,861 bytes | 696,059 bytes | +155,198 bytes |
+| Production installed files | 517,990 bytes | 696,059 bytes | +178,069 bytes |
+
+Accept this as a maintenance/alignment upgrade, not a package-size or memory
+optimization. The older dependency branches can be reviewed with their parents.
+No server RAM or browser-size saving is claimed. Full CI and CodeQL remain
+required before merge into the modernization branch.

--- a/lib/middleware/express-extension-to-accept.js
+++ b/lib/middleware/express-extension-to-accept.js
@@ -11,7 +11,9 @@ module.exports = function (formats) {
     if (!/^\w+$/.test(format))
       throw new TypeError('Invalid format - must be a word.')
 
-    var type = getType[format] = mime.lookup(format)
+    // The v1 status endpoint explicitly negotiates application/javascript.
+    // Keep that API contract even though mime-types 3 maps js to text/javascript.
+    var type = getType[format] = format === 'js' ? 'application/javascript' : mime.lookup(format)
     if (!type || type === 'application/octet-stream')
       throw new Error('Invalid format.')
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "jquery": "^3.5.1",
         "jquery-ui": "^1.14.2",
         "jsonwebtoken": "^9.0.0",
-        "mime-types": "^2.1.35",
+        "mime-types": "3.0.2",
         "moment": "^2.27.0",
         "moment-timezone": "^0.6.3",
         "mongodb": "^7.6.0",
@@ -3666,6 +3666,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/accepts/node_modules/negotiator": {
       "version": "0.6.3",
       "license": "MIT",
@@ -5618,22 +5639,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/express/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/express/node_modules/negotiator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
@@ -5868,6 +5873,27 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/formidable": {
@@ -7337,20 +7363,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types/node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -8888,22 +8913,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/serialize-javascript": {
       "version": "7.0.5",
       "dev": true,
@@ -9727,22 +9736,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "dev": true,
@@ -10099,21 +10092,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/mime-types": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "jquery": "^3.5.1",
     "jquery-ui": "^1.14.2",
     "jsonwebtoken": "^9.0.0",
-    "mime-types": "^2.1.35",
+    "mime-types": "3.0.2",
     "moment": "^2.27.0",
     "moment-timezone": "^0.6.3",
     "mongodb": "^7.6.0",

--- a/tests/api.status.test.js
+++ b/tests/api.status.test.js
@@ -71,15 +71,18 @@ describe('Status REST api', function ( ) {
   });
 
 
-  it('/status.js', function (done) {
-    request(this.app)
-      .get('/api/status.js')
-      .end(function(err, res) {
+  it('preserves JavaScript status by extension and explicit Accept header', async function () {
+    for (let cycle = 0; cycle < 2; cycle++) {
+      for (const endpoint of ['/api/status.js?count=1', '/api/status']) {
+        const res = await request(this.app).get(endpoint)
+          .set('Accept', 'application/javascript').expect(200);
         res.type.should.equal('application/javascript');
-        res.statusCode.should.equal(200);
         res.text.should.startWith('this.serverSettings =');
-        done();
-      });
+        const info = JSON.parse(res.text.slice('this.serverSettings = '.length, -2));
+        info.status.should.equal('ok');
+        info.apiEnabled.should.equal(true);
+      }
+    }
   });
 
   it('/status.png', function (done) {

--- a/tests/mime-negotiation.test.js
+++ b/tests/mime-negotiation.test.js
@@ -39,7 +39,7 @@ describe('API extension negotiation contracts', function () {
       if(type==='application/json') assert.deepEqual(result.body.result,[{sgv:123}]);
       else assert(result.text.includes('123'));
     }
-    for(const ext of ['unknown','exe','dll','deb','dmg','iso','msi','asc','wav','mpp','html','jsonld','rdf']) {
+    for(const ext of ['unknown','exe','dll','deb','dmg','iso','msi','asc','wav','mpp','html','jsonld','rdf','es','js','mjs','xfdf','fdf','prc','sql','aac','hsj2','mts','jpgm']) {
       await request(app).get('/entries.'+ext).expect(406);
     }
   });


### PR DESCRIPTION
Upgrade Nightscout's direct mime-types dependency to 3.0.2, aligning extension lookup with the release already used by Express 5. Preserve the established application/javascript mapping for v1 `/status.js`: upgrading alone would map `.js` to text/javascript and break that route's explicit negotiation.

The API regression checks cover both JavaScript status transports over two cycles, all configured v1 formats, query/header preservation, supported V3 aliases and rejection of the 12 extensions whose MIME mappings changed. No intended UI/UX change; all six generated browser JavaScript bundles are byte-for-byte identical to the entities integration candidate.

Local validation: clean Node 22 installation and production build; 22 focused status/rendering tests on Node 22.23.2 and 24.20.0; full Node 22 backend suite passes 2,060 tests with one existing pending test; lint has zero errors and 16 existing warnings. All required hosted CI/CodeQL checks passed. The actual merge f24c029a matches the tested tree, and all four browser artifacts preserve the previous integration's app bundle hashes and historical timezone comparison results.

This is a maintenance upgrade, not a size-saving change: legacy accepts/form-data still need compatible 2.x copies, and their duplicated MIME database increases production package files by 178,069 bytes. No incompatible transitive override or RAM-saving claim. The test specification records the measured tradeoff and the M09 plan remains open.

Targets chore/nightscout-modernization for integration through #8605.
