### PR TITLE
Update APNs provider and verify Loop transport lifecycle

### DIFF
--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -120,6 +120,12 @@ negotiation. Legacy accepts/form-data consumers retain compatible 2.x copies;
 this is a maintenance upgrade with a measured installation-size increase, not
 a memory-saving claim.
 
+The [APNs provider review](../test-specs/apn-upgrade.md) moves to 8.1.0, removes
+five duplicate dependency paths and the redundant node-forge override. Owned
+TLS/HTTP2 tests cover actual signed Loop requests, retries, failure handling and
+session/timer cleanup. The published package files grow slightly; no RAM-saving
+claim is made. Remaining M09 reviews stay open.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/test-specs/apn-upgrade.md
+++ b/docs/test-specs/apn-upgrade.md
@@ -1,0 +1,63 @@
+# APNs provider maintenance (M09)
+
+Upgrade `@parse/node-apn` from installed 5.2.3 to 8.1.0, the latest release
+verified against the registry and [upstream releases](https://github.com/parse-community/node-apn/releases)
+on 2026-09-06. Its runtime policy explicitly supports Node 22 and 24. The
+intervening major releases drop older Node versions; the API remains CommonJS.
+Retain the provider: native HTTP/2 and crypto do not replace APNs token handling,
+response classification, retries and session management by themselves.
+
+The new provider directly requires node-forge 1.4.0, so remove the redundant
+root override. `npm ls` confirms this is the sole node-forge consumer. It shares
+debug 4.4.3 and jsonwebtoken 9.0.3 with the existing graph, removing five nested
+package paths (debug, jsonwebtoken, jwa, jws and ms). No other retained package
+version changes. The full npm audit has zero known advisories at review time.
+
+## Behavior and regression coverage
+
+Provider.send now uses allSettled and returns individual transport rejections
+in `failed`. Loop must still report failure rather than success, invoke its
+completion once, and tear down the provider. The notification implementation
+now explicitly emits the default priority 10 header. Loop's unspecified
+push-type and its topic, APS and custom payload contracts are retained. The
+Live Activity `events` to `event` change does not affect Nightscout's consumers.
+
+`tests/apn-transport.test.js` uses the actual public Provider and Notification,
+a generated EC signing key, an owned certificate and a loopback TLS/HTTP2
+server. A scoped loader supplies only the provider's fixture address/CA options;
+it executes the actual Loop notification code. No Apple server or real device
+is contacted, and TLS validation is enabled.
+
+Over two cycles, the tests verify:
+
+- JWT ES256 signature, issuer and key ID; request method, device path, topic and
+  priority; temporary override/cancel, carbs/absorption and bolus payloads;
+  notes, origin and the five-minute payload expiration interval.
+- BadDeviceToken rejection, transient 503 retry with identical payload,
+  exhausted retry limits and one completion per notification.
+- An untrusted certificate prevents any notification request reaching the server.
+- HTTP/2 sessions close and both heartbeat timers are cleared after success
+  and failure. The new SDK has separate normal/broadcast heartbeat timers.
+
+Existing APN lifecycle and Loop environment-selection tests remain in place.
+The owned transport tests supplement them; they do not establish real Apple
+account credentials, device receipt or delivery timing. No runtime Loop code,
+notification policy or UI is intentionally changed. All six generated browser
+JavaScript bundles are byte-for-byte identical to the preceding MIME build.
+
+## Resource tradeoff
+
+Compared with the preceding MIME candidate, summing each production package's
+own regular files (excluding nested node_modules to avoid double counting):
+282 paths / 60,325,080 bytes becomes 277 paths / 60,348,921 bytes. Removing
+five nested copies and an override simplifies the graph, but the newer SDK's
+published files offset that reduction: net **23,841 bytes larger**. This is a
+maintenance upgrade, not a claimed package-size or runtime-memory saving.
+
+## Validation
+
+Run `tests/apn-transport.test.js`, `tests/apn-lifecycle.test.js` and
+`tests/loop-server.test.js` on both supported Node floors. Run the full backend
+suite, clean install/production build, npm dependency resolution and audit,
+then require the existing hosted CI/CodeQL matrix and merge-tree verification.
+No additional CI environment is introduced.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.1127.0",
-        "@parse/node-apn": "^5.1.3",
+        "@parse/node-apn": "8.1.0",
         "axios": "1.20.0",
         "braces": "^3.0.2",
         "compression": "^1.7.4",
@@ -3240,67 +3240,19 @@
       }
     },
     "node_modules/@parse/node-apn": {
-      "version": "5.2.3",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-8.1.0.tgz",
+      "integrity": "sha512-LowcdkKPDikbbzIr3zwEdoFW5wfEbbTzpYQeen3S8kKLePG0AQK586Li+OLC7bonyLmlk//Yk3smHZOLSV6TZA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "4.3.3",
-        "jsonwebtoken": "9.0.0",
-        "node-forge": "1.3.1",
+        "debug": "4.4.3",
+        "jsonwebtoken": "9.0.3",
+        "node-forge": "1.4.0",
         "verror": "1.10.1"
       },
       "engines": {
-        "node": ">= 12"
+        "node": "20 || 22 || 24"
       }
-    },
-    "node_modules/@parse/node-apn/node_modules/debug": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@parse/node-apn/node_modules/jsonwebtoken": {
-      "version": "9.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash": "^4.17.21",
-        "ms": "^2.1.1",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@parse/node-apn/node_modules/jwa": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@parse/node-apn/node_modules/jws": {
-      "version": "3.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.2",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@parse/node-apn/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@aws-sdk/credential-providers": "3.1127.0",
-    "@parse/node-apn": "^5.1.3",
+    "@parse/node-apn": "8.1.0",
     "axios": "1.20.0",
     "braces": "^3.0.2",
     "compression": "^1.7.4",
@@ -158,7 +158,6 @@
     "xss": "^1.0.15"
   },
   "overrides": {
-    "node-forge": "1.4.0",
     "lodash": "4.18.1",
     "ip-address": "10.7.0",
     "postcss": "8.5.28",

--- a/tests/apn-transport.test.js
+++ b/tests/apn-transport.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const vm = require('node:vm');
+const http2 = require('node:http2');
+const {execFile} = require('node:child_process');
+const {promisify} = require('node:util');
+const {generateKeyPairSync} = require('node:crypto');
+const {setTimeout: delay} = require('node:timers/promises');
+const apn = require('@parse/node-apn');
+const jwt = require('jsonwebtoken');
+
+// Exercise the real public Provider/Notification against an owned TLS endpoint.
+// Only provider configuration is redirected; no production APNs connection is made.
+describe('Loop APNs HTTP/2 transport', function () {
+  this.timeout(20000);
+  let directory, server, loop, sessions, requests, clients, reply, publicKey;
+  let trustFixture = true;
+  const device = 'a'.repeat(64);
+
+  before(async function () {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'nightscout-apn-tls-'));
+    await promisify(execFile)('openssl', ['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-sha256',
+      '-keyout', path.join(directory, 'key.pem'), '-out', path.join(directory, 'cert.pem'),
+      '-days', '1', '-subj', '/CN=127.0.0.1', '-addext', 'subjectAltName=IP:127.0.0.1'], {timeout: 10000});
+    const cert = await fs.readFile(path.join(directory, 'cert.pem'));
+    server = http2.createSecureServer({cert, key: await fs.readFile(path.join(directory, 'key.pem'))});
+    sessions = new Set(); requests = []; clients = [];
+    server.on('session', session => {
+      sessions.add(session);
+      session.on('error', () => {});
+      session.on('close', () => sessions.delete(session));
+    });
+    server.on('stream', (stream, headers) => {
+      stream.on('error', () => {});
+      let body = '';
+      stream.setEncoding('utf8');
+      stream.on('data', chunk => { body += chunk; });
+      stream.on('end', () => {
+        requests.push({headers, body: JSON.parse(body)});
+        const response = reply(requests.length);
+        stream.respond({':status': response.status, 'apns-id': 'owned-apn-id'});
+        stream.end(response.reason ? JSON.stringify({reason: response.reason}) : '');
+      });
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const keys = generateKeyPairSync('ec', {namedCurve: 'prime256v1'});
+    publicKey = keys.publicKey;
+    const sandbox = {module: {exports: {}}, console: {log() {}, error() {}}, require(name) {
+      assert.equal(name, '@parse/node-apn');
+      return {...apn, Provider: function (options) {
+        const provider = new apn.Provider({...options, address: '127.0.0.1', port: server.address().port,
+          ca: trustFixture ? cert : undefined, rejectUnauthorized: true, connectionRetryLimit: 1, requestTimeout: 1000});
+        clients.push(provider.client);
+        return provider;
+      }};
+    }};
+    vm.runInNewContext(await fs.readFile(path.join(__dirname, '../lib/server/loop.js'), 'utf8'), sandbox);
+    loop = sandbox.module.exports({extendedSettings: {loop: {
+      apnsKey: keys.privateKey.export({type: 'pkcs8', format: 'pem'}), apnsKeyId: 'OWNEDKEY01', developerTeamId: 'TEAMID1234'
+    }}}, {ddata: {profiles: [{isAPNSProduction: false, loopSettings: {deviceToken: device, bundleIdentifier: 'org.example.loop'}}]}});
+  });
+
+  after(async function () {
+    for (const client of clients || []) client.shutdown();
+    for (const session of sessions || []) session.destroy();
+    if (server) await new Promise(resolve => server.close(resolve));
+    if (directory) await fs.rm(directory, {recursive: true, force: true});
+  });
+
+  async function send(data) {
+    let callbacks = 0;
+    const result = await new Promise(resolve => loop.sendNotification(data, '127.0.0.1', error => {
+      callbacks++; resolve(error);
+    }));
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline && (sessions.size || !clients.at(-1).isDestroyed)) await delay(10);
+    assert.equal(callbacks, 1);
+    assert.equal(sessions.size, 0, 'Provider must close its HTTP/2 session after completion');
+    assert.equal(clients.at(-1).isDestroyed, true);
+    assert.equal(clients.at(-1).healthCheckInterval, null);
+    assert.equal(clients.at(-1).manageChannelsHealthCheckInterval, null);
+    return result;
+  }
+
+  it('preserves signed requests, therapy payloads and teardown over two cycles', async function () {
+    reply = () => ({status: 200});
+    const cases = [
+      [{eventType: 'Temporary Override Cancel'}, {'cancel-temporary-override': 'true'}],
+      [{eventType: 'Temporary Override', reason: 'exercise', reasonDisplay: 'Exercise', duration: 30}, {'override-name': 'exercise', 'override-duration-minutes': 30}],
+      [{eventType: 'Remote Carbs Entry', remoteCarbs: 15, remoteAbsorption: 2, otp: 'fixture', created_at: '2026-01-01T12:00:00Z'}, {'carbs-entry': 15, 'absorption-time': 2, otp: 'fixture', 'start-time': '2026-01-01T12:00:00Z'}],
+      [{eventType: 'Remote Bolus Entry', remoteBolus: 0.5, otp: 'fixture'}, {'bolus-entry': 0.5, otp: 'fixture'}]
+    ];
+    for (let cycle = 0; cycle < 2; cycle++) for (const [data, expected] of cases) {
+      const count = requests.length;
+      assert.equal(await send({...data, notes: 'owned note', enteredBy: 'owned user'}), undefined);
+      assert.equal(requests.length, count + 1);
+      const {headers, body} = requests.at(-1);
+      assert.equal(headers[':method'], 'POST');
+      assert.equal(headers[':path'], '/3/device/' + device);
+      assert.equal(headers['apns-topic'], 'org.example.loop');
+      assert.equal(headers['apns-priority'], '10');
+      // Loop has historically left push-type unspecified; retain that wire contract.
+      assert.equal(headers['apns-push-type'], undefined);
+      const token = headers.authorization.replace(/^bearer /, '');
+      const decoded = jwt.verify(token, publicKey, {algorithms: ['ES256'], issuer: 'TEAMID1234', complete: true});
+      assert.equal(decoded.header.kid, 'OWNEDKEY01');
+      assert.equal(body.aps['content-available'], 1);
+      assert.equal(body.aps['interruption-level'], 'time-sensitive');
+      assert.equal(body.notes, 'owned note');
+      assert.equal(body['entered-by'], 'owned user');
+      assert.equal(body['remote-address'], '127.0.0.1');
+      assert.equal(Date.parse(body.expiration) - Date.parse(body['sent-at']), 300000);
+      for (const [key, value] of Object.entries(expected)) assert.equal(body[key], value);
+    }
+  });
+
+  it('rejects an untrusted server certificate without sending a notification', async function () {
+    trustFixture = false;
+    reply = () => ({status: 200});
+    try {
+      for (let cycle = 0; cycle < 2; cycle++) {
+        const count = requests.length;
+        assert.match(await send({eventType: 'Temporary Override Cancel'}), /^APNs delivery failed:/);
+        assert.equal(requests.length, count);
+      }
+    } finally { trustFixture = true; }
+  });
+
+  it('reports rejected tokens and retries transient failure without changing the payload', async function () {
+    for (let cycle = 0; cycle < 2; cycle++) {
+      reply = () => ({status: 400, reason: 'BadDeviceToken'});
+      const count = requests.length;
+      assert.equal(await send({eventType: 'Temporary Override Cancel'}), 'APNs delivery failed: BadDeviceToken');
+      assert.equal(requests.length, count + 1);
+      let attempts = 0;
+      reply = () => ++attempts === 1 ? {status: 503, reason: 'ServiceUnavailable'} : {status: 200};
+      assert.equal(await send({eventType: 'Temporary Override Cancel'}), undefined);
+      assert.equal(attempts, 2);
+      assert.deepEqual(requests.at(-1).body, requests.at(-2).body);
+      attempts = 0;
+      reply = () => { attempts++; return {status: 503, reason: 'ServiceUnavailable'}; };
+      assert.equal(await send({eventType: 'Temporary Override Cancel'}), 'APNs delivery failed: ServiceUnavailable');
+      assert.equal(attempts, 2, 'Provider must stop after its configured retry limit');
+    }
+  });
+});


### PR DESCRIPTION
Upgrade @parse/node-apn from 5.2.3 to 8.1.0, with explicit Node 22/24 support. The provider now shares debug/JWT dependencies with the existing graph, removing five nested package paths. Remove the redundant node-forge override because the provider directly requires the patched 1.4.0 release.

Add owned TLS/HTTP2 tests using the actual public Provider/Notification and Loop code. Over two cycles they verify signed requests and therapy payloads, certificate rejection, device-token failure, transient retry and exhaustion, exactly-once completion, closed sessions and both cleared heartbeat timers. No Apple server or real device is contacted. No runtime Loop or intentional UI/policy change; all six browser bundles are byte-for-byte unchanged from the MIME candidate.

Validation: clean Node 22 install/production build; full backend suite passes 2,063 tests with one existing pending test; focused provider tests pass on Node 22.23.2 and 24.20.0; dependency resolution succeeds without the node-forge override; full npm audit reports zero known advisories; lint has zero errors and 16 existing warnings. All required hosted CI/CodeQL checks passed. Actual merge 1b31c6f3 matches the tested tree; all four browser artifacts preserve the preceding integration's bundle hashes and historical timezone comparisons.

The graph is simpler, but the larger SDK files offset removed duplicates: production package files grow by 23,841 bytes. No package-size or runtime-memory saving is claimed. Documentation records the API changes, tests and resource tradeoff.

Targets chore/nightscout-modernization for integration through #8605. M09 remains open.
