### PR TITLE
Retire Pushover SDK with bounded native HTTPS transport

### DIFF
--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -126,6 +126,12 @@ TLS/HTTP2 tests cover actual signed Loop requests, retries, failure handling and
 session/timer cleanup. The published package files grow slightly; no RAM-saving
 claim is made. Remaining M09 reviews stay open.
 
+The [native Pushover transport](../test-specs/pushover-native-transport.md) removes
+pushover-notifications and preserves message/receipt contracts using Node HTTPS.
+Owned TLS tests cover encoding, cancellation, failure classification, deadlines
+and cleanup. Package plus runtime source decreases by 22,575 bytes; no measured
+RAM saving is claimed. This does not complete the remaining M09 reviews.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/test-specs/pushover-native-transport.md
+++ b/docs/test-specs/pushover-native-transport.md
@@ -1,0 +1,70 @@
+# Native Pushover transport (M09)
+
+Remove `pushover-notifications` 1.2.3 and replace the application's used subset
+with `lib/server/pushover-client.js`, using Node HTTPS and URLSearchParams.
+Nightscout uses message submission and receipt cancellation; it does not use the
+SDK's attachments, custom proxy, sound enumeration or scheduled sound refresh.
+No replacement dependency or public endpoint override is added.
+
+The [message API](https://pushover.net/api) supports URL-encoded HTTPS POSTs,
+and [receipt cancellation](https://pushover.net/api/receipts) specifies POST.
+TLS verification stays enabled and the production origin is fixed. The helper
+has a ten-second total request deadline and a 64 KiB response limit. It does
+not follow redirects or automatically retry a POST: a timeout can occur after
+a message was accepted, so retrying could duplicate a notification.
+
+## Preserved and corrected behavior
+
+- Existing user/group/alarm/announcement routing, disabled-key fallback, sound,
+  priority, retry, 15-minute expiration and callback URLs remain unchanged.
+  Each recipient's form is encoded synchronously without mutating the shared
+  message. Normal priority is explicitly sent as 0 rather than omitted; both
+  mean normal priority in the API.
+- Successful send callbacks retain JSON text, which `pushnotify` parses to
+  store receipts and extend suppression TTLs. Cancellation retains the response
+  object/statusCode callback shape after consuming its response.
+- Cancellation now uses the documented POST method with the token in the body,
+  rather than GET with a token in the URL. The receipt path segment is encoded.
+- HTTP failures, API status 0, malformed JSON, interrupted/oversized responses,
+  TLS failures and timeouts invoke the error callback once. The previous SDK
+  could log an API error but still invoke the send callback as a success;
+  cancellation previously treated an HTTP error response as success. Failures
+  now preserve existing retryable receipt-cache behavior.
+- Message timestamps now use Unix seconds from the server clock. The previous
+  Date object serialized to an empty form value. This makes the existing
+  creation-time intent explicit; operators should keep the server clock correct.
+- Newly created errors contain stable categories and HTTP status where useful,
+  not raw response bodies, tokens or request objects. Existing application
+  logging policy is otherwise unchanged.
+
+No configuration migration is required. This intentionally corrects protocol
+and failure handling; it is not a claim of byte-identical wire requests.
+
+## Verification
+
+`tests/pushover-transport.test.js` uses generated certificates and an owned HTTPS
+fixture with TLS verification enabled. The fixture redirects requests only in
+the test loader; no real Pushover account or device is contacted. It checks:
+
+- Unicode/form encoding, independent simultaneous recipients and unchanged
+  input objects; actual plugin recipient routing, alarm fields and timestamps.
+- Raw JSON receipt results and POST cancellation with body credentials.
+- HTTP 400/429/503, redirects, API failure, malformed/oversized/truncated responses,
+  deadlines and untrusted certificates, with exactly one completion and no retry.
+- Repeated send/cancel calls and owned request socket cleanup. The fixture uses
+  a non-pooled agent; production retains Node's normal shared HTTPS agent policy.
+
+Existing plugin/lifecycle and notification-cache tests retain recipient selection,
+suppression, acknowledgement, cancellation and teardown coverage. The provider
+measurement tool recognizes both the old SDK and new native client, preserving
+its interception of all outbound sends. New checks use existing CI environments.
+These tests do not establish live vendor/device delivery or account validity.
+
+## Measured footprint
+
+The removed SDK's regular files total 26,270 bytes. The net runtime source
+increase is 3,695 bytes, so package plus runtime source decreases by 22,575 bytes
+(excluding test/documentation files and filesystem allocation). One production
+package path is removed. All six generated browser JavaScript bundles are
+byte-for-byte unchanged from the APNs candidate. No measured server RAM,
+Docker-image or browser-transfer saving is claimed.

--- a/lib/plugins/pushover.js
+++ b/lib/plugins/pushover.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var https = require('https');
 var times = require('../times');
 
 function init (env, ctx) {
@@ -34,7 +33,7 @@ function init (env, ctx) {
         , title: notify.title
         , message: notify.message
         , sound: notify.pushoverSound || 'gamelan'
-        , timestamp: new Date()
+        , timestamp: Math.floor(Date.now() / 1000)
         //USE PUSHOVER_EMERGENCY for WARN and URGENT so we get the acks
         , priority: notify.level >= ctx.levels.WARN ? pushover.PRIORITY_EMERGENCY : pushover.PRIORITY_NORMAL
       };
@@ -75,14 +74,7 @@ function init (env, ctx) {
   };
 
   pushover.cancelWithReceipt = function cancelWithReceipt (receipt, callback) {
-    https
-      .get('https://api.pushover.net/1/receipts/' + receipt + '/cancel.json?token=' + pushoverAPI.apiToken, function (response) {
-        response.resume();
-        callback(null, response);
-      })
-      .on('error', function (err) {
-        callback(err);
-      });
+    pushoverAPI.cancel(receipt, callback);
   };
 
   if (pushoverAPI) {
@@ -122,12 +114,9 @@ function setupPushover (env) {
   var announcementKeys = keysByType('announcementKey', userKeys || alarmKeys);
 
   if (apiToken && (userKeys.length > 0 || alarmKeys.length > 0 || announcementKeys.length > 0)) {
-    var Pushover = require('pushover-notifications');
+    var Pushover = require('../server/pushover-client');
     var pushoverAPI = new Pushover({
-      token: apiToken,
-      onerror: function(error) {
-        console.error('Pushover error', error);
-      }
+      token: apiToken
     });
 
     pushoverAPI.apiToken = apiToken;

--- a/lib/server/pushover-client.js
+++ b/lib/server/pushover-client.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const https = require('node:https');
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const REQUEST_TIMEOUT_MS = 10000;
+
+function failure(code, message, statusCode) {
+  const error = new Error(message);
+  error.code = code;
+  if (statusCode) error.statusCode = statusCode;
+  return error;
+}
+
+// Nightscout needs only messages and receipt cancellation, not a general SDK.
+// Keep the origin fixed and never retry a POST whose delivery is uncertain.
+class PushoverClient {
+  constructor({token}) {
+    this.token = token;
+  }
+
+  send(message, callback) {
+    this.post('/1/messages.json', message, callback);
+  }
+
+  cancel(receipt, callback) {
+    callback = typeof callback === 'function' ? callback : () => {};
+    if (typeof receipt !== 'string' || !receipt) {
+      queueMicrotask(() => callback(failure('EPUSHOVER_INPUT', 'Invalid Pushover receipt')));
+      return;
+    }
+    let encoded;
+    try { encoded = encodeURIComponent(receipt); } catch {
+      queueMicrotask(() => callback(failure('EPUSHOVER_INPUT', 'Invalid Pushover receipt')));
+      return;
+    }
+    this.post('/1/receipts/' + encoded + '/cancel.json', {}, (error, text, response) => callback(error, response));
+  }
+
+  post(path, fields, callback) {
+    callback = typeof callback === 'function' ? callback : () => {};
+    const form = new URLSearchParams();
+    for (const [key, value] of Object.entries({...fields, token: this.token})) {
+      if (value !== undefined && value !== null) form.set(key, String(value));
+    }
+    const body = form.toString();
+    let request, timer, finished = false;
+    function finish(error, text, response) {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      callback(error, text, response);
+    }
+    function abort(error) {
+      // Destroy before calling application code; an error event may follow.
+      if (request) request.destroy();
+      finish(error);
+    }
+    try {
+      request = https.request({hostname: 'api.pushover.net', port: 443, method: 'POST', path,
+        rejectUnauthorized: true,
+        headers: {'Content-Type': 'application/x-www-form-urlencoded', 'Content-Length': Buffer.byteLength(body)}
+      }, response => {
+        const chunks = [];
+        let bytes = 0;
+        response.on('data', chunk => {
+          if (finished) return;
+          bytes += chunk.length;
+          if (bytes > MAX_RESPONSE_BYTES) {
+            abort(failure('EPUSHOVER_SIZE', 'Pushover response exceeded its size limit'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        response.on('error', () => abort(failure('EPUSHOVER_TRANSPORT', 'Pushover response failed')));
+        response.on('aborted', () => abort(failure('EPUSHOVER_TRANSPORT', 'Pushover response was interrupted')));
+        response.on('end', () => {
+          if (finished) return;
+          const status = response.statusCode;
+          if (status < 200 || status >= 300) {
+            finish(failure('EPUSHOVER_HTTP', 'Pushover returned HTTP ' + status, status));
+            return;
+          }
+          const text = Buffer.concat(chunks).toString('utf8');
+          let result;
+          try { result = JSON.parse(text); } catch {
+            finish(failure('EPUSHOVER_JSON', 'Pushover returned invalid JSON'));
+            return;
+          }
+          if (!result || result.status !== 1) {
+            finish(failure('EPUSHOVER_API', 'Pushover rejected the request'));
+            return;
+          }
+          // Preserve the JSON-text contract consumed by pushnotify.
+          finish(null, text, response);
+        });
+      });
+      request.on('error', () => finish(failure('EPUSHOVER_TRANSPORT', 'Pushover request failed')));
+      timer = setTimeout(() => abort(failure('EPUSHOVER_TIMEOUT', 'Pushover request timed out')), REQUEST_TIMEOUT_MS);
+      request.end(body);
+    } catch {
+      if (request) request.destroy();
+      queueMicrotask(() => finish(failure('EPUSHOVER_TRANSPORT', 'Pushover request failed')));
+    }
+  }
+}
+
+module.exports = PushoverClient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "node-cache": "^4.2.1",
         "process": "^0.11.10",
         "proxy-addr": "^2.0.7",
-        "pushover-notifications": "^1.2.2",
         "qs": "6.16.0",
         "sanitize-html": "2.17.7",
         "semver": "^7.8.5",
@@ -8451,12 +8450,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pushover-notifications": {
-      "version": "1.2.3",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/qified": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "node-cache": "^4.2.1",
     "process": "^0.11.10",
     "proxy-addr": "^2.0.7",
-    "pushover-notifications": "^1.2.2",
     "qs": "6.16.0",
     "sanitize-html": "2.17.7",
     "semver": "^7.8.5",

--- a/tests/pushover-lifecycle.test.js
+++ b/tests/pushover-lifecycle.test.js
@@ -5,15 +5,13 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 const {createRequire} = require('module');
-const {EventEmitter} = require('events');
 const levels = require('../lib/levels');
 
-function loadPushover(loadProvider, transport) {
+function loadPushover(loadProvider) {
   const filename = path.resolve(__dirname, '../lib/plugins/pushover.js');
   const localRequire = createRequire(filename);
   const sandbox = {module: {exports: {}}, console: {info() {}, error() {}}, require(name) {
-    if (name === 'pushover-notifications') return loadProvider();
-    if (name === 'https' && transport) return transport;
+    if (name === '../server/pushover-client') return loadProvider();
     return localRequire(name);
   }};
   vm.runInNewContext(fs.readFileSync(filename, 'utf8'), sandbox, {filename});
@@ -95,18 +93,14 @@ describe('Pushover lazy loading and transport lifecycle', function () {
   for (const failed of [false, true]) {
     it('preserves receipt cancellation ' + (failed ? 'errors' : 'success') + ' over repeated calls', function () {
       const failure = new Error('fixture cancellation error');
-      let requests = 0, resumed = 0;
-      const transport = {get(url, callback) {
-        requests++;
-        assert.strictEqual(url, 'https://api.pushover.net/1/receipts/fixture-receipt/cancel.json?token=fixture-token');
-        const request = new EventEmitter();
-        process.nextTick(() => {
-          if (failed) request.emit('error', failure);
-          else callback({statusCode: 200, resume() { resumed++; }});
-        });
-        return request;
-      }};
-      const pushover = loadPushover(() => function Provider() {}, transport)(configuration({apiToken: 'fixture-token', userKey: 'user'}), {levels});
+      let requests = 0;
+      const pushover = loadPushover(() => function Provider() {
+        this.cancel = (receipt, callback) => {
+          requests++;
+          assert.strictEqual(receipt, 'fixture-receipt');
+          process.nextTick(() => callback(failed ? failure : null, {statusCode: 200}));
+        };
+      })(configuration({apiToken: 'fixture-token', userKey: 'user'}), {levels});
       return (async () => {
         for (let cycle = 1; cycle <= 2; cycle++) {
           await new Promise(resolve => pushover.cancelWithReceipt('fixture-receipt', (error, response) => {
@@ -115,7 +109,6 @@ describe('Pushover lazy loading and transport lifecycle', function () {
             resolve();
           }));
           assert.strictEqual(requests, cycle);
-          assert.strictEqual(resumed, failed ? 0 : cycle);
         }
       })();
     });

--- a/tests/pushover-transport.test.js
+++ b/tests/pushover-transport.test.js
@@ -32,7 +32,7 @@ describe('Native Pushover HTTPS transport', function () {
     server.on('connection', socket => { sockets.add(socket); socket.on('close', () => sockets.delete(socket)); });
     await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
     const sandbox = {module: {exports: {}}, URLSearchParams, Buffer, queueMicrotask, clearTimeout,
-      setTimeout(fn, ms) { return setTimeout(fn, fastTimeout ? 80 : ms); },
+      setTimeout(fn, ms) { return setTimeout(fn, fastTimeout ? 250 : ms); },
       require(name) {
         assert.equal(name, 'node:https');
         return {request(options, callback) {

--- a/tests/pushover-transport.test.js
+++ b/tests/pushover-transport.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const https = require('node:https');
+const vm = require('node:vm');
+const {execFile} = require('node:child_process');
+const {promisify} = require('node:util');
+const {setTimeout: delay} = require('node:timers/promises');
+
+describe('Native Pushover HTTPS transport', function () {
+  this.timeout(20000);
+  let directory, server, Client, cert, sockets, received, handler;
+  let trust = true, fastTimeout = false;
+  const token = 'owned-token-never-log';
+
+  before(async function () {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'nightscout-pushover-tls-'));
+    await promisify(execFile)('openssl', ['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-sha256',
+      '-keyout', path.join(directory, 'key.pem'), '-out', path.join(directory, 'cert.pem'),
+      '-days', '1', '-subj', '/CN=127.0.0.1', '-addext', 'subjectAltName=IP:127.0.0.1'], {timeout: 10000});
+    cert = await fs.readFile(path.join(directory, 'cert.pem'));
+    sockets = new Set(); received = [];
+    server = https.createServer({cert, key: await fs.readFile(path.join(directory, 'key.pem'))}, (req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', () => { received.push({method: req.method, url: req.url, headers: req.headers, body}); handler(req, res); });
+    });
+    server.on('connection', socket => { sockets.add(socket); socket.on('close', () => sockets.delete(socket)); });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const sandbox = {module: {exports: {}}, URLSearchParams, Buffer, queueMicrotask, clearTimeout,
+      setTimeout(fn, ms) { return setTimeout(fn, fastTimeout ? 80 : ms); },
+      require(name) {
+        assert.equal(name, 'node:https');
+        return {request(options, callback) {
+          assert.equal(options.hostname, 'api.pushover.net');
+          assert.equal(options.port, 443);
+          assert.equal(options.rejectUnauthorized, true);
+          assert.equal(options.method, 'POST');
+          // Redirect only inside the fixture and keep certificate verification.
+          return https.request({...options, hostname: '127.0.0.1', port: server.address().port,
+            ca: trust ? cert : undefined, agent: false}, callback);
+        }};
+      }
+    };
+    vm.runInNewContext(await fs.readFile(path.join(__dirname, '../lib/server/pushover-client.js'), 'utf8'), sandbox);
+    Client = sandbox.module.exports;
+  });
+
+  after(async function () {
+    for (const socket of sockets || []) socket.destroy();
+    if (server) await new Promise(resolve => server.close(resolve));
+    if (directory) await fs.rm(directory, {recursive: true, force: true});
+  });
+
+  async function invoke(client, method, value) {
+    let calls = 0;
+    const result = await new Promise(resolve => client[method](value, (error, result) => { calls++; resolve({error, result}); }));
+    const deadline = Date.now() + 2000;
+    while (sockets.size && Date.now() < deadline) await delay(10);
+    assert.equal(sockets.size, 0, 'Owned request socket must be released');
+    await delay(10);
+    assert.equal(calls, 1, 'Completion must be called exactly once');
+    if (result.error) assert.ok(!String(result.error.stack).includes(token), 'Do not expose credentials through errors');
+    return result;
+  }
+
+  it('encodes independent messages and cancels receipts with a body token over two cycles', async function () {
+    handler = (req, res) => { res.writeHead(200); res.end('{"status":1,"receipt":"owned-receipt"}'); };
+    const client = new Client({token});
+    for (let cycle = 0; cycle < 2; cycle++) {
+      const message = {user: 'user a&b', title: 'BG < 70 & 🍕', message: 'one\ntwo + three', priority: 2,
+        retry: 120, expire: 900, callback: 'https://nightscout.test/callback?a=b&c=d', timestamp: 1700000000, sound: 'gamelan'};
+      const before = {...message};
+      const results = await Promise.all([invoke(client, 'send', message), invoke(client, 'send', {...message, user: 'second-user'})]);
+      for (const result of results) { assert.ifError(result.error); assert.equal(result.result, '{"status":1,"receipt":"owned-receipt"}'); }
+      assert.deepEqual(message, before, 'Do not mutate the shared message object');
+      const requests = received.slice(-2);
+      assert.deepEqual(requests.map(r => new URLSearchParams(r.body).get('user')).sort(), ['second-user', 'user a&b']);
+      for (const request of requests) {
+        assert.equal(request.url, '/1/messages.json');
+        assert.equal(request.headers['content-type'], 'application/x-www-form-urlencoded');
+        assert.equal(Number(request.headers['content-length']), Buffer.byteLength(request.body));
+        const form = new URLSearchParams(request.body);
+        assert.equal(form.get('token'), token);
+        for (const [key, value] of Object.entries(message)) if (key !== 'user') assert.equal(form.get(key), String(value));
+      }
+      const cancelled = await invoke(client, 'cancel', 'receipt/with?reserved');
+      assert.ifError(cancelled.error);
+      assert.equal(cancelled.result.statusCode, 200);
+      assert.equal(received.at(-1).url, '/1/receipts/receipt%2Fwith%3Freserved/cancel.json');
+      assert.equal(received.at(-1).body, new URLSearchParams({token}).toString());
+      assert.ok(!received.at(-1).url.includes(token));
+    }
+  });
+
+  it('preserves actual plugin routing, alarm parameters and Unix timestamps', async function () {
+    const levels = require('../lib/levels');
+    const sandbox = {module: {exports: {}}, console: {info() {}, error() {}}, require(name) {
+      if (name === '../server/pushover-client') return Client;
+      assert.equal(name, '../times');
+      return require('../lib/times');
+    }};
+    vm.runInNewContext(await fs.readFile(path.join(__dirname, '../lib/plugins/pushover.js'), 'utf8'), sandbox);
+    const plugin = sandbox.module.exports({settings: {baseURL: 'https://nightscout.test'}, extendedSettings: {pushover: {
+      apiToken: token, userKey: 'normal-a normal-b', alarmKey: 'alarm', announcementKey: 'announcement'
+    }}}, {levels});
+    handler = (req, res) => res.end('{"status":1,"receipt":"owned-receipt"}');
+    for (let cycle = 0; cycle < 2; cycle++) {
+      for (const [notify, recipients] of [
+        [{level: levels.INFO}, ['normal-a', 'normal-b']],
+        [{level: levels.URGENT}, ['alarm']],
+        [{level: levels.INFO, isAnnouncement: true}, ['announcement']]
+      ]) {
+        const count = received.length;
+        let completed = 0;
+        await new Promise((resolve, reject) => plugin.send({...notify, title: 'Fixture', message: 'Fixture message'}, (error, text) => {
+          if (error) return reject(error);
+          assert.equal(JSON.parse(text).receipt, 'owned-receipt');
+          if (++completed === recipients.length) resolve();
+        }));
+        const requests = received.slice(count).map(request => new URLSearchParams(request.body));
+        assert.deepEqual(requests.map(form => form.get('user')).sort(), recipients.slice().sort());
+        for (const form of requests) {
+          assert.equal(form.get('sound'), 'gamelan');
+          assert.equal(form.get('expire'), '900');
+          const timestamp = Number(form.get('timestamp'));
+          assert.ok(Number.isInteger(timestamp) && Math.abs(Date.now() / 1000 - timestamp) < 10);
+          if (notify.level === levels.URGENT) {
+            assert.equal(form.get('priority'), '2');
+            assert.equal(form.get('retry'), '120');
+            assert.equal(form.get('callback'), 'https://nightscout.test/api/v1/notifications/pushovercallback');
+          } else assert.equal(form.get('priority'), '0');
+        }
+      }
+    }
+  });
+
+  const failures = [
+    ['HTTP rejection', (req, res) => { res.writeHead(400); res.end('{"status":0}'); }, 'EPUSHOVER_HTTP'],
+    ['rate limit', (req, res) => { res.writeHead(429); res.end('{"status":0}'); }, 'EPUSHOVER_HTTP'],
+    ['server failure', (req, res) => { res.writeHead(503); res.end('{"status":0}'); }, 'EPUSHOVER_HTTP'],
+    ['redirect', (req, res) => { res.writeHead(302, {location: 'https://example.invalid'}); res.end(); }, 'EPUSHOVER_HTTP'],
+    ['API rejection', (req, res) => res.end('{"status":0,"errors":["' + token + '"]}'), 'EPUSHOVER_API'],
+    ['invalid JSON', (req, res) => res.end('not-json ' + token), 'EPUSHOVER_JSON'],
+    ['oversized response', (req, res) => res.end('x'.repeat(65537)), 'EPUSHOVER_SIZE'],
+    ['truncated response', (req, res) => { res.writeHead(200, {'content-length': 100}); res.write('{'); res.flushHeaders(); setImmediate(() => res.destroy()); }, 'EPUSHOVER_TRANSPORT'],
+    ['timeout', () => {}, 'EPUSHOVER_TIMEOUT']
+  ];
+  for (const [name, respond, code] of failures) it('reports ' + name + ' once without retrying', async function () {
+    handler = respond; fastTimeout = name === 'timeout';
+    try {
+      const client = new Client({token});
+      for (const method of ['send', 'cancel']) {
+        const count = received.length;
+        const result = await invoke(client, method, method === 'send' ? {user: 'fixture', message: 'fixture'} : 'fixture');
+        assert.equal(result.error.code, code);
+        assert.equal(received.length, count + 1);
+      }
+    } finally { fastTimeout = false; }
+  });
+
+  it('rejects an untrusted certificate without sending credentials', async function () {
+    trust = false;
+    try {
+      for (let cycle = 0; cycle < 2; cycle++) {
+        const count = received.length;
+        const result = await invoke(new Client({token}), 'send', {user: 'fixture', message: 'fixture'});
+        assert.equal(result.error.code, 'EPUSHOVER_TRANSPORT');
+        assert.equal(received.length, count);
+      }
+    } finally { trust = true; }
+  });
+});

--- a/tools/audits/notification-provider-probe.cjs
+++ b/tools/audits/notification-provider-probe.cjs
@@ -13,7 +13,7 @@ let ctx;
     fixtureEnv;
   Module._load = function (name, ...args) {
     const value = originalLoad.call(this, name, ...args);
-    if (name === "pushover-notifications") {
+    if ((name === "pushover-notifications" || name === "../server/pushover-client")) {
       if (!wrappers.has(value)) {
         wrappers.set(value, function (options) {
           const provider = new value(options);
@@ -153,7 +153,7 @@ let ctx;
     providerSends: sends,
     pushoverSends: pushes,
     pushoverLoaded: Object.keys(require.cache).some((p) =>
-      p.includes("/pushover-notifications/"),
+      p.includes("/pushover-notifications/") || p.endsWith("/lib/server/pushover-client.js"),
     ),
     apnLoaded: Object.keys(require.cache).some((p) =>
       p.includes("/@parse/node-apn/"),


### PR DESCRIPTION
Remove pushover-notifications and replace the used message/cancellation API surface with bounded native HTTPS requests. No replacement dependency is added. Preserve recipient routing, emergency parameters, raw JSON receipt results and notification-cache behavior.

Correct the documented cancellation method to POST with body credentials, send Unix-second timestamps, and report HTTP/API/JSON failures through the error callback. The previous SDK could log a rejected message but still report success; cancellation treated HTTP errors as success. Requests have a ten-second deadline, a 64 KiB response limit, TLS verification and no automatic POST retry or redirect following.

Owned HTTPS tests exercise the actual plugin and transport, Unicode/form encoding, concurrent recipients, POST cancellation, rejection/error/timeout paths, exactly-once callbacks and cleanup. No real Pushover request is sent. Existing notification lifecycle/cache tests remain; the measurement probe is updated for both old/new clients.

Validation: clean Node 22 install/production build; full backend suites pass on Node 22 (2,074 tests) and Node 24 (2,075 after adding plugin-to-transport coverage), with one existing pending test; 36 focused cases pass on Node 24 and the final transport cases pass on Node 22; lint has zero errors and 16 existing warnings; npm audit reports zero known advisories. All six browser bundles are byte-for-byte unchanged. Hosted CI/CodeQL and merge-tree verification are required before merge.

Removed package files total 26,270 bytes; net runtime source adds 3,695 bytes, for 22,575 bytes less package-plus-runtime source. No measured RAM or Docker-image saving is claimed. Documentation records intentional protocol/error-handling corrections; no configuration migration is needed.

Targets chore/nightscout-modernization for integration through #8605. M09 remains open.
