### PR TITLE
Modernization: refresh webpack CLI and analyzer

### DIFF
--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -126,6 +126,12 @@ TLS/HTTP2 tests cover actual signed Loop requests, retries, failure handling and
 session/timer cleanup. The published package files grow slightly; no RAM-saving
 claim is made. Remaining M09 reviews stay open.
 
+The [native Pushover transport](../test-specs/pushover-native-transport.md) removes
+pushover-notifications and preserves message/receipt contracts using Node HTTPS.
+Owned TLS tests cover encoding, cancellation, failure classification, deadlines
+and cleanup. Package plus runtime source decreases by 22,575 bytes; no measured
+RAM saving is claimed. This does not complete the remaining M09 reviews.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -132,6 +132,12 @@ Owned TLS tests cover encoding, cancellation, failure classification, deadlines
 and cleanup. Package plus runtime source decreases by 22,575 bytes; no measured
 RAM saving is claimed. This does not complete the remaining M09 reviews.
 
+The [CLI/analyzer review](../test-specs/webpack-cli-analyzer.md) upgrades the
+build commands to CLI 7.2.3 and analyzer 5.3.2, preserves resource-limit tests
+and adds real command/report regression coverage. Production lock entries and
+application bundles are unchanged; development package bytes increase despite
+six fewer paths. Remaining dependency and override reviews keep M09 open.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/test-specs/pushover-native-transport.md
+++ b/docs/test-specs/pushover-native-transport.md
@@ -1,0 +1,70 @@
+# Native Pushover transport (M09)
+
+Remove `pushover-notifications` 1.2.3 and replace the application's used subset
+with `lib/server/pushover-client.js`, using Node HTTPS and URLSearchParams.
+Nightscout uses message submission and receipt cancellation; it does not use the
+SDK's attachments, custom proxy, sound enumeration or scheduled sound refresh.
+No replacement dependency or public endpoint override is added.
+
+The [message API](https://pushover.net/api) supports URL-encoded HTTPS POSTs,
+and [receipt cancellation](https://pushover.net/api/receipts) specifies POST.
+TLS verification stays enabled and the production origin is fixed. The helper
+has a ten-second total request deadline and a 64 KiB response limit. It does
+not follow redirects or automatically retry a POST: a timeout can occur after
+a message was accepted, so retrying could duplicate a notification.
+
+## Preserved and corrected behavior
+
+- Existing user/group/alarm/announcement routing, disabled-key fallback, sound,
+  priority, retry, 15-minute expiration and callback URLs remain unchanged.
+  Each recipient's form is encoded synchronously without mutating the shared
+  message. Normal priority is explicitly sent as 0 rather than omitted; both
+  mean normal priority in the API.
+- Successful send callbacks retain JSON text, which `pushnotify` parses to
+  store receipts and extend suppression TTLs. Cancellation retains the response
+  object/statusCode callback shape after consuming its response.
+- Cancellation now uses the documented POST method with the token in the body,
+  rather than GET with a token in the URL. The receipt path segment is encoded.
+- HTTP failures, API status 0, malformed JSON, interrupted/oversized responses,
+  TLS failures and timeouts invoke the error callback once. The previous SDK
+  could log an API error but still invoke the send callback as a success;
+  cancellation previously treated an HTTP error response as success. Failures
+  now preserve existing retryable receipt-cache behavior.
+- Message timestamps now use Unix seconds from the server clock. The previous
+  Date object serialized to an empty form value. This makes the existing
+  creation-time intent explicit; operators should keep the server clock correct.
+- Newly created errors contain stable categories and HTTP status where useful,
+  not raw response bodies, tokens or request objects. Existing application
+  logging policy is otherwise unchanged.
+
+No configuration migration is required. This intentionally corrects protocol
+and failure handling; it is not a claim of byte-identical wire requests.
+
+## Verification
+
+`tests/pushover-transport.test.js` uses generated certificates and an owned HTTPS
+fixture with TLS verification enabled. The fixture redirects requests only in
+the test loader; no real Pushover account or device is contacted. It checks:
+
+- Unicode/form encoding, independent simultaneous recipients and unchanged
+  input objects; actual plugin recipient routing, alarm fields and timestamps.
+- Raw JSON receipt results and POST cancellation with body credentials.
+- HTTP 400/429/503, redirects, API failure, malformed/oversized/truncated responses,
+  deadlines and untrusted certificates, with exactly one completion and no retry.
+- Repeated send/cancel calls and owned request socket cleanup. The fixture uses
+  a non-pooled agent; production retains Node's normal shared HTTPS agent policy.
+
+Existing plugin/lifecycle and notification-cache tests retain recipient selection,
+suppression, acknowledgement, cancellation and teardown coverage. The provider
+measurement tool recognizes both the old SDK and new native client, preserving
+its interception of all outbound sends. New checks use existing CI environments.
+These tests do not establish live vendor/device delivery or account validity.
+
+## Measured footprint
+
+The removed SDK's regular files total 26,270 bytes. The net runtime source
+increase is 3,695 bytes, so package plus runtime source decreases by 22,575 bytes
+(excluding test/documentation files and filesystem allocation). One production
+package path is removed. All six generated browser JavaScript bundles are
+byte-for-byte unchanged from the APNs candidate. No measured server RAM,
+Docker-image or browser-transfer saving is claimed.

--- a/docs/test-specs/webpack-cli-analyzer.md
+++ b/docs/test-specs/webpack-cli-analyzer.md
@@ -1,0 +1,51 @@
+# Webpack CLI and bundle analyzer maintenance (M09 partial)
+
+Upgrade webpack-cli 4.10.0 to 7.2.3 and webpack-bundle-analyzer 4.10.2 to
+5.3.2, the registry releases reviewed on 2026-09-06. Both require Node >=20.9;
+Nightscout's supported Node 22/24 floors satisfy this. Keep webpack 5.110.3.
+These remain development dependencies, excluded from the pruned runtime.
+
+Review sources: [CLI releases](https://github.com/webpack/webpack-cli/releases)
+and [analyzer changelog](https://github.com/webpack/webpack-bundle-analyzer/blob/main/CHANGELOG.md).
+CLI 5/6/7 retire old commands and flags, change explicit entry handling, and
+use dynamic import before interpret to load configuration. Nightscout does not
+use the removed flags, CLI programmatic API or webpack-dev-server. Its CommonJS
+configuration and production/development/profile/JSON commands remain supported.
+Analyzer 5 adds compression/display options and changes its WebSocket consumer
+from ws 7 to 8. The retained resource-limit tests now use Receiver's options
+object, preserving the same limits and adversarial frames. Resolve the lockfile
+with legacy peer mode disabled: CLI needs optional js-yaml 4/5 while NYC retains
+its compatible nested js-yaml 3. Versions and copy counts are unchanged by this
+hoisting correction. A real YAML-config CLI build protects the resolution.
+
+Regression coverage:
+
+- Run the installed CLI in both build modes with a disposable CommonJS fixture;
+  require parseable profiling JSON, expected module/asset and nonempty bundle.
+- Feed those actual stats and bundles through the installed analyzer CLI;
+  require JSON reports with parsed/compressed sizes and standalone HTML reports.
+- Require invalid configuration to exit unsuccessfully with the invalid option
+  identified. Fixtures never replace application assets or open a browser.
+- Preserve fragment/chunk bounds, consecutive-message counter reset and real
+  localhost WebSocket Unicode/fragmented-binary exchanges over two connections.
+- Run the real application production/development builds and existing backend,
+  browser, HMR and resource-budget checks before integrating the upgrade.
+
+Local validation: clean Node 22 install/build with legacy peer mode disabled,
+valid full npm dependency tree, 286 dependency cases on Node 22 and eight
+focused CLI/WebSocket cases on Node 24. The actual Node 24 development build
+produces reports for all six bundles; the standalone HTML renders in Chromium
+without JavaScript errors. Full/production audits report zero known advisories.
+Full current-head hosted CI remains required before merge.
+
+Matched clean Node 22 installations have 838 -> 832 lockfile package paths.
+Summing regular package-owned files (excluding nested node_modules and symlinks)
+gives 201,877,508 -> 202,324,614 bytes: **447,106 more development-tree bytes**,
+despite fewer paths. All 276 production lock entries and all six production
+application JavaScript bundles are unchanged. No RAM, image-size or build-time
+saving is claimed.
+
+No deployment or Nightscout user-interface change is intended. The optional
+analyzer's developer report UI gains upstream display/compression features;
+it is not served by Nightscout. Restore both manifest/lockfile and Receiver
+constructor tests together to roll back. This does not complete M09.

--- a/docs/test-specs/webpack-cli-analyzer.md
+++ b/docs/test-specs/webpack-cli-analyzer.md
@@ -36,7 +36,9 @@ valid full npm dependency tree, 286 dependency cases on Node 22 and eight
 focused CLI/WebSocket cases on Node 24. The actual Node 24 development build
 produces reports for all six bundles; the standalone HTML renders in Chromium
 without JavaScript errors. Full/production audits report zero known advisories.
-Full current-head hosted CI remains required before merge.
+The final Node 24 backend run passes 2,079 tests with one existing pending case;
+the earlier Node 22 run passed 2,078 before the added YAML case and peer-layout
+correction. Hosted Node 22/24 checks remain required on the final head before merge.
 
 Matched clean Node 22 installations have 838 -> 832 lockfile package paths.
 Summing regular package-owned files (excluding nested node_modules and symlinks)

--- a/lib/plugins/pushover.js
+++ b/lib/plugins/pushover.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var https = require('https');
 var times = require('../times');
 
 function init (env, ctx) {
@@ -34,7 +33,7 @@ function init (env, ctx) {
         , title: notify.title
         , message: notify.message
         , sound: notify.pushoverSound || 'gamelan'
-        , timestamp: new Date()
+        , timestamp: Math.floor(Date.now() / 1000)
         //USE PUSHOVER_EMERGENCY for WARN and URGENT so we get the acks
         , priority: notify.level >= ctx.levels.WARN ? pushover.PRIORITY_EMERGENCY : pushover.PRIORITY_NORMAL
       };
@@ -75,14 +74,7 @@ function init (env, ctx) {
   };
 
   pushover.cancelWithReceipt = function cancelWithReceipt (receipt, callback) {
-    https
-      .get('https://api.pushover.net/1/receipts/' + receipt + '/cancel.json?token=' + pushoverAPI.apiToken, function (response) {
-        response.resume();
-        callback(null, response);
-      })
-      .on('error', function (err) {
-        callback(err);
-      });
+    pushoverAPI.cancel(receipt, callback);
   };
 
   if (pushoverAPI) {
@@ -122,12 +114,9 @@ function setupPushover (env) {
   var announcementKeys = keysByType('announcementKey', userKeys || alarmKeys);
 
   if (apiToken && (userKeys.length > 0 || alarmKeys.length > 0 || announcementKeys.length > 0)) {
-    var Pushover = require('pushover-notifications');
+    var Pushover = require('../server/pushover-client');
     var pushoverAPI = new Pushover({
-      token: apiToken,
-      onerror: function(error) {
-        console.error('Pushover error', error);
-      }
+      token: apiToken
     });
 
     pushoverAPI.apiToken = apiToken;

--- a/lib/server/pushover-client.js
+++ b/lib/server/pushover-client.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const https = require('node:https');
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const REQUEST_TIMEOUT_MS = 10000;
+
+function failure(code, message, statusCode) {
+  const error = new Error(message);
+  error.code = code;
+  if (statusCode) error.statusCode = statusCode;
+  return error;
+}
+
+// Nightscout needs only messages and receipt cancellation, not a general SDK.
+// Keep the origin fixed and never retry a POST whose delivery is uncertain.
+class PushoverClient {
+  constructor({token}) {
+    this.token = token;
+  }
+
+  send(message, callback) {
+    this.post('/1/messages.json', message, callback);
+  }
+
+  cancel(receipt, callback) {
+    callback = typeof callback === 'function' ? callback : () => {};
+    if (typeof receipt !== 'string' || !receipt) {
+      queueMicrotask(() => callback(failure('EPUSHOVER_INPUT', 'Invalid Pushover receipt')));
+      return;
+    }
+    let encoded;
+    try { encoded = encodeURIComponent(receipt); } catch {
+      queueMicrotask(() => callback(failure('EPUSHOVER_INPUT', 'Invalid Pushover receipt')));
+      return;
+    }
+    this.post('/1/receipts/' + encoded + '/cancel.json', {}, (error, text, response) => callback(error, response));
+  }
+
+  post(path, fields, callback) {
+    callback = typeof callback === 'function' ? callback : () => {};
+    const form = new URLSearchParams();
+    for (const [key, value] of Object.entries({...fields, token: this.token})) {
+      if (value !== undefined && value !== null) form.set(key, String(value));
+    }
+    const body = form.toString();
+    let request, timer, finished = false;
+    function finish(error, text, response) {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      callback(error, text, response);
+    }
+    function abort(error) {
+      // Destroy before calling application code; an error event may follow.
+      if (request) request.destroy();
+      finish(error);
+    }
+    try {
+      request = https.request({hostname: 'api.pushover.net', port: 443, method: 'POST', path,
+        rejectUnauthorized: true,
+        headers: {'Content-Type': 'application/x-www-form-urlencoded', 'Content-Length': Buffer.byteLength(body)}
+      }, response => {
+        const chunks = [];
+        let bytes = 0;
+        response.on('data', chunk => {
+          if (finished) return;
+          bytes += chunk.length;
+          if (bytes > MAX_RESPONSE_BYTES) {
+            abort(failure('EPUSHOVER_SIZE', 'Pushover response exceeded its size limit'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        response.on('error', () => abort(failure('EPUSHOVER_TRANSPORT', 'Pushover response failed')));
+        response.on('aborted', () => abort(failure('EPUSHOVER_TRANSPORT', 'Pushover response was interrupted')));
+        response.on('end', () => {
+          if (finished) return;
+          const status = response.statusCode;
+          if (status < 200 || status >= 300) {
+            finish(failure('EPUSHOVER_HTTP', 'Pushover returned HTTP ' + status, status));
+            return;
+          }
+          const text = Buffer.concat(chunks).toString('utf8');
+          let result;
+          try { result = JSON.parse(text); } catch {
+            finish(failure('EPUSHOVER_JSON', 'Pushover returned invalid JSON'));
+            return;
+          }
+          if (!result || result.status !== 1) {
+            finish(failure('EPUSHOVER_API', 'Pushover rejected the request'));
+            return;
+          }
+          // Preserve the JSON-text contract consumed by pushnotify.
+          finish(null, text, response);
+        });
+      });
+      request.on('error', () => finish(failure('EPUSHOVER_TRANSPORT', 'Pushover request failed')));
+      timer = setTimeout(() => abort(failure('EPUSHOVER_TIMEOUT', 'Pushover request timed out')), REQUEST_TIMEOUT_MS);
+      request.end(body);
+    } catch {
+      if (request) request.destroy();
+      queueMicrotask(() => finish(failure('EPUSHOVER_TRANSPORT', 'Pushover request failed')));
+    }
+  }
+}
+
+module.exports = PushoverClient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "node-cache": "^4.2.1",
         "process": "^0.11.10",
         "proxy-addr": "^2.0.7",
-        "pushover-notifications": "^1.2.2",
         "qs": "6.16.0",
         "sanitize-html": "2.17.7",
         "semver": "^7.8.5",
@@ -8451,12 +8450,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pushover-notifications": {
-      "version": "1.2.3",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/qified": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,8 +67,8 @@
         "socket.io-client": "^4.8.3",
         "supertest": "^7.2.2",
         "webpack": "^5.110.3",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-cli": "^4.10.0",
+        "webpack-bundle-analyzer": "5.3.2",
+        "webpack-cli": "7.2.3",
         "webpack-dev-middleware": "^8.3.0",
         "xml2js": "^0.5.0",
         "xss": "^1.0.15"
@@ -2372,11 +2372,13 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.5.7",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2629,6 +2631,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "dev": true,
@@ -2639,6 +2651,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -3264,6 +3290,8 @@
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
     },
@@ -3563,39 +3591,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x",
-        "webpack-cli": "4.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "envinfo": "^7.7.3"
-      },
-      "peerDependencies": {
-        "webpack-cli": "4.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "webpack-cli": "4.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "dev": true,
@@ -3809,12 +3804,11 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -4246,6 +4240,8 @@
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4259,6 +4255,8 @@
     },
     "node_modules/clone-deep/node_modules/is-plain-object": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4280,11 +4278,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4893,11 +4886,6 @@
       "version": "1.11.20",
       "license": "MIT"
     },
-    "node_modules/debounce": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "license": "MIT",
@@ -5078,11 +5066,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "dev": true,
@@ -5234,6 +5217,8 @@
     },
     "node_modules/envinfo": {
       "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5466,6 +5451,8 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -5666,14 +5653,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
     },
     "node_modules/file-entry-cache": {
       "version": "11.1.5",
@@ -6075,20 +6054,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/gzip-size": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -6401,11 +6366,13 @@
       }
     },
     "node_modules/interpret": {
-      "version": "2.2.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/ip-address": {
@@ -6437,6 +6404,8 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6553,6 +6522,8 @@
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6991,14 +6962,23 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
-      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -7087,6 +7067,8 @@
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7463,11 +7445,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/mocha/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/mocha/node_modules/brace-expansion": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
@@ -7476,19 +7453,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
-      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -7612,6 +7576,8 @@
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8236,6 +8202,8 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8533,14 +8501,16 @@
       }
     },
     "node_modules/rechoir": {
-      "version": "0.7.1",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/regenerate": {
@@ -8646,6 +8616,8 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8898,6 +8870,8 @@
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9073,7 +9047,9 @@
       }
     },
     "node_modules/sirv": {
-      "version": "2.0.4",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9082,7 +9058,7 @@
         "totalist": "^3.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/smart-buffer": {
@@ -9280,6 +9256,8 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -9438,6 +9416,8 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9579,6 +9559,8 @@
     },
     "node_modules/totalist": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9902,96 +9884,102 @@
       }
     },
     "node_modules/webpack-bundle-analyzer": {
-      "version": "4.10.2",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-5.3.2.tgz",
+      "integrity": "sha512-IagCa/GrdxSz+ba9OMgK7UCfQp97HtXbgjXu7ObcqmRo9PTp0d+24rgY+mIFOx7JPQ9bo6FGsqZhA55rYRZrrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "0.5.7",
+        "@discoveryjs/json-ext": "^0.6.3",
         "acorn": "^8.0.4",
         "acorn-walk": "^8.0.0",
-        "commander": "^7.2.0",
-        "debounce": "^1.2.1",
-        "escape-string-regexp": "^4.0.0",
-        "gzip-size": "^6.0.0",
-        "html-escaper": "^2.0.2",
+        "commander": "^14.0.2",
+        "escape-string-regexp": "^5.0.0",
+        "html-escaper": "^3.0.3",
         "opener": "^1.5.2",
         "picocolors": "^1.0.0",
-        "sirv": "^2.0.3",
-        "ws": "^7.3.1"
+        "sirv": "^3.0.2",
+        "ws": "^8.19.0"
       },
       "bin": {
         "webpack-bundle-analyzer": "lib/bin/analyzer.js"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 20.9.0"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/commander": {
-      "version": "7.2.0",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">=20"
       }
     },
-    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
-      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+    "node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=12"
       },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webpack-cli": {
-      "version": "4.10.0",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.3.tgz",
+      "integrity": "sha512-vDFU7jrfCctnN7jJQWPl+V26B51GLp11prVZXg50oeonsgeBzSTJEWmXkjHsOjTgMjlPOQM8GWLh33X9RN/0ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.2.0",
-        "@webpack-cli/info": "^1.5.0",
-        "@webpack-cli/serve": "^1.7.0",
-        "colorette": "^2.0.14",
-        "commander": "^7.0.0",
-        "cross-spawn": "^7.0.3",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
-        "interpret": "^2.2.0",
-        "rechoir": "^0.7.0",
-        "webpack-merge": "^5.7.3"
+        "@discoveryjs/json-ext": "^1.1.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
+        "envinfo": "^7.21.0",
+        "import-local": "^3.2.0",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
+        "webpack-merge": "^6.0.1"
       },
       "bin": {
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x"
+        "js-yaml": "^4.0.0 || ^5.0.0",
+        "json5": "^2.2.3",
+        "toml": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "webpack": "^5.101.0",
+        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+        "webpack-dev-server": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
-        "@webpack-cli/generators": {
+        "js-yaml": {
           "optional": true
         },
-        "@webpack-cli/migrate": {
+        "json5": {
+          "optional": true
+        },
+        "toml": {
           "optional": true
         },
         "webpack-bundle-analyzer": {
@@ -10002,12 +9990,24 @@
         }
       }
     },
-    "node_modules/webpack-cli/node_modules/commander": {
-      "version": "7.2.0",
+    "node_modules/webpack-cli/node_modules/@discoveryjs/json-ext": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">=14.17.0"
+      }
+    },
+    "node_modules/webpack-cli/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/webpack-dev-middleware": {
@@ -10040,16 +10040,18 @@
       }
     },
     "node_modules/webpack-merge": {
-      "version": "5.10.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
+        "wildcard": "^2.0.1"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/webpack-sources": {
@@ -10096,6 +10098,8 @@
     },
     "node_modules/wildcard": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "node-cache": "^4.2.1",
     "process": "^0.11.10",
     "proxy-addr": "^2.0.7",
-    "pushover-notifications": "^1.2.2",
     "qs": "6.16.0",
     "sanitize-html": "2.17.7",
     "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -150,8 +150,8 @@
     "socket.io-client": "^4.8.3",
     "supertest": "^7.2.2",
     "webpack": "^5.110.3",
-    "webpack-bundle-analyzer": "^4.5.0",
-    "webpack-cli": "^4.10.0",
+    "webpack-bundle-analyzer": "5.3.2",
+    "webpack-cli": "7.2.3",
     "webpack-dev-middleware": "^8.3.0",
     "xml2js": "^0.5.0",
     "xss": "^1.0.15"

--- a/tests/dependency-webpack-tools.test.js
+++ b/tests/dependency-webpack-tools.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const {createRequire} = require('node:module');
+const path = require('node:path');
+const {execFileSync, spawnSync} = require('node:child_process');
+
+// Exercise the installed command-line consumers, without overwriting app assets.
+describe('Webpack command-line and analyzer compatibility', function () {
+  this.timeout(30000);
+  let directory;
+  const cli = require.resolve('webpack-cli/bin/cli.js');
+  const analyzer = require.resolve('webpack-bundle-analyzer/lib/bin/analyzer.js');
+  function run(script, args) {
+    return execFileSync(process.execPath, [script, ...args], {
+      cwd: directory, encoding: 'utf8', timeout: 20000, maxBuffer: 8 * 1024 * 1024
+    });
+  }
+  before(function () {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nightscout-webpack-tools-'));
+    fs.writeFileSync(path.join(directory, 'entry.js'), 'console.log("Nightscout fixture 💉");');
+    fs.writeFileSync(path.join(directory, 'webpack.config.cjs'),
+      'module.exports = {entry: "./entry.js", output: {filename: "fixture.js"}};');
+  });
+  after(function () { fs.rmSync(directory, {recursive: true, force: true}); });
+
+  for (const mode of ['production', 'development']) {
+    it('builds ' + mode + ' assets and emits parseable profiling stats and reports', function () {
+      const stats = run(cli, ['--mode', mode, '--config', 'webpack.config.cjs', '--profile', '--json']);
+      const parsed = JSON.parse(stats);
+      assert.strictEqual(parsed.errorsCount, 0);
+      assert(parsed.assets.some(asset => asset.name === 'fixture.js' && asset.size > 0));
+      assert(parsed.modules.some(module => module.name === './entry.js'));
+      const bundle = fs.readFileSync(path.join(directory, 'dist/fixture.js'), 'utf8');
+      assert(bundle.includes('Nightscout fixture'));
+      fs.writeFileSync(path.join(directory, 'stats.json'), stats);
+      run(analyzer, ['stats.json', 'dist', '--mode', 'json', '--report', 'report.json', '--no-open']);
+      const report = JSON.parse(fs.readFileSync(path.join(directory, 'report.json'), 'utf8'));
+      assert(report.some(asset => asset.label === 'fixture.js' && asset.parsedSize > 0 && asset.gzipSize > 0));
+      run(analyzer, ['stats.json', 'dist', '--mode', 'static', '--report', 'report.html', '--no-open']);
+      const html = fs.readFileSync(path.join(directory, 'report.html'), 'utf8');
+      assert(html.includes('fixture.js'));
+      assert(html.includes('<html'));
+    });
+  }
+  it('loads YAML configuration through the compatible optional parser', function () {
+    // CLI resolves optional parsers beside the config, so expose its actual
+    // installed consumer resolution to this otherwise isolated fixture.
+    const yamlPackage = createRequire(cli).resolve('js-yaml/package.json');
+    fs.mkdirSync(path.join(directory, 'node_modules'));
+    fs.symlinkSync(path.dirname(yamlPackage), path.join(directory, 'node_modules/js-yaml'), 'dir');
+    fs.writeFileSync(path.join(directory, 'webpack.config.yaml'),
+      'entry: ./entry.js\noutput:\n  filename: yaml-fixture.js\n');
+    const stats = JSON.parse(run(cli, ['--mode', 'production', '--config', 'webpack.config.yaml', '--json']));
+    assert.strictEqual(stats.errorsCount, 0);
+    assert(stats.assets.some(asset => asset.name === 'yaml-fixture.js' && asset.size > 0));
+  });
+  it('returns a failure for invalid configuration instead of producing a successful build', function () {
+    fs.writeFileSync(path.join(directory, 'invalid.cjs'), 'module.exports = {unknownNightscoutOption: true};');
+    const result = spawnSync(process.execPath, [cli, '--config', 'invalid.cjs'], {
+      cwd: directory, encoding: 'utf8', timeout: 20000
+    });
+    assert.ifError(result.error);
+    assert.notStrictEqual(result.status, 0);
+    assert(result.stderr.includes('unknownNightscoutOption'));
+  });
+});

--- a/tests/dependency-ws-analyzer.test.js
+++ b/tests/dependency-ws-analyzer.test.js
@@ -8,7 +8,7 @@ const WebSocket = analyzerRequire('ws');
 
 describe('Bundle analyzer WebSocket compatibility', function () {
   it('bounds retained message fragments', async function () {
-    const receiver = new WebSocket.Receiver('nodebuffer', {}, false, 0, 0, 4);
+    const receiver = new WebSocket.Receiver({binaryType: 'nodebuffer', maxFragments: 4});
     try {
       const error = once(receiver, 'error', {signal: AbortSignal.timeout(1000)});
       receiver.end(Buffer.from([2, 0, 0, 0, 0, 0, 0, 0, 128, 0]));
@@ -16,7 +16,7 @@ describe('Bundle analyzer WebSocket compatibility', function () {
     } finally { receiver.destroy(); }
   });
   it('resets the fragment count between consecutive valid messages', function () {
-    const receiver = new WebSocket.Receiver('nodebuffer', {}, false, 0, 0, 4);
+    const receiver = new WebSocket.Receiver({binaryType: 'nodebuffer', maxFragments: 4});
     const received = [];
     const errors = [];
     receiver.on('message', data => received.push(Array.from(data)));
@@ -29,7 +29,7 @@ describe('Bundle analyzer WebSocket compatibility', function () {
     } finally { receiver.destroy(); }
   });
   it('bounds tiny buffered chunks in an incomplete frame', async function () {
-    const receiver = new WebSocket.Receiver('nodebuffer', {}, false, 0, 4, 0);
+    const receiver = new WebSocket.Receiver({binaryType: 'nodebuffer', maxBufferedChunks: 4});
     try {
       const error = once(receiver, 'error', {signal: AbortSignal.timeout(1000)});
       receiver.write(Buffer.from([130, 126, 1, 0]));

--- a/tests/pushover-lifecycle.test.js
+++ b/tests/pushover-lifecycle.test.js
@@ -5,15 +5,13 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 const {createRequire} = require('module');
-const {EventEmitter} = require('events');
 const levels = require('../lib/levels');
 
-function loadPushover(loadProvider, transport) {
+function loadPushover(loadProvider) {
   const filename = path.resolve(__dirname, '../lib/plugins/pushover.js');
   const localRequire = createRequire(filename);
   const sandbox = {module: {exports: {}}, console: {info() {}, error() {}}, require(name) {
-    if (name === 'pushover-notifications') return loadProvider();
-    if (name === 'https' && transport) return transport;
+    if (name === '../server/pushover-client') return loadProvider();
     return localRequire(name);
   }};
   vm.runInNewContext(fs.readFileSync(filename, 'utf8'), sandbox, {filename});
@@ -95,18 +93,14 @@ describe('Pushover lazy loading and transport lifecycle', function () {
   for (const failed of [false, true]) {
     it('preserves receipt cancellation ' + (failed ? 'errors' : 'success') + ' over repeated calls', function () {
       const failure = new Error('fixture cancellation error');
-      let requests = 0, resumed = 0;
-      const transport = {get(url, callback) {
-        requests++;
-        assert.strictEqual(url, 'https://api.pushover.net/1/receipts/fixture-receipt/cancel.json?token=fixture-token');
-        const request = new EventEmitter();
-        process.nextTick(() => {
-          if (failed) request.emit('error', failure);
-          else callback({statusCode: 200, resume() { resumed++; }});
-        });
-        return request;
-      }};
-      const pushover = loadPushover(() => function Provider() {}, transport)(configuration({apiToken: 'fixture-token', userKey: 'user'}), {levels});
+      let requests = 0;
+      const pushover = loadPushover(() => function Provider() {
+        this.cancel = (receipt, callback) => {
+          requests++;
+          assert.strictEqual(receipt, 'fixture-receipt');
+          process.nextTick(() => callback(failed ? failure : null, {statusCode: 200}));
+        };
+      })(configuration({apiToken: 'fixture-token', userKey: 'user'}), {levels});
       return (async () => {
         for (let cycle = 1; cycle <= 2; cycle++) {
           await new Promise(resolve => pushover.cancelWithReceipt('fixture-receipt', (error, response) => {
@@ -115,7 +109,6 @@ describe('Pushover lazy loading and transport lifecycle', function () {
             resolve();
           }));
           assert.strictEqual(requests, cycle);
-          assert.strictEqual(resumed, failed ? 0 : cycle);
         }
       })();
     });

--- a/tests/pushover-transport.test.js
+++ b/tests/pushover-transport.test.js
@@ -32,7 +32,7 @@ describe('Native Pushover HTTPS transport', function () {
     server.on('connection', socket => { sockets.add(socket); socket.on('close', () => sockets.delete(socket)); });
     await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
     const sandbox = {module: {exports: {}}, URLSearchParams, Buffer, queueMicrotask, clearTimeout,
-      setTimeout(fn, ms) { return setTimeout(fn, fastTimeout ? 80 : ms); },
+      setTimeout(fn, ms) { return setTimeout(fn, fastTimeout ? 250 : ms); },
       require(name) {
         assert.equal(name, 'node:https');
         return {request(options, callback) {

--- a/tests/pushover-transport.test.js
+++ b/tests/pushover-transport.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const https = require('node:https');
+const vm = require('node:vm');
+const {execFile} = require('node:child_process');
+const {promisify} = require('node:util');
+const {setTimeout: delay} = require('node:timers/promises');
+
+describe('Native Pushover HTTPS transport', function () {
+  this.timeout(20000);
+  let directory, server, Client, cert, sockets, received, handler;
+  let trust = true, fastTimeout = false;
+  const token = 'owned-token-never-log';
+
+  before(async function () {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'nightscout-pushover-tls-'));
+    await promisify(execFile)('openssl', ['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-sha256',
+      '-keyout', path.join(directory, 'key.pem'), '-out', path.join(directory, 'cert.pem'),
+      '-days', '1', '-subj', '/CN=127.0.0.1', '-addext', 'subjectAltName=IP:127.0.0.1'], {timeout: 10000});
+    cert = await fs.readFile(path.join(directory, 'cert.pem'));
+    sockets = new Set(); received = [];
+    server = https.createServer({cert, key: await fs.readFile(path.join(directory, 'key.pem'))}, (req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', () => { received.push({method: req.method, url: req.url, headers: req.headers, body}); handler(req, res); });
+    });
+    server.on('connection', socket => { sockets.add(socket); socket.on('close', () => sockets.delete(socket)); });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const sandbox = {module: {exports: {}}, URLSearchParams, Buffer, queueMicrotask, clearTimeout,
+      setTimeout(fn, ms) { return setTimeout(fn, fastTimeout ? 80 : ms); },
+      require(name) {
+        assert.equal(name, 'node:https');
+        return {request(options, callback) {
+          assert.equal(options.hostname, 'api.pushover.net');
+          assert.equal(options.port, 443);
+          assert.equal(options.rejectUnauthorized, true);
+          assert.equal(options.method, 'POST');
+          // Redirect only inside the fixture and keep certificate verification.
+          return https.request({...options, hostname: '127.0.0.1', port: server.address().port,
+            ca: trust ? cert : undefined, agent: false}, callback);
+        }};
+      }
+    };
+    vm.runInNewContext(await fs.readFile(path.join(__dirname, '../lib/server/pushover-client.js'), 'utf8'), sandbox);
+    Client = sandbox.module.exports;
+  });
+
+  after(async function () {
+    for (const socket of sockets || []) socket.destroy();
+    if (server) await new Promise(resolve => server.close(resolve));
+    if (directory) await fs.rm(directory, {recursive: true, force: true});
+  });
+
+  async function invoke(client, method, value) {
+    let calls = 0;
+    const result = await new Promise(resolve => client[method](value, (error, result) => { calls++; resolve({error, result}); }));
+    const deadline = Date.now() + 2000;
+    while (sockets.size && Date.now() < deadline) await delay(10);
+    assert.equal(sockets.size, 0, 'Owned request socket must be released');
+    await delay(10);
+    assert.equal(calls, 1, 'Completion must be called exactly once');
+    if (result.error) assert.ok(!String(result.error.stack).includes(token), 'Do not expose credentials through errors');
+    return result;
+  }
+
+  it('encodes independent messages and cancels receipts with a body token over two cycles', async function () {
+    handler = (req, res) => { res.writeHead(200); res.end('{"status":1,"receipt":"owned-receipt"}'); };
+    const client = new Client({token});
+    for (let cycle = 0; cycle < 2; cycle++) {
+      const message = {user: 'user a&b', title: 'BG < 70 & 🍕', message: 'one\ntwo + three', priority: 2,
+        retry: 120, expire: 900, callback: 'https://nightscout.test/callback?a=b&c=d', timestamp: 1700000000, sound: 'gamelan'};
+      const before = {...message};
+      const results = await Promise.all([invoke(client, 'send', message), invoke(client, 'send', {...message, user: 'second-user'})]);
+      for (const result of results) { assert.ifError(result.error); assert.equal(result.result, '{"status":1,"receipt":"owned-receipt"}'); }
+      assert.deepEqual(message, before, 'Do not mutate the shared message object');
+      const requests = received.slice(-2);
+      assert.deepEqual(requests.map(r => new URLSearchParams(r.body).get('user')).sort(), ['second-user', 'user a&b']);
+      for (const request of requests) {
+        assert.equal(request.url, '/1/messages.json');
+        assert.equal(request.headers['content-type'], 'application/x-www-form-urlencoded');
+        assert.equal(Number(request.headers['content-length']), Buffer.byteLength(request.body));
+        const form = new URLSearchParams(request.body);
+        assert.equal(form.get('token'), token);
+        for (const [key, value] of Object.entries(message)) if (key !== 'user') assert.equal(form.get(key), String(value));
+      }
+      const cancelled = await invoke(client, 'cancel', 'receipt/with?reserved');
+      assert.ifError(cancelled.error);
+      assert.equal(cancelled.result.statusCode, 200);
+      assert.equal(received.at(-1).url, '/1/receipts/receipt%2Fwith%3Freserved/cancel.json');
+      assert.equal(received.at(-1).body, new URLSearchParams({token}).toString());
+      assert.ok(!received.at(-1).url.includes(token));
+    }
+  });
+
+  it('preserves actual plugin routing, alarm parameters and Unix timestamps', async function () {
+    const levels = require('../lib/levels');
+    const sandbox = {module: {exports: {}}, console: {info() {}, error() {}}, require(name) {
+      if (name === '../server/pushover-client') return Client;
+      assert.equal(name, '../times');
+      return require('../lib/times');
+    }};
+    vm.runInNewContext(await fs.readFile(path.join(__dirname, '../lib/plugins/pushover.js'), 'utf8'), sandbox);
+    const plugin = sandbox.module.exports({settings: {baseURL: 'https://nightscout.test'}, extendedSettings: {pushover: {
+      apiToken: token, userKey: 'normal-a normal-b', alarmKey: 'alarm', announcementKey: 'announcement'
+    }}}, {levels});
+    handler = (req, res) => res.end('{"status":1,"receipt":"owned-receipt"}');
+    for (let cycle = 0; cycle < 2; cycle++) {
+      for (const [notify, recipients] of [
+        [{level: levels.INFO}, ['normal-a', 'normal-b']],
+        [{level: levels.URGENT}, ['alarm']],
+        [{level: levels.INFO, isAnnouncement: true}, ['announcement']]
+      ]) {
+        const count = received.length;
+        let completed = 0;
+        await new Promise((resolve, reject) => plugin.send({...notify, title: 'Fixture', message: 'Fixture message'}, (error, text) => {
+          if (error) return reject(error);
+          assert.equal(JSON.parse(text).receipt, 'owned-receipt');
+          if (++completed === recipients.length) resolve();
+        }));
+        const requests = received.slice(count).map(request => new URLSearchParams(request.body));
+        assert.deepEqual(requests.map(form => form.get('user')).sort(), recipients.slice().sort());
+        for (const form of requests) {
+          assert.equal(form.get('sound'), 'gamelan');
+          assert.equal(form.get('expire'), '900');
+          const timestamp = Number(form.get('timestamp'));
+          assert.ok(Number.isInteger(timestamp) && Math.abs(Date.now() / 1000 - timestamp) < 10);
+          if (notify.level === levels.URGENT) {
+            assert.equal(form.get('priority'), '2');
+            assert.equal(form.get('retry'), '120');
+            assert.equal(form.get('callback'), 'https://nightscout.test/api/v1/notifications/pushovercallback');
+          } else assert.equal(form.get('priority'), '0');
+        }
+      }
+    }
+  });
+
+  const failures = [
+    ['HTTP rejection', (req, res) => { res.writeHead(400); res.end('{"status":0}'); }, 'EPUSHOVER_HTTP'],
+    ['rate limit', (req, res) => { res.writeHead(429); res.end('{"status":0}'); }, 'EPUSHOVER_HTTP'],
+    ['server failure', (req, res) => { res.writeHead(503); res.end('{"status":0}'); }, 'EPUSHOVER_HTTP'],
+    ['redirect', (req, res) => { res.writeHead(302, {location: 'https://example.invalid'}); res.end(); }, 'EPUSHOVER_HTTP'],
+    ['API rejection', (req, res) => res.end('{"status":0,"errors":["' + token + '"]}'), 'EPUSHOVER_API'],
+    ['invalid JSON', (req, res) => res.end('not-json ' + token), 'EPUSHOVER_JSON'],
+    ['oversized response', (req, res) => res.end('x'.repeat(65537)), 'EPUSHOVER_SIZE'],
+    ['truncated response', (req, res) => { res.writeHead(200, {'content-length': 100}); res.write('{'); res.flushHeaders(); setImmediate(() => res.destroy()); }, 'EPUSHOVER_TRANSPORT'],
+    ['timeout', () => {}, 'EPUSHOVER_TIMEOUT']
+  ];
+  for (const [name, respond, code] of failures) it('reports ' + name + ' once without retrying', async function () {
+    handler = respond; fastTimeout = name === 'timeout';
+    try {
+      const client = new Client({token});
+      for (const method of ['send', 'cancel']) {
+        const count = received.length;
+        const result = await invoke(client, method, method === 'send' ? {user: 'fixture', message: 'fixture'} : 'fixture');
+        assert.equal(result.error.code, code);
+        assert.equal(received.length, count + 1);
+      }
+    } finally { fastTimeout = false; }
+  });
+
+  it('rejects an untrusted certificate without sending credentials', async function () {
+    trust = false;
+    try {
+      for (let cycle = 0; cycle < 2; cycle++) {
+        const count = received.length;
+        const result = await invoke(new Client({token}), 'send', {user: 'fixture', message: 'fixture'});
+        assert.equal(result.error.code, 'EPUSHOVER_TRANSPORT');
+        assert.equal(received.length, count);
+      }
+    } finally { trust = true; }
+  });
+});

--- a/tools/audits/notification-provider-probe.cjs
+++ b/tools/audits/notification-provider-probe.cjs
@@ -13,7 +13,7 @@ let ctx;
     fixtureEnv;
   Module._load = function (name, ...args) {
     const value = originalLoad.call(this, name, ...args);
-    if (name === "pushover-notifications") {
+    if ((name === "pushover-notifications" || name === "../server/pushover-client")) {
       if (!wrappers.has(value)) {
         wrappers.set(value, function (options) {
           const provider = new value(options);
@@ -153,7 +153,7 @@ let ctx;
     providerSends: sends,
     pushoverSends: pushes,
     pushoverLoaded: Object.keys(require.cache).some((p) =>
-      p.includes("/pushover-notifications/"),
+      p.includes("/pushover-notifications/") || p.endsWith("/lib/server/pushover-client.js"),
     ),
     apnLoaded: Object.keys(require.cache).some((p) =>
       p.includes("/@parse/node-apn/"),


### PR DESCRIPTION
Refresh the build commands from webpack-cli 4.10.0 to 7.2.3 and webpack-bundle-analyzer 4.10.2 to 5.3.2, retaining webpack 5.110.3. This is one M09 dependency-family review; M09 and draft integration #8605 remain open.

Depends on #8708. This branch contains that Pushover candidate plus the latest modernization base; after #8708 merges, the remaining diff is the CLI/analyzer manifest, lockfile, consumer tests and review documentation. Target remains chore/nightscout-modernization.

The CLI now loads configurations through dynamic import and has new optional parser peers. Resolve the lockfile without legacy peer mode so CLI sees compatible js-yaml 4 while NYC retains nested 3; no parser versions or copy counts change. Analyzer uses ws 8, so adapt the existing Receiver tests to its options-object API while retaining the original resource bounds and adversarial frames.

Validation:

- Clean Node 22 install/production build with legacy peer mode disabled; full npm dependency tree valid.
- 286 dependency regression tests on Node 22; eight focused CLI/analyzer/WebSocket tests on Node 24. Real fixture builds exercise production/development profiling JSON, analyzer JSON/HTML reports, YAML configuration, and invalid-config failure exits.
- Final Node 24 full backend: 2,079 passing, one existing pending. Earlier Node 22 full backend: 2,078 passing before adding the YAML case and correcting peer hoisting. Current-head hosted CI must cover the final Node 22/24 tree before merge.
- Actual app Node 24 development build and six-bundle analyzer reports pass. Standalone HTML report renders in Chromium without JavaScript errors.
- All 276 production lock entries and all six production application bundles are unchanged. Full/production audits report zero known advisories. Application lint: zero errors, 16 existing warnings.
- 838 -> 832 installed package paths; package-owned regular files increase 447,106 bytes. No runtime-memory, image-size or build-time saving claimed.

No Nightscout UI/configuration change intended; the optional developer analyzer gains upstream report features. Documentation records release/API review, measured cost, regression evidence and rollback. All existing browser/HMR/resource-budget gates remain required.
