### PR TITLE
Modernize Mocha and protect XML test-parser contracts

### DIFF
--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -138,6 +138,12 @@ and adds real command/report regression coverage. Production lock entries and
 application bundles are unchanged; development package bytes increase despite
 six fewer paths. Remaining dependency and override reviews keep M09 open.
 
+The [Mocha 12 review](../test-specs/mocha12-modernization.md) adopts native Node
+argument parsing, removes two redundant runner overrides and 40 package paths.
+Runner failure/reporting, YAML defaults and retained parser security contracts
+have consumer coverage; production dependencies and bundles remain unchanged.
+Other M09 dependency and override reviews remain open.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -144,6 +144,11 @@ Runner failure/reporting, YAML defaults and retained parser security contracts
 have consumer coverage; production dependencies and bundles remain unchanged.
 Other M09 dependency and override reviews remain open.
 
+The [XML parser review](../test-specs/xml-parser-review.md) retains test-only
+xml2js 0.5.0: latest 0.6.2 inserts inherited objects/functions into prototype-named
+XML fields on Node 22/24. New regression coverage records the required data
+contract; reconsider a published fix or separately evaluated replacement.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/test-specs/mocha12-modernization.md
+++ b/docs/test-specs/mocha12-modernization.md
@@ -1,0 +1,50 @@
+# Mocha 12 and native command parsing (M09 partial)
+
+Upgrade Mocha 11.8.0 to 12.0.0, reviewed on 2026-09-06. Its Node requirement
+(^20.19.0 or >=22.12.0) supports Nightscout's Node 22/24 floors. This is a
+development-only tool; application modules and deployment configuration do not
+change. Review [Mocha releases](https://github.com/mochajs/mocha/releases),
+including the v12 prerelease breaking changes, and
+[js-yaml documentation](https://nodeca.github.io/js-yaml/doc/).
+
+Mocha 12 changes its entry points to ESM, replaces its yargs parsing/respawn
+helpers with native Node argument parsing, removes its HTML-encoding dependency,
+and updates watcher/glob/worker dependencies. Nightscout calls bin/mocha.js;
+it does not call the retired bin/_mocha or internal Mocha APIs. CommonJS tests,
+root hooks, glob discovery, parallel execution, nyc coverage and browser hooks
+remain required validation gates.
+
+Remove the scoped diff and serialize-javascript overrides: Mocha declares diff
+^9 and serialize-javascript ^7.0.2, resolving 9.0.0 and 7.0.5 naturally. Forcing
+the old diff 8 override would violate Mocha's new declared range. Other parents'
+security overrides remain unchanged pending their own review.
+
+Mocha now resolves js-yaml 5.4.1. Its default YAML 1.2 schema treats `<<` as an
+ordinary property, not a merge directive, and rejects ordered-map/executable
+tags. Nightscout's test scripts do not rely on YAML merge configuration.
+Contributors with private .mocharc.yml files should flatten inherited YAML
+values or use a JavaScript configuration before upgrading. NYC retains js-yaml
+3.15.2 and webpack CLI retains 4.3.2, with their original merge/ordered-map
+security contracts. Tests resolve each parser through its actual consumer.
+The v5 compatibility-tag tests explicitly enable those tags solely to retain
+merge-work/ordered-map resource tests; separate tests protect the actual default
+schema and real Mocha YAML configuration loading.
+
+Regression coverage includes serial/parallel callback and async root hooks,
+fluent suite timeouts, assertion failure exit codes and diffs, setup failure,
+timeout failure, quoted grep values with Node-flag respawning, and xunit XML
+escaping after removal of the HTML helper. YAML tests cover all three consumers,
+prototype keys, executable tags, duplicates, alias limits, and bounded merge
+work. Dependency-test totals change when duplicate package copies disappear;
+the dynamically generated duplicate-copy cases are not manually removed.
+
+Matched clean Node 22 installations: 832 -> 792 package paths and
+202,324,614 -> 192,961,958 package-owned regular file bytes, excluding nested
+node_modules and symlinks (**9,362,656 bytes removed from the development tree**).
+All 276 production lock entries and all six production JavaScript bundles are
+unchanged. These are installed package measurements, not server RAM, image-size
+or build-time savings. No Nightscout user-facing UI change is intended.
+
+Full current-head CI, browser hooks and coverage validation remain required
+before integration. Roll back manifest, lockfile and consumer-version tests
+together. This review does not complete the remaining M09 work.

--- a/docs/test-specs/mocha12-modernization.md
+++ b/docs/test-specs/mocha12-modernization.md
@@ -23,9 +23,11 @@ Mocha now resolves js-yaml 5.4.1. Its default YAML 1.2 schema treats `<<` as an
 ordinary property, not a merge directive, and rejects ordered-map/executable
 tags. Nightscout's test scripts do not rely on YAML merge configuration.
 Contributors with private .mocharc.yml files should flatten inherited YAML
-values or use a JavaScript configuration before upgrading. NYC retains js-yaml
-3.15.2 and webpack CLI retains 4.3.2, with their original merge/ordered-map
-security contracts. Tests resolve each parser through its actual consumer.
+values or use a JavaScript configuration before upgrading. NYC retains required js-yaml 3.15.2. With peer resolution enabled, webpack
+CLI receives optional 4.3.2; legacy-peer-deps installations omit that optional
+parser because Mocha no longer requires v4. Nightscout builds use JavaScript
+configuration and do not require the optional YAML loader. Retain the original
+merge/ordered-map security contracts for every installed parser. Tests resolve each parser through its actual consumer.
 The v5 compatibility-tag tests explicitly enable those tags solely to retain
 merge-work/ordered-map resource tests; separate tests protect the actual default
 schema and real Mocha YAML configuration loading.
@@ -38,7 +40,7 @@ prototype keys, executable tags, duplicates, alias limits, and bounded merge
 work. Dependency-test totals change when duplicate package copies disappear;
 the dynamically generated duplicate-copy cases are not manually removed.
 
-Matched clean Node 22 installations: 832 -> 792 package paths and
+Matched clean Node 22 installations with peer resolution enabled: 832 -> 792 package paths and
 202,324,614 -> 192,961,958 package-owned regular file bytes, excluding nested
 node_modules and symlinks (**9,362,656 bytes removed from the development tree**).
 All 276 production lock entries and all six production JavaScript bundles are
@@ -48,7 +50,13 @@ or build-time savings. No Nightscout user-facing UI change is intended.
 Local validation: clean Node 22 install/build without legacy peer mode; valid
 full npm dependency tree and no known audit advisories. Node 22 full backend
 passed 2,081 tests before the final two runner cases; final Node 24 backend
-passed 2,083, each with one existing pending case and nyc coverage. Node 24
+passed 2,083, each with one existing pending case and nyc coverage. Before the XML retention cases, Node 24
 passed all 290 dependency tests and 283 client-core cases; Node 22 Chromium
-passed all 574 browser cases. Final hosted CI remains required before integration. Roll back manifest, lockfile and consumer-version tests
+passed all 574 browser cases. The subsequent hosted run exposed the omitted optional CLI parser. The corrected
+tests exercise a clear failed YAML-config build when it is absent and a real
+successful build when installed; no dependency is added merely for testing.
+Final local dependency coverage passes 294 cases on Node 22 with peers enabled
+and 285 on Node 24 with legacy peer mode, which omits nine optional-parser
+cases. Both include the four added XML retention tests. Hosted CI on this
+corrected head remains required before integration. Roll back manifest, lockfile and consumer-version tests
 together. This review does not complete the remaining M09 work.

--- a/docs/test-specs/mocha12-modernization.md
+++ b/docs/test-specs/mocha12-modernization.md
@@ -45,6 +45,10 @@ All 276 production lock entries and all six production JavaScript bundles are
 unchanged. These are installed package measurements, not server RAM, image-size
 or build-time savings. No Nightscout user-facing UI change is intended.
 
-Full current-head CI, browser hooks and coverage validation remain required
-before integration. Roll back manifest, lockfile and consumer-version tests
+Local validation: clean Node 22 install/build without legacy peer mode; valid
+full npm dependency tree and no known audit advisories. Node 22 full backend
+passed 2,081 tests before the final two runner cases; final Node 24 backend
+passed 2,083, each with one existing pending case and nyc coverage. Node 24
+passed all 290 dependency tests and 283 client-core cases; Node 22 Chromium
+passed all 574 browser cases. Final hosted CI remains required before integration. Roll back manifest, lockfile and consumer-version tests
 together. This review does not complete the remaining M09 work.

--- a/docs/test-specs/webpack-cli-analyzer.md
+++ b/docs/test-specs/webpack-cli-analyzer.md
@@ -51,3 +51,8 @@ No deployment or Nightscout user-interface change is intended. The optional
 analyzer's developer report UI gains upstream display/compression features;
 it is not served by Nightscout. Restore both manifest/lockfile and Receiver
 constructor tests together to roll back. This does not complete M09.
+
+Mocha 12 follow-up: when v4 YAML is needed only as CLI's optional peer, legacy
+peer installations omit it. JavaScript builds remain supported; the consumer
+regression requires an explicit missing-parser error for YAML configs and also
+tests successful YAML builds when the optional peer is installed.

--- a/docs/test-specs/xml-parser-review.md
+++ b/docs/test-specs/xml-parser-review.md
@@ -1,0 +1,51 @@
+# XML test parser review (M09)
+
+Retain xml2js 0.5.0. The latest published release checked on 2026-09-06 is
+0.6.2, but it fails a reproduced data-preservation contract on both supported
+Node floors. No manifest or lockfile change is accepted in this review.
+
+The parser is used only by API3 XML renderer tests and the Mocha xunit reporter
+regression. It is not a production XML-input parser. Node has no built-in XML
+DOM parser suitable for these backend tests. Reimplementing XML parsing locally
+would weaken an independent validation tool and add maintenance complexity.
+
+For this fixture:
+
+```xml
+<root><constructor>ordinary</constructor><__proto__><polluted>fixture</polluted></__proto__></root>
+```
+
+With `explicitArray: false`, 0.5.0 returns the intended scalar `constructor` and
+nested `__proto__` document in objects with null prototypes. Version 0.6.2 returns
+arrays containing the inherited `Object` constructor and `Object.prototype`
+before the XML values. This reproduces on Node 22.23.2 and 24.20.0. Updating
+its SAX consumer to 1.6.1 does not fix the xml2js object-building behavior.
+The fixture does **not** modify Object.prototype; do not describe this finding
+as a demonstrated global prototype-pollution exploit.
+
+The [upstream report #719](https://github.com/Leonidas-from-XIV/node-xml2js/issues/719)
+describes the inherited-property check; the
+[0.5.0...0.6.2 source changes](https://github.com/Leonidas-from-XIV/node-xml2js/compare/0.5.0...0.6.2)
+explain the change from null-prototype objects to defineProperty-based writes.
+Although that report is closed, the published 0.6.2 package still reproduces the
+behavior. A closed issue or a clean advisory scan is not evidence of a fixed
+published consumer.
+
+New regression tests preserve renderer-style scalar/array/attribute values,
+Unicode and escaping; require prototype-named elements to remain writable own
+data without inherited values; check constructor attributes; and verify parser
+recovery after malformed XML and unknown/external entity references. Existing
+API3 renderer/security tests and xunit XML round-trip coverage remain.
+The tests intentionally preserve null-prototype output. They must not be relaxed
+solely to accept an upgrade that inserts inherited objects/functions into data.
+
+The existing SAX parser also omits a `__proto__` attribute in both reviewed
+xml2js versions; this review does not claim that pre-existing behavior is fixed.
+The new prototype-attribute test covers `constructor`, which both the renderer
+oracle and retained parser can represent. ElementTree's production SAX pin is
+unchanged; no override is forced across that separate consumer.
+
+Reconsider a later published fix or a separately evaluated maintained parser
+when it satisfies these contracts and the actual renderer tests. No package,
+server-memory, browser, or user-facing configuration change is claimed here.
+M09's other dependency and override reviews remain open.

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "eslint": "^10.10.0",
         "eslint-plugin-security": "^4.0.1",
         "globals": "^17.12.0",
-        "mocha": "^11.8.0",
+        "mocha": "12.0.0",
         "moment-timezone-data-webpack-plugin": "^1.5.0",
         "nodemon": "^3.1.14",
         "nyc": "^18.0.0",
@@ -2575,47 +2575,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "dev": true,
@@ -3279,15 +3238,6 @@
         "node": "20 || 22 || 24"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -3881,11 +3831,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "license": "MIT",
@@ -4143,30 +4088,17 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/chokidar": {
-      "version": "4.0.3",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -4970,7 +4902,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.3",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5066,11 +5000,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/easyxml": {
       "version": "2.0.1",
       "license": "(BSD-3-Clause OR GPL-2.0)",
@@ -5123,11 +5052,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/empathic": {
       "version": "2.0.1",
@@ -5956,19 +5880,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.5.0",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6000,30 +5923,6 @@
       },
       "peerDependencies": {
         "tslib": "2"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -6131,14 +6030,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/helmet": {
@@ -6459,14 +6350,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "license": "MIT",
@@ -6498,6 +6381,8 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6801,37 +6686,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/glob": {
-      "version": "13.0.6",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/istanbul-lib-processinfo/node_modules/rimraf": {
       "version": "6.1.3",
       "dev": true,
@@ -6902,20 +6756,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "dev": true,
@@ -6977,6 +6817,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7151,21 +6993,6 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/lru-cache": {
       "version": "11.5.2",
@@ -7409,64 +7236,57 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
-      "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-12.0.0.tgz",
+      "integrity": "sha512-NYNh5IFt6WYqm9bi4601m7vix8MZdXC0DwS4gY6WhXO2RgJWhivhISVmq1oklCif18OSI9l+vx5Mdm5oh1XGiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
-        "chokidar": "^4.0.1",
+        "chokidar": "^5.0.0",
         "debug": "^4.3.5",
-        "diff": "^7.0.0",
-        "escape-string-regexp": "^4.0.0",
+        "diff": "^9.0.0",
         "find-up": "^5.0.0",
-        "glob": "^10.4.5",
-        "he": "^1.2.0",
+        "glob": "^13.0.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
+        "is-unicode-supported": "^0.1.0",
+        "js-yaml": "^5.0.0",
+        "minimatch": "^10.2.2",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
-        "serialize-javascript": "^6.0.2",
-        "strip-json-comments": "^3.1.1",
+        "serialize-javascript": "^7.0.2",
+        "strip-json-comments": "^5.0.3",
         "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
-        "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1",
-        "yargs-unparser": "^2.0.0"
+        "workerpool": "^10.0.0"
       },
       "bin": {
-        "_mocha": "bin/_mocha",
         "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "9.0.9",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "argparse": "^2.0.1"
       },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -7860,22 +7680,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/nyc/node_modules/glob": {
-      "version": "13.0.6",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/nyc/node_modules/locate-path": {
       "version": "5.0.0",
       "dev": true,
@@ -7910,21 +7714,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nyc/node_modules/resolve-from": {
@@ -8208,24 +7997,21 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -8489,11 +8275,13 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -9200,37 +8988,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/spawn-wrap/node_modules/glob": {
-      "version": "13.0.6",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/spawn-wrap/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/spawn-wrap/node_modules/rimraf": {
       "version": "6.1.3",
       "dev": true,
@@ -9270,80 +9027,8 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9361,11 +9046,13 @@
       }
     },
     "node_modules/strip-json-comments": {
-      "version": "3.1.1",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9488,37 +9175,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "13.0.6",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/thingies": {
@@ -10112,96 +9768,11 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.3.4",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-10.0.3.tgz",
+      "integrity": "sha512-6z2Iis68Wqth93/G/wJP9u+R3O+d2XTlgWChGCwuT1qLbBsOYueGRZuJ++v3mtDP5KjYdy+WzvWC+VWETSVXJA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -10331,42 +9902,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/camelcase": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/decamelize": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yargs/node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "eslint": "^10.10.0",
     "eslint-plugin-security": "^4.0.1",
     "globals": "^17.12.0",
-    "mocha": "^11.8.0",
+    "mocha": "12.0.0",
     "moment-timezone-data-webpack-plugin": "^1.5.0",
     "nodemon": "^3.1.14",
     "nyc": "^18.0.0",
@@ -171,10 +171,6 @@
     },
     "ajv-formats": {
       "ajv": "8.18.0"
-    },
-    "mocha": {
-      "diff": "8.0.3",
-      "serialize-javascript": "7.0.5"
     },
     "brace-expansion@^1.0.0": "1.1.18",
     "brace-expansion@^2.0.0": "2.1.4",

--- a/tests/dependency-js-yaml.test.js
+++ b/tests/dependency-js-yaml.test.js
@@ -12,12 +12,23 @@ const { spawnSync } = require('child_process');
 const semver = require('semver');
 const lock = require('../package-lock.json');
 
-const consumers = ['@istanbuljs/load-nyc-config', 'webpack-cli', 'mocha'];
+// Legacy-peer-deps installations omit CLI's optional parser after Mocha
+// stops requiring v4. Required parsers must still always resolve.
+let cliYamlPresent = true;
+try {
+  createRequire(require.resolve('webpack-cli')).resolve('js-yaml');
+} catch (error) {
+  assert.strictEqual(error.code, 'MODULE_NOT_FOUND');
+  assert.strictEqual(require('webpack-cli/package.json').peerDependenciesMeta['js-yaml'].optional, true);
+  cliYamlPresent = false;
+}
+const consumers = ['@istanbuljs/load-nyc-config', 'mocha'];
+if (cliYamlPresent) consumers.push('webpack-cli');
 const versions = [
   { consumer: '@istanbuljs/load-nyc-config', major: 3, method: 'safeLoad', all: 'safeLoadAll', dump: 'safeDump' },
-  { consumer: 'webpack-cli', major: 4, method: 'load', all: 'loadAll', dump: 'dump' },
   { consumer: 'mocha', major: 5, method: 'load', all: 'loadAll', dump: 'dump' }
 ];
+if (cliYamlPresent) versions.push({consumer: 'webpack-cli', major: 4, method: 'load', all: 'loadAll', dump: 'dump'});
 
 function run(program, args, cwd) {
   // Keep parent coverage instrumentation and application settings out of fixtures.
@@ -38,8 +49,13 @@ describe('js-yaml dependency compatibility', function () {
     const copies = Object.entries(lock.packages).filter(([name]) => name.endsWith('/js-yaml'));
     assert.ok(copies.length > 0);
     for (const [name, entry] of copies) {
+      const manifest = path.resolve(__dirname, '..', name, 'package.json');
+      if (!fs.existsSync(manifest)) {
+        assert.ok(entry.optional && entry.peer, 'Only an optional peer parser may be absent: ' + name);
+        continue;
+      }
       // eslint-disable-next-line security/detect-non-literal-require
-      const installed = require(path.resolve(__dirname, '..', name, 'package.json'));
+      const installed = require(manifest);
       assert.strictEqual(installed.version, entry.version);
       assert.ok(semver.satisfies(installed.version, '>=3.15.2 <4 || >=4.3.2 <5 || >=5.4.1 <6'));
     }

--- a/tests/dependency-js-yaml.test.js
+++ b/tests/dependency-js-yaml.test.js
@@ -12,10 +12,11 @@ const { spawnSync } = require('child_process');
 const semver = require('semver');
 const lock = require('../package-lock.json');
 
-const consumers = ['@istanbuljs/load-nyc-config', 'mocha'];
+const consumers = ['@istanbuljs/load-nyc-config', 'webpack-cli', 'mocha'];
 const versions = [
   { consumer: '@istanbuljs/load-nyc-config', major: 3, method: 'safeLoad', all: 'safeLoadAll', dump: 'safeDump' },
-  { consumer: 'mocha', major: 4, method: 'load', all: 'loadAll', dump: 'dump' }
+  { consumer: 'webpack-cli', major: 4, method: 'load', all: 'loadAll', dump: 'dump' },
+  { consumer: 'mocha', major: 5, method: 'load', all: 'loadAll', dump: 'dump' }
 ];
 
 function run(program, args, cwd) {
@@ -40,15 +41,15 @@ describe('js-yaml dependency compatibility', function () {
       // eslint-disable-next-line security/detect-non-literal-require
       const installed = require(path.resolve(__dirname, '..', name, 'package.json'));
       assert.strictEqual(installed.version, entry.version);
-      assert.ok(semver.satisfies(installed.version, '>=3.15.2 <4 || >=4.3.2 <5'));
+      assert.ok(semver.satisfies(installed.version, '>=3.15.2 <4 || >=4.3.2 <5 || >=5.4.1 <6'));
     }
     for (const consumer of consumers) {
       const consumerRequire = createRequire(require.resolve(consumer));
       const installed = consumerRequire('js-yaml/package.json');
       // eslint-disable-next-line security/detect-non-literal-require
       const parent = require(consumer + '/package.json');
-      assert.ok(semver.satisfies(installed.version, parent.dependencies['js-yaml']));
-      assert.strictEqual(typeof consumerRequire('js-yaml')[consumer === 'mocha' ? 'load' : 'safeLoad'], 'function');
+      assert.ok(semver.satisfies(installed.version, (parent.dependencies || {})['js-yaml'] || (parent.peerDependencies || {})['js-yaml']));
+      assert.strictEqual(typeof consumerRequire('js-yaml')[consumer === '@istanbuljs/load-nyc-config' ? 'safeLoad' : 'load'], 'function');
     }
   });
 
@@ -56,7 +57,11 @@ describe('js-yaml dependency compatibility', function () {
     describe('js-yaml ' + version.major + '.x', function () {
       const consumerRequire = createRequire(require.resolve(version.consumer));
       const yaml = consumerRequire('js-yaml');
-      const load = yaml[version.method];
+      // v5 defaults to YAML 1.2 without merges/ordered maps. Exercise its
+      // explicit compatibility tags for the retained resource-limit checks;
+      // the actual Mocha defaults are covered separately below.
+      const options = version.major === 5 ? {schema: yaml.CORE_SCHEMA.withTags(yaml.mergeTag, yaml.omapTag)} : {};
+      const load = (source, extra) => yaml[version.method](source, {...options, ...extra});
 
       it('preserves configuration values, anchors and explicit merge overrides', function () {
         const value = load('base: &base {timeout: 5000, enabled: true}\nconfig:\n  <<: *base\n  timeout: 3000\n  label: "off"\n');
@@ -84,7 +89,7 @@ describe('js-yaml dependency compatibility', function () {
 
       it('bounds merge work across multiple documents in one call', function () {
         const input = 'config: {<<: {enabled: true}}\n---\nconfig: {<<: {enabled: false}}';
-        const loadAll = yaml[version.all];
+        const loadAll = (source, extra) => yaml[version.all](source, {...options, ...extra});
         assert.strictEqual(loadAll(input, { maxTotalMergeKeys: 4 }).length, 2);
         assert.throws(() => loadAll(input, { maxTotalMergeKeys: 3 }), /maxTotalMergeKeys/);
       });
@@ -99,12 +104,12 @@ describe('js-yaml dependency compatibility', function () {
       });
 
       it('rejects executable YAML tags through the safe configuration API', function () {
-        assert.throws(() => load('!!js/function "function () { return 1; }"'), /unknown tag/);
+        assert.throws(() => load('!!js/function "function () { return 1; }"'), /unknown.*tag/);
       });
 
       it('preserves ordered maps and rejects duplicate keys', function () {
         assert.deepStrictEqual(load('!!omap\n- constructor: 1\n- __proto__: 2\n'), [{ constructor: 1 }, JSON.parse('{"__proto__":2}')]);
-        assert.throws(() => load('!!omap\n- repeated: 1\n- repeated: 2\n'), /cannot resolve/);
+        assert.throws(() => load('!!omap\n- repeated: 1\n- repeated: 2\n'), version.major === 5 ? /duplicate key in ordered map/ : /cannot resolve/);
       });
 
       it('parses a large ordered map without quadratic CPU consumption', function () {
@@ -114,14 +119,44 @@ describe('js-yaml dependency compatibility', function () {
           const yaml = require(process.argv[1]);
           const count = 200000;
           const source = '!!omap\\n' + Array.from({length: count}, (_, i) => '- k' + i + ': ' + i).join('\\n');
-          const result = yaml[process.argv[2]](source);
+          const options = process.argv[3] === '5' ? {schema: yaml.CORE_SCHEMA.withTags(yaml.omapTag)} : {};
+          const result = yaml[process.argv[2]](source, options);
           assert.strictEqual(result.length, count);
           assert.strictEqual(result[count - 1]['k' + (count - 1)], count - 1);
         `;
-        run('-e', [script, consumerRequire.resolve('js-yaml'), version.method], __dirname);
+        run('-e', [script, consumerRequire.resolve('js-yaml'), version.method, String(version.major)], __dirname);
       });
     });
   }
+
+  describe('Mocha YAML 1.2 defaults', function () {
+    const yaml = createRequire(require.resolve('mocha'))('js-yaml');
+    it('preserves numeric options, aliases and strings without implicit merge expansion', function () {
+      const value = yaml.load('base: &base {timeout: 5000}\nconfig: {<<: *base, timeout: 3000, label: off}');
+      assert.strictEqual(value.config.timeout, 3000);
+      assert.strictEqual(value.config.label, 'off');
+      assert.strictEqual(value.config['<<'], value.base);
+      assert.deepStrictEqual(yaml.load(yaml.dump({timeout: 3000, spec: ['*.test.cjs']})),
+        {timeout: 3000, spec: ['*.test.cjs']});
+    });
+    it('keeps prototype keys as own data and rejects executable and unsupported tags', function () {
+      const value = yaml.load('__proto__: {polluted: true}\nconstructor: ordinary');
+      assert.strictEqual(Object.getPrototypeOf(value), Object.prototype);
+      assert.strictEqual(value.polluted, undefined);
+      assert.strictEqual(Object.prototype.polluted, undefined);
+      assert(Object.hasOwn(value, '__proto__'));
+      assert.strictEqual(value.constructor, 'ordinary');
+      assert.throws(() => yaml.load('!!js/function "function () {}"'), /unknown.*tag/);
+      assert.throws(() => yaml.load('!!omap\n- key: value'), /unknown.*tag/);
+      assert.throws(() => yaml.load('!!merge <<'), /unknown.*tag/);
+    });
+    it('rejects duplicate keys and enforces a configured alias budget', function () {
+      assert.throws(() => yaml.load('timeout: 1\ntimeout: 2'), /duplicat/);
+      const input = 'a: &a {enabled: true}\nb: [*a, *a]';
+      assert.strictEqual(yaml.load(input, {maxAliases: 2}).b.length, 2);
+      assert.throws(() => yaml.load(input, {maxAliases: 1}), /maxAliases/);
+    });
+  });
 
   describe('tool configuration consumers', function () {
     let directory;

--- a/tests/dependency-mocha.test.js
+++ b/tests/dependency-mocha.test.js
@@ -112,7 +112,7 @@ describe('Mocha runner compatibility', function () {
     });
   }
 
-  it('renders assertion diffs with the overridden diff dependency', function () {
+  it('renders assertion diffs with the installed diff dependency', function () {
     const file = fixture('diff.test.cjs', `
       const assert = require('assert');
       it('intentional diff', function () { assert.strictEqual('actual-value', 'expected-value'); });
@@ -136,6 +136,29 @@ describe('Mocha runner compatibility', function () {
     assert.strictEqual(result.report.stats.passes, 0);
     assert.strictEqual(result.report.failures[0].err.message, 'fixture setup failed');
     assert.ok(!result.stdout.includes('affected test ran'));
+  });
+
+  it('preserves quoted grep values and Node flags when respawning', function () {
+    const file = fixture('flags.test.cjs', `
+      const assert = require('assert');
+      it('quoted "name" -1', function () { assert.strictEqual(typeof global.gc, 'function'); });
+      it('excluded test', function () { throw new Error('grep filter lost'); });
+    `);
+    const result = run(['--node-option', 'expose-gc', '--grep', 'quoted "name" -1', file]);
+    assert.strictEqual(result.status, 0, result.stdout + result.stderr);
+    assert.strictEqual(result.report.stats.passes, 1);
+    assert.strictEqual(result.report.tests[0].title, 'quoted "name" -1');
+  });
+
+  it('escapes test names in the xunit reporter after removal of its HTML helper', async function () {
+    const file = fixture('xml.test.cjs', `
+      it('fixture <script>&"', function () {});
+    `);
+    const result = run([file], 'xunit');
+    assert.strictEqual(result.status, 0, result.stdout + result.stderr);
+    const parsed = await require('xml2js').parseStringPromise(result.stdout);
+    assert.strictEqual(parsed.testsuite.testcase[0].$.name, 'fixture <script>&"');
+    assert(!result.stdout.includes('<script>'));
   });
 
   it('fails timed-out asynchronous tests instead of returning success', function () {

--- a/tests/dependency-webpack-tools.test.js
+++ b/tests/dependency-webpack-tools.test.js
@@ -45,14 +45,29 @@ describe('Webpack command-line and analyzer compatibility', function () {
       assert(html.includes('<html'));
     });
   }
-  it('loads YAML configuration through the compatible optional parser', function () {
-    // CLI resolves optional parsers beside the config, so expose its actual
-    // installed consumer resolution to this otherwise isolated fixture.
-    const yamlPackage = createRequire(cli).resolve('js-yaml/package.json');
-    fs.mkdirSync(path.join(directory, 'node_modules'));
-    fs.symlinkSync(path.dirname(yamlPackage), path.join(directory, 'node_modules/js-yaml'), 'dir');
+  it('handles YAML configuration with and without its optional parser', function () {
     fs.writeFileSync(path.join(directory, 'webpack.config.yaml'),
       'entry: ./entry.js\noutput:\n  filename: yaml-fixture.js\n');
+    // Optional parsers resolve beside the config. This isolated fixture starts
+    // without one and must fail clearly, rather than claim a successful build.
+    const missing = spawnSync(process.execPath, [cli, '--mode', 'production', '--config', 'webpack.config.yaml'], {
+      cwd: directory, encoding: 'utf8', timeout: 20000
+    });
+    assert.ifError(missing.error);
+    assert.notStrictEqual(missing.status, 0);
+    assert(missing.stderr.includes("'js-yaml' package, which is not installed"));
+    let yamlPackage;
+    try {
+      yamlPackage = createRequire(cli).resolve('js-yaml/package.json');
+    } catch (error) {
+      assert.strictEqual(error.code, 'MODULE_NOT_FOUND');
+      assert.strictEqual(require('webpack-cli/package.json').peerDependenciesMeta['js-yaml'].optional, true);
+      return;
+    }
+    // When the install includes the optional peer, validate the success path
+    // using that actual consumer resolution, without adding a root dependency.
+    fs.mkdirSync(path.join(directory, 'node_modules'));
+    fs.symlinkSync(path.dirname(yamlPackage), path.join(directory, 'node_modules/js-yaml'), 'dir');
     const stats = JSON.parse(run(cli, ['--mode', 'production', '--config', 'webpack.config.yaml', '--json']));
     assert.strictEqual(stats.errorsCount, 0);
     assert(stats.assets.some(asset => asset.name === 'yaml-fixture.js' && asset.size > 0));

--- a/tests/dependency-xml2js.test.js
+++ b/tests/dependency-xml2js.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const assert = require('node:assert');
+const xml2js = require('xml2js');
+
+describe('XML test parser compatibility', function () {
+  it('preserves renderer-style scalars, repeated elements, Unicode and escaped text', async function () {
+    const parser = new xml2js.Parser({explicitArray: false});
+    const source = '<result><value>150</value><empty/><note>Café 💉 &lt;script&gt; &amp; text</note>' +
+      '<entry id="a">first</entry><entry id="b">second</entry></result>';
+    for (let cycle = 0; cycle < 2; cycle++) {
+      const data = await parser.parseStringPromise(source);
+      assert.deepStrictEqual(JSON.parse(JSON.stringify(data)), {result: {
+        value: '150', empty: '', note: 'Café 💉 <script> & text',
+        entry: [{_: 'first', $: {id: 'a'}}, {_: 'second', $: {id: 'b'}}]
+      }});
+    }
+  });
+
+  it('preserves prototype-named elements as writable own data without pollution', async function () {
+    const data = await xml2js.parseStringPromise(
+      '<root><__proto__><polluted>true</polluted></__proto__><constructor>ordinary</constructor></root>',
+      {explicitArray: false});
+    assert.strictEqual(Object.getPrototypeOf(data.root), null);
+    assert(Object.hasOwn(data.root, '__proto__'));
+    assert.strictEqual(data.root.__proto__.polluted, 'true');
+    assert.strictEqual(data.root.constructor, 'ordinary');
+    assert.strictEqual(data.root.polluted, undefined);
+    assert.strictEqual(Object.prototype.polluted, undefined);
+    data.root.__proto__ = 'updated';
+    assert.strictEqual(data.root.__proto__, 'updated');
+    assert.strictEqual(Object.getPrototypeOf(data.root), null);
+  });
+
+  it('preserves prototype-named attributes without changing the attribute object prototype', async function () {
+    const data = await xml2js.parseStringPromise('<root constructor="ordinary"/>');
+    assert(Object.hasOwn(data.root.$, 'constructor'));
+    assert.strictEqual(data.root.$.constructor, 'ordinary');
+    assert.strictEqual(Object.getPrototypeOf(data.root.$), null);
+  });
+
+  it('rejects malformed XML and undeclared external entities, then parses a fresh document', async function () {
+    const parser = new xml2js.Parser({explicitArray: false});
+    for (const source of ['<root><child></root>', '<root>&unknown;</root>',
+      '<!DOCTYPE root [<!ENTITY xxe SYSTEM "https://example.invalid/not-requested">]><root>&xxe;</root>']) {
+      await assert.rejects(parser.parseStringPromise(source));
+      assert.strictEqual((await parser.parseStringPromise('<root>valid</root>')).root, 'valid');
+    }
+  });
+});


### PR DESCRIPTION
Upgrade the development test runner to Mocha 12.0.0, adopting its native Node argument parsing and removing the obsolete diff/serialize-javascript overrides. Add regression coverage for runner respawning, quoted arguments, XML report escaping and the changed YAML defaults. This is M09 work targeting chore/nightscout-modernization; integration #8605 remains draft.

Mocha's ESM entry points, serial/parallel hooks, failure exits, nyc coverage and browser hooks were reviewed and exercised. NYC retains compatible js-yaml 3 and Mocha uses 5.4.1. Webpack CLI receives optional v4 with peer resolution enabled; legacy peer installations omit it. JavaScript builds do not require that optional parser. Preserve the older consumers' security checks and explicitly test v5's default YAML 1.2 behavior. Contributors using private YAML merge-key configurations must flatten them or use JavaScript configuration; Nightscout's scripts do not depend on them.

A separate commit reviews and retains test-only xml2js 0.5.0. Latest 0.6.2 inserts inherited Object/Object.prototype values into constructor/__proto__ XML fields, reproduced on Node 22/24 and matching upstream #719. New tests protect scalar/array/attribute data, prototype-named fields, malformed/entity rejection and parser recovery. No global prototype-pollution exploit is claimed. No XML manifest/lockfile change is included.

Validation:

- Clean Node 22 install/build without legacy peer mode; valid full npm tree and zero known audit advisories.
- Mocha backend: Node 22 2,081 passing before the final two runner cases; Node 24 2,083 passing including them, each with one existing pending case and nyc coverage.
- Node 24: 290 dependency cases and 283 client-core cases; Node 22: 574 Chromium browser cases.
- Added XML retention coverage: 17 focused XML/renderer/runner cases on both Nodes. Final dependency suites: Node 22 with peers enabled, 294 passing; Node 24 with legacy peer mode, 285 passing (nine optional-parser cases absent). YAML configuration tests require a clear error without the optional parser and a successful real build when it is installed. The first hosted run exposed this install-mode difference; the corrected legacy-mode Node 24 full backend run passes 2,078 tests with one existing pending case and nyc coverage. Current-head hosted CI remains required.
- Application lint: zero errors, 16 existing warnings. No application source changes.
- All 276 production lock entries and six production application bundles are unchanged. Development package paths fall 832 -> 792; regular package-owned files shrink by 9,362,656 bytes. No server RAM, image-size or build-time saving claimed.

Both reviews are documented in the modernization plan, including compatibility decisions, measured scope and rollback. Refresh against the current integration base and verify all CI/browser artifacts and the actual merge tree before integration. M09's remaining dependency/override reviews stay open.
