### PR TITLE
Upgrade Swagger UI and reduce documentation middleware heap

### DIFF
--- a/docs/audits/swagger-middleware-heap.json
+++ b/docs/audits/swagger-middleware-heap.json
@@ -1,0 +1,296 @@
+[
+  {
+    "node": "v22.23.2",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11473920,
+    "rssDelta": 42860544,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 0
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1543632,
+    "rssDelta": 4521984,
+    "retainedBrowserBundles": [],
+    "cycle": 0
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11472800,
+    "rssDelta": 44122112,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 1
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1541520,
+    "rssDelta": 4472832,
+    "retainedBrowserBundles": [],
+    "cycle": 1
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11472056,
+    "rssDelta": 42795008,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 2
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1543632,
+    "rssDelta": 4931584,
+    "retainedBrowserBundles": [],
+    "cycle": 2
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11472632,
+    "rssDelta": 43433984,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 3
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1543632,
+    "rssDelta": 5029888,
+    "retainedBrowserBundles": [],
+    "cycle": 3
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11472728,
+    "rssDelta": 44122112,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 4
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1543632,
+    "rssDelta": 5259264,
+    "retainedBrowserBundles": [],
+    "cycle": 4
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11472728,
+    "rssDelta": 43188224,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 5
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1543632,
+    "rssDelta": 4816896,
+    "retainedBrowserBundles": [],
+    "cycle": 5
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11470752,
+    "rssDelta": 43909120,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 6
+  },
+  {
+    "node": "v22.23.2",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1543632,
+    "rssDelta": 5128192,
+    "retainedBrowserBundles": [],
+    "cycle": 6
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11764008,
+    "rssDelta": 34045952,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 0
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1555008,
+    "rssDelta": 5193728,
+    "retainedBrowserBundles": [],
+    "cycle": 0
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11770424,
+    "rssDelta": 33406976,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 1
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1556272,
+    "rssDelta": 5046272,
+    "retainedBrowserBundles": [],
+    "cycle": 1
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11770424,
+    "rssDelta": 33456128,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 2
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1554976,
+    "rssDelta": 5046272,
+    "retainedBrowserBundles": [],
+    "cycle": 2
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11770392,
+    "rssDelta": 33751040,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 3
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1555064,
+    "rssDelta": 4751360,
+    "retainedBrowserBundles": [],
+    "cycle": 3
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11771112,
+    "rssDelta": 33390592,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 4
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1555008,
+    "rssDelta": 5079040,
+    "retainedBrowserBundles": [],
+    "cycle": 4
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11770496,
+    "rssDelta": 34078720,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 5
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1556240,
+    "rssDelta": 4767744,
+    "retainedBrowserBundles": [],
+    "cycle": 5
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "4.6.3",
+    "ui": "4.19.1",
+    "heapDelta": 11770464,
+    "rssDelta": 34340864,
+    "retainedBrowserBundles": [
+      "swagger-ui-bundle.js",
+      "swagger-ui-standalone-preset.js"
+    ],
+    "cycle": 6
+  },
+  {
+    "node": "v24.20.0",
+    "wrapper": "5.0.1",
+    "ui": "5.32.15",
+    "heapDelta": 1554976,
+    "rssDelta": 4997120,
+    "retainedBrowserBundles": [],
+    "cycle": 6
+  }
+]

--- a/docs/audits/swagger-package-comparison.json
+++ b/docs/audits/swagger-package-comparison.json
@@ -1,0 +1,38 @@
+[
+  {
+    "root": "modernization-mocha12",
+    "packageBytes": 8677768,
+    "assets": {
+      "swagger-ui-bundle.js": {
+        "raw": 1048219,
+        "gzip9": 326885
+      },
+      "swagger-ui-standalone-preset.js": {
+        "raw": 322770,
+        "gzip9": 103075
+      },
+      "swagger-ui.css": {
+        "raw": 145206,
+        "gzip9": 22225
+      }
+    }
+  },
+  {
+    "root": "modernization-swagger",
+    "packageBytes": 11793971,
+    "assets": {
+      "swagger-ui-bundle.js": {
+        "raw": 1552209,
+        "gzip9": 419362
+      },
+      "swagger-ui-standalone-preset.js": {
+        "raw": 267624,
+        "gzip9": 80071
+      },
+      "swagger-ui.css": {
+        "raw": 185784,
+        "gzip9": 26716
+      }
+    }
+  }
+]

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -149,6 +149,12 @@ xml2js 0.5.0: latest 0.6.2 inserts inherited objects/functions into prototype-na
 XML fields on Node 22/24. New regression coverage records the required data
 contract; reconsider a published fix or separately evaluated replacement.
 
+The [Swagger review](../test-specs/swagger-modernization.md) upgrades the docs UI,
+fixes cross-schema initializer state and avoids evaluating browser bundles in
+Node. Isolated middleware retained heap falls about 9.5–9.7 MiB; package and
+documentation-download sizes increase. Installation analytics are disabled.
+Other M09 dependency/override audit work remains open.
+
 ## Phase 3 — reduce production installation and browser cost
 
 - [ ] **M10 — Separate build from runtime dependencies** (after M01; coordinate with M07 and M11 to avoid lockfile overlap).

--- a/docs/test-specs/swagger-modernization.md
+++ b/docs/test-specs/swagger-modernization.md
@@ -1,0 +1,83 @@
+# Swagger UI maintenance and server loading (M09 partial)
+
+Upgrade swagger-ui-express 4.6.3 to 5.0.1 and swagger-ui-dist 4.19.1 to
+5.32.15, the latest published npm releases checked on 2026-09-06. The wrapper's
+GitHub releases also list 5.0.2, but npm's versions and latest tag stop at 5.0.1;
+do not substitute an unpublished artifact. Review sources:
+[wrapper changes](https://github.com/scottie1984/swagger-ui-express/compare/4.6.3...5.0.1),
+[UI 5 release](https://github.com/swagger-api/swagger-ui/releases/tag/v5.0.0) and
+[UI 5.32.15](https://github.com/swagger-api/swagger-ui/releases/tag/v5.32.15).
+UI 5 supports the existing OpenAPI 3.0 documents; the specifications and API
+request/response contracts are unchanged.
+
+The wrapper now imports the absolute-path helper directly. Version 4 required
+the distribution's main module, which evaluated both browser bundles inside
+Node just to obtain their filesystem path. The new consumer test verifies that
+loading the real server docs middleware does not evaluate either browser bundle.
+
+Also fix a reproduced existing route-isolation bug: HTML requests for v1 then
+v3 followed by the v1 initializer returned the v3 schema. Register each document
+with serveFiles(schema) and setup(schema), so each mount owns its initializer.
+The small api-docs module is the production registration used by the fixtures.
+Preserve /api-docs, /api3-docs and both legacy redirect contracts.
+
+Validation covers:
+
+- Interleaved HTML/initializer requests for both complete real specifications,
+  static assets, trailing-slash redirects and package-metadata rejection.
+- Actual server docs routes and legacy redirects in the existing production/
+  development HTTP-contract fixture.
+- Real Chromium/WebKit authentication dialogs and two read-only status requests
+  per API, requiring the expected Bearer header at a disposable loopback server.
+  External browser requests are blocked and unexpected attempts fail the tests.
+- Nightscout's actual enforced CSP, retrieved from the app factory; mobile-width
+  authorization, keyboard operation and light/dark theme controls.
+- Existing full backend/browser suites and current-head hosted gates before merge.
+
+Local results: Node 22 backend 2,089 passing before the final two consumer
+checks; Node 24 backend 2,090 before the final analytics check, each with one
+existing pending case. All four final consumer checks pass on both Nodes; full
+Node 22 Chromium passes 577 cases. Focused WebKit checks pass for authentication,
+CSP and mobile controls. Clean install/build, application lint (zero errors,
+16 existing warnings) and full npm audit (zero known advisories) pass. Hosted
+checks must cover the final combined head before merge.
+
+The new distribution declares @scarf/scarf 1.4.0 for installation analytics.
+Disable it project-wide using scarfSettings.enabled=false, the
+[supported opt-out](https://docs.scarf.sh/package-analytics/). A child-process test
+runs the installed reporter with the real dependency tree/root manifest and
+requires its disabled result before any HTTP(S) request; network attempts are
+intercepted and fail. This package remains declared upstream and is not used by
+Nightscout's request handlers. Do not add a fake replacement or force an unrelated
+package version merely to hide a dependency path.
+
+Measurements:
+
+- Seven fresh processes per version and Node floor, each registering both docs
+  and serving two cycles of HTML/initializer requests, followed by server close
+  and GC. Median incremental heap falls 11,472,728 -> 1,543,632 bytes on Node 22
+  and 11,770,424 -> 1,555,008 on Node 24: approximately **9.5–9.7 MiB less retained
+  heap in this isolated middleware workload**. This is not a whole-server,
+  container, or production-memory measurement. RSS is recorded but is noisier.
+  [Raw trials](../audits/swagger-middleware-heap.json); reproduce with
+  `node --expose-gc tools/audits/swagger-middleware-probe.cjs /path/to/checkout`.
+- The two packages plus newly declared Scarf grow 8,677,768 -> 11,832,618 regular
+  file bytes, excluding symlinks and nested node_modules: **3,154,850 more bytes**.
+  Production package paths increase 276 -> 277. Only these three production
+  package entries change; no unrelated production version is updated.
+- Main documentation JS/CSS gzip level 9 totals rise 452,185 -> 526,149 bytes:
+  **73,964 more bytes**. This is a matched asset-compression comparison, not an
+  exact HTTP transfer measurement. [Asset/package details](../audits/swagger-package-comparison.json)
+  cover the two Swagger packages; Scarf contributes a further 38,647 file bytes.
+- All six Nightscout application/page JavaScript bundles remain byte-identical.
+
+Visual comparison at 1280px and 390px shows the new theme control and an explicit
+OAS 3.0 badge. The theme control wraps the mobile header onto another row; code
+and description spacing changes slightly. Documentation content remains readable,
+and tested authorization/execute controls work. Accept these documentation-only
+UI changes if the final browser gates pass. This does not replace physical
+Safari/VoiceOver validation for the modernization release.
+
+No API authentication or deployment-setting migration is introduced. Restore
+manifest/lockfile, route registration and associated consumer tests together to
+roll back. M09's remaining dependency/override audit stays open.

--- a/lib/server/api-docs.js
+++ b/lib/server/api-docs.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const swaggerUi = require('swagger-ui-express');
+
+module.exports = function registerApiDocs(app) {
+  for (const [route, schema] of [
+    ['/api-docs', require('./swagger.json')],
+    ['/api3-docs', require('../api3/swagger.json')]
+  ]) {
+    // Each mount owns its initializer. The shared `serve` middleware uses
+    // mutable module-wide state and can return the other API's schema.
+    app.use(route, swaggerUi.serveFiles(schema), swaggerUi.setup(schema));
+  }
+  app.use('/swagger-ui-dist', (req, res) => res.redirect(307, '/api-docs'));
+};

--- a/lib/server/app.js
+++ b/lib/server/app.js
@@ -315,17 +315,7 @@ function create (env, ctx) {
 
   // API docs
 
-  const swaggerUi = require('swagger-ui-express');
-  const swaggerUseSchema = schema => (...args) => swaggerUi.setup(schema)(...args);
-  const swaggerDocument = require('./swagger.json');
-  const swaggerDocumentApiV3 = require('../api3/swagger.json');
-
-  app.use('/api-docs', swaggerUi.serve, swaggerUseSchema(swaggerDocument));
-  app.use('/api3-docs', swaggerUi.serve, swaggerUseSchema(swaggerDocumentApiV3));
-
-  app.use('/swagger-ui-dist', (req, res) => {
-    res.redirect(307, '/api-docs');
-  });
+  require('./api-docs')(app);
 
   // if this is dev environment, package scripts on the fly
   // if production, rely on postinstall script to run packaging for us

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,8 @@
         "shiro-trie": "^0.4.9",
         "socket.io": "~4.8.3",
         "socks": "2.8.10",
-        "swagger-ui-dist": "^4.13.2",
-        "swagger-ui-express": "^4.5.0"
+        "swagger-ui-dist": "5.32.15",
+        "swagger-ui-express": "5.0.1"
       },
       "devDependencies": {
         "@babel/core": "^8.0.1",
@@ -3244,6 +3244,13 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@smithy/core": {
       "version": "3.33.3",
@@ -9115,14 +9122,21 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "4.19.1",
-      "license": "Apache-2.0"
+      "version": "5.32.15",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.15.tgz",
+      "integrity": "sha512-TSFER+rFQlf1nzk6WvKkMaHTxAPQ3eAAxigFThnxQedSREanfZgSbJFayZVs/ULnSbNdrJOb99vLD6xpb3R3eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
     },
     "node_modules/swagger-ui-express": {
-      "version": "4.6.3",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
       "license": "MIT",
       "dependencies": {
-        "swagger-ui-dist": ">=4.11.0"
+        "swagger-ui-dist": ">=5.0.0"
       },
       "engines": {
         "node": ">= v0.10.32"

--- a/package.json
+++ b/package.json
@@ -127,8 +127,8 @@
     "shiro-trie": "^0.4.9",
     "socket.io": "~4.8.3",
     "socks": "2.8.10",
-    "swagger-ui-dist": "^4.13.2",
-    "swagger-ui-express": "^4.5.0"
+    "swagger-ui-dist": "5.32.15",
+    "swagger-ui-express": "5.0.1"
   },
   "devDependencies": {
     "@babel/core": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -178,5 +178,8 @@
     "js-yaml@^3.0.0": "3.15.2",
     "js-yaml@^4.0.0": "4.3.2",
     "fast-uri@^3.0.0": "3.1.7"
+  },
+  "scarfSettings": {
+    "enabled": false
   }
 }

--- a/tests/browser/swagger-docs.test.js
+++ b/tests/browser/swagger-docs.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const path = require('node:path');
+const createApp = require('../../lib/server/app');
+const {withPage} = require('./fixture');
+const registerApiDocs = require('../../lib/server/api-docs');
+
+describe('Interactive API documentation', function () {
+  let server, origin;
+  const requests = [];
+  before(async function () {
+    const env = {name: 'owned-swagger', version: 'fixture', trustProxy: '127.0.0.1,::1',
+      insecureUseHttp: true, secureHstsHeader: false, secureCsp: true,
+      secureCspReportOnly: false, allowUnrestrictedFrameEmbedding: true,
+      static_files: path.resolve(__dirname, '../../static'), settings: require('../../lib/settings')()};
+    // Read the actual application's enforced policy without booting a database.
+    const policyResponse = await request(createApp(env, {bootErrors: [{desc: 'fixture', err: 'fixture'}]})).get('/fixture-policy');
+    const policy = policyResponse.headers['content-security-policy'];
+    assert(policy && policy.includes("script-src 'self'"));
+    const app = express();
+    app.use((req, res, next) => {res.set('Content-Security-Policy', policy); next();});
+    registerApiDocs(app);
+    for (const version of ['v1', 'v3']) {
+      app.get('/api/' + version + '/status', (req, res) => {
+        requests.push({version, authorization: req.headers.authorization, secret: req.headers['api-secret']});
+        if (req.headers.authorization !== 'Bearer fixture-token-' + version) return res.status(401).json({error: 'fixture authorization required'});
+        res.json({fixture: version, status: 'ok'});
+      });
+    }
+    server = await new Promise(resolve => {const listening = app.listen(0, '127.0.0.1', () => resolve(listening));});
+    origin = 'http://127.0.0.1:' + server.address().port;
+  });
+  after(async function () {if (server) await new Promise(resolve => server.close(resolve));});
+
+  for (const [route, version] of [['/api-docs/', 'v1'], ['/api3-docs/', 'v3']]) {
+    it('renders and executes owned read-only requests from ' + route + ' twice', async function () {
+      await withPage(origin, async ({page}) => {
+        for (let cycle = 0; cycle < 2; cycle++) {
+          await page.goto(origin + route);
+          await page.waitForFunction(() => window.ui && window.ui.specSelectors.specJson().get('paths'));
+          assert.equal(await page.evaluate(() => window.ui.specSelectors.specJson().getIn(['servers', 0, 'url'])), '/api/' + version);
+          assert.equal(await page.evaluate(() => window.ui.authSelectors.authorized().size), 0);
+          await page.getByRole('button', {name: 'Authorize', exact: true}).first().click();
+          const auth = page.locator('.auth-container').filter({hasText: 'jwtoken'});
+          await auth.locator('input').fill('fixture-token-' + version);
+          await auth.getByRole('button', {name: 'Apply credentials', exact: true}).click();
+          await auth.getByRole('button', {name: 'Close', exact: true}).click();
+          const operation = page.locator('.opblock').filter({has: page.locator('.opblock-summary-path[data-path="/status"]')});
+          assert.equal(await operation.count(), 1);
+          await operation.locator('.opblock-summary-control').click();
+          await operation.getByRole('button', {name: 'Try it out'}).click();
+          const response = page.waitForResponse(response => response.url() === origin + '/api/' + version + '/status');
+          await operation.getByRole('button', {name: 'Execute', exact: true}).click();
+          assert.deepEqual(await (await response).json(), {fixture: version, status: 'ok'});
+          await operation.locator('.responses-inner').getByText('"fixture"', {exact: false}).first().waitFor();
+        }
+      });
+      const observed = requests.filter(request => request.version === version);
+      assert.equal(observed.length, 2);
+      assert(observed.every(request => request.authorization === 'Bearer fixture-token-' + version));
+    });
+  }
+  it('keeps mobile authorization controls visible and keyboard-operable for both schemas', async function () {
+    await withPage(origin, async ({page}) => {
+      await page.setViewportSize({width: 390, height: 844});
+      for (const route of ['/api-docs/', '/api3-docs/']) {
+        await page.goto(origin + route);
+        const open = page.getByRole('button', {name: 'Authorize', exact: true}).first();
+        await open.focus();
+        await page.keyboard.press('Enter');
+        const auth = page.locator('.auth-container').filter({hasText: 'jwtoken'});
+        await auth.locator('input').fill('fixture-mobile-token');
+        const apply = auth.getByRole('button', {name: 'Apply credentials', exact: true});
+        await apply.scrollIntoViewIfNeeded();
+        const bounds = await apply.boundingBox();
+        assert(bounds && bounds.x >= 0 && bounds.x + bounds.width <= 390);
+        await apply.focus();
+        await page.keyboard.press('Enter');
+        const close = auth.getByRole('button', {name: 'Close', exact: true});
+        await close.focus();
+        await page.keyboard.press('Enter');
+        await page.locator('.modal-ux').waitFor({state: 'hidden'});
+        assert.equal(await page.evaluate(() => window.ui.authSelectors.authorized().getIn(['jwtoken', 'value'])), 'fixture-mobile-token');
+      }
+    });
+  });
+
+});

--- a/tests/browser/swagger-docs.test.js
+++ b/tests/browser/swagger-docs.test.js
@@ -68,6 +68,13 @@ describe('Interactive API documentation', function () {
       await page.setViewportSize({width: 390, height: 844});
       for (const route of ['/api-docs/', '/api3-docs/']) {
         await page.goto(origin + route);
+        const title = page.locator('.info .title');
+        await title.waitFor();
+        const lightColor = await title.evaluate(element => getComputedStyle(element).color);
+        await page.getByRole('button', {name: 'Switch to dark mode'}).click();
+        await page.waitForFunction(color => getComputedStyle(document.querySelector('.info .title')).color !== color, lightColor);
+        await page.getByRole('button', {name: 'Switch to light mode'}).click();
+        await page.waitForFunction(color => getComputedStyle(document.querySelector('.info .title')).color === color, lightColor);
         const open = page.getByRole('button', {name: 'Authorize', exact: true}).first();
         await open.focus();
         await page.keyboard.press('Enter');

--- a/tests/dependency-swagger.test.js
+++ b/tests/dependency-swagger.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const express = require('express');
+const request = require('supertest');
+const registerApiDocs = require('../lib/server/api-docs');
+
+function configuredSchema(source) {
+  let configuration;
+  const bundle = config => {configuration = config; return {};};
+  bundle.presets = {apis: {}};
+  bundle.plugins = {DownloadUrl: {}};
+  const context = {window: {location: {search: '', origin: 'http://127.0.0.1'}},
+    SwaggerUIBundle: bundle, SwaggerUIStandalonePreset: {}};
+  vm.runInNewContext(source, context, {timeout: 1000});
+  context.window.onload();
+  return JSON.parse(JSON.stringify(configuration.spec));
+}
+
+describe('Swagger documentation route isolation', function () {
+  const app = express();
+  registerApiDocs(app);
+  const documents = [
+    ['/api-docs', require('../lib/server/swagger.json')],
+    ['/api3-docs', require('../lib/api3/swagger.json')]
+  ];
+  it('preserves each schema when HTML and initializer requests interleave', async function () {
+    for (let cycle = 0; cycle < 2; cycle++) {
+      await Promise.all(documents.map(([route]) => request(app).get(route + '/').expect(200)));
+      for (const [route, schema] of documents.slice().reverse()) {
+        const response = await request(app).get(route + '/swagger-ui-init.js').expect(200);
+        assert.deepEqual(configuredSchema(response.text), schema);
+      }
+    }
+  });
+  it('serves assets and redirects legacy docs while refusing package metadata', async function () {
+    await request(app).get('/swagger-ui-dist').expect(307).expect('Location', '/api-docs');
+    for (const [route] of documents) {
+      await request(app).get(route).expect(301);
+      await request(app).get(route + '/swagger-ui.css').expect(200).expect('Content-Type', /text\/css/);
+      const response = await request(app).get(route + '/swagger-ui-bundle.js').expect(200);
+      assert(response.text.includes('SwaggerUIBundle'));
+      await request(app).get(route + '/package.json').expect(404);
+    }
+  });
+});

--- a/tests/dependency-swagger.test.js
+++ b/tests/dependency-swagger.test.js
@@ -2,6 +2,8 @@
 
 const assert = require('node:assert/strict');
 const vm = require('node:vm');
+const {execFileSync} = require('node:child_process');
+const path = require('node:path');
 const express = require('express');
 const request = require('supertest');
 const registerApiDocs = require('../lib/server/api-docs');
@@ -33,6 +35,31 @@ describe('Swagger documentation route isolation', function () {
         assert.deepEqual(configuredSchema(response.text), schema);
       }
     }
+  });
+  it('loads server documentation middleware without evaluating browser bundles', function () {
+    const output = execFileSync(process.execPath, ['-e', `
+      require(process.argv[1]);
+      process.stdout.write(JSON.stringify(Object.keys(require.cache).filter(file =>
+        /swagger-ui-(bundle|standalone-preset)\\.js$/.test(file))));
+    `, require.resolve('../lib/server/api-docs')], {encoding: 'utf8', timeout: 5000});
+    assert.deepEqual(JSON.parse(output), []);
+  });
+  it('honors the project installation-analytics opt-out before making a request', function () {
+    this.timeout(10000);
+    const root = path.resolve(__dirname, '..');
+    const env = {INIT_CWD: root, PATH: process.env.PATH, HOME: process.env.HOME,
+      npm_execpath: path.resolve(path.dirname(process.execPath), '../lib/node_modules/npm/bin/npm-cli.js')};
+    execFileSync(process.execPath, ['-e', `
+      const assert = require('node:assert/strict');
+      let requests = 0;
+      const deny = () => {requests++; throw new Error('Unexpected analytics request');};
+      require('node:https').request = deny;
+      require('node:http').request = deny;
+      const scarf = require(process.argv[1]);
+      assert.rejects(scarf.reportPostInstall(), /opted out|disabled/i).then(() => {
+        assert.equal(requests, 0);
+      }).catch(error => {console.error(error); process.exitCode = 1;});
+    `, require.resolve('@scarf/scarf')], {cwd: root, env, encoding: 'utf8', timeout: 8000});
   });
   it('serves assets and redirects legacy docs while refusing package metadata', async function () {
     await request(app).get('/swagger-ui-dist').expect(307).expect('Location', '/api-docs');

--- a/tests/fixtures/http-assets/worker.js
+++ b/tests/fixtures/http-assets/worker.js
@@ -83,6 +83,13 @@ async function run() {
   const app = createApp(env, ctx);
   app.locals.cachebuster = 'http-contract';
   const client = await serve(app);
+  for (const [route, apiPath] of [['/api-docs/', '/api/v1'], ['/api3-docs/', '/api/v3']]) {
+    await client.get(route).expect(200).expect('Content-Type', /text\/html/);
+    const init = await client.get(route + 'swagger-ui-init.js').expect(200);
+    assert.ok(init.text.includes('"url": "' + apiPath + '"'), route + ' keeps its own API schema');
+  }
+  await client.get('/swagger-ui-dist/').expect(307).expect('Location', '/api-docs');
+  await client.get('/api/v3/swagger-ui-dist/').expect(307).expect('Location', '../../../api3-docs');
   const bundlePrefix = development ? '/devbundle' : '/bundle';
   const results = [];
   const sources = [

--- a/tools/audits/swagger-middleware-probe.cjs
+++ b/tools/audits/swagger-middleware-probe.cjs
@@ -1,0 +1,35 @@
+'use strict';
+
+// Usage: node --expose-gc tools/audits/swagger-middleware-probe.cjs /path/to/checkout
+// Fresh-process comparison of the real docs middleware. Only an ephemeral
+// loopback server is used; this does not start Nightscout or access MongoDB.
+const path = require('node:path');
+const {createRequire} = require('node:module');
+const root = process.argv[2];
+const load = createRequire(path.join(root, 'package.json'));
+const express = load('express');
+const http = require('node:http');
+async function settle() {await new Promise(resolve => setImmediate(resolve)); for(let i=0;i<3;i++) global.gc();}
+(async () => {
+ if (typeof global.gc !== 'function') throw new Error('Run with --expose-gc');
+ await settle();
+ const before = process.memoryUsage();
+ const app = express();
+ const ui = load('swagger-ui-express');
+ const v1 = load('./lib/server/swagger.json'), v3 = load('./lib/api3/swagger.json');
+ if (load('swagger-ui-express/package.json').version.startsWith('5.')) load('./lib/server/api-docs')(app);
+ else for (const [route, schema] of [['/api-docs',v1],['/api3-docs',v3]]) app.use(route,ui.serve,(...args)=>ui.setup(schema)(...args));
+ const server = await new Promise(resolve => {const s=app.listen(0,'127.0.0.1',()=>resolve(s));});
+ try {
+ for(let cycle=0;cycle<2;cycle++) for(const route of ['/api-docs/','/api3-docs/']) for(const suffix of ['', 'swagger-ui-init.js']) {
+  await new Promise((resolve,reject)=>{http.get({hostname:'127.0.0.1',port:server.address().port,path:route+suffix,agent:false},res=>{res.resume();res.on('end',resolve);res.on('error',reject)}).on('error',reject)});
+ }
+ } finally {
+  await new Promise(resolve=>server.close(resolve));
+ }
+ await settle();
+ const after=process.memoryUsage();
+ console.log(JSON.stringify({node:process.version,wrapper:load('swagger-ui-express/package.json').version,
+  ui:load('swagger-ui-dist/package.json').version,heapDelta:after.heapUsed-before.heapUsed,rssDelta:after.rss-before.rss,
+  retainedBrowserBundles:Object.keys(require.cache).filter(x=>/swagger-ui-(bundle|standalone-preset)\.js$/.test(x)).map(x=>path.basename(x))}));
+})().catch(e=>{console.error(e);process.exitCode=1});


### PR DESCRIPTION
Upgrade API documentation to swagger-ui-express 5.0.1 and swagger-ui-dist 5.32.15. The new wrapper stops evaluating browser bundles inside Node just to find their filesystem path. Also fix a reproduced existing bug where opening v1 and v3 docs could make the v1 initializer return the v3 schema: each route now owns its initializer through serveFiles(schema).

This M09 child targets chore/nightscout-modernization; #8605 remains draft. API specifications, authentication handlers and six application/page bundles are unchanged. Both legacy docs redirects are preserved. GitHub lists wrapper 5.0.2, but npm has not published it; 5.0.1 is the highest published npm release checked.

Validation:

- Interleaved real-schema initializer tests, asset/redirect checks and actual production/development server-route coverage.
- Chromium and WebKit exercise authorization and two owned read-only requests per API under the actual enforced CSP; mobile keyboard controls and theme switching have coverage. Full Chromium: 577 passing.
- Node 22 backend: 2,089 passing before the final two consumer checks; Node 24: 2,090 before the final analytics check, each with one existing pending case. All four final consumer checks pass on both Nodes. Final combined hosted CI remains required before merge.
- Clean install/build, zero lint errors (16 existing warnings), zero known npm audit advisories. Both desktop/mobile screenshots were visually reviewed.

Measured tradeoffs:

- Seven fresh processes per Node floor show about 9.5–9.7 MiB less retained heap in the isolated docs middleware workload. This is not a whole-server/container memory claim. Raw trials and a reproducible probe are included.
- Production package paths increase 276 -> 277; the Swagger pair plus Scarf grows by 3,154,850 installed file bytes. Main docs JS/CSS increases 73,964 bytes at gzip level 9. All six application/page JavaScript bundles remain byte-identical.
- Swagger introduces an install-time Scarf dependency. Project-wide analytics are explicitly disabled through its supported setting; a real reporter/dependency-tree test requires the disabled result before any HTTP(S) request.

UI assessment: the docs gain a theme control and explicit OAS 3.0 badge, with minor spacing changes and an extra mobile header row. Content remains readable and the tested controls work. No Nightscout dashboard interaction change is intended. Documentation records API review, measurements, validation limits and rollback. The remaining M09 override/reachability audit is still open.
