### PR TITLE
Refresh remaining compatible transitives and finish M09 review

### DIFF
--- a/docs/audits/m09-final-inventory.json
+++ b/docs/audits/m09-final-inventory.json
@@ -1,0 +1,57 @@
+{
+  "reviewDate": "2026-09-06",
+  "lockfileSha256": "376a459f3e505df6fb88524018d6095a7c6638dced2bc72cc7c0fa1179b88ceb",
+  "compatibleTransitiveUpdates": [],
+  "remainingOutdatedEntryCount": 157,
+  "interpretation": "Remaining entries advertise newer majors outside current parent ranges, or deliberate root holds. This is not a claim that every major upgrade has been implemented.",
+  "directHolds": {
+    "flot": "M28 browser widget migration",
+    "jquery": "M28 browser widget migration",
+    "node-cache": "M25 cache replacement",
+    "xml2js": "0.6.2 has reproduced data-preservation regression; retain 0.5.0"
+  },
+  "fullAudit": {
+    "auditReportVersion": 2,
+    "vulnerabilities": {},
+    "metadata": {
+      "vulnerabilities": {
+        "info": 0,
+        "low": 0,
+        "moderate": 0,
+        "high": 0,
+        "critical": 0,
+        "total": 0
+      },
+      "dependencies": {
+        "prod": 278,
+        "dev": 516,
+        "optional": 3,
+        "peer": 1,
+        "peerOptional": 0,
+        "total": 793
+      }
+    }
+  },
+  "productionAudit": {
+    "auditReportVersion": 2,
+    "vulnerabilities": {},
+    "metadata": {
+      "vulnerabilities": {
+        "info": 0,
+        "low": 0,
+        "moderate": 0,
+        "high": 0,
+        "critical": 0,
+        "total": 0
+      },
+      "dependencies": {
+        "prod": 278,
+        "dev": 516,
+        "optional": 3,
+        "peer": 1,
+        "peerOptional": 0,
+        "total": 793
+      }
+    }
+  }
+}

--- a/docs/audits/m09-transitive-package-comparison.json
+++ b/docs/audits/m09-transitive-package-comparison.json
@@ -1,0 +1,30 @@
+[
+  {
+    "package": "dayjs",
+    "before": "1.11.20",
+    "after": "1.11.23",
+    "bytesBefore": 680073,
+    "bytesAfter": 681693
+  },
+  {
+    "package": "es-module-lexer",
+    "before": "2.1.0",
+    "after": "2.3.2",
+    "bytesBefore": 100716,
+    "bytesAfter": 175452
+  },
+  {
+    "package": "extsprintf",
+    "before": "1.3.0",
+    "after": "1.4.1",
+    "bytesBefore": 22806,
+    "bytesAfter": 30346
+  },
+  {
+    "package": "serialize-javascript",
+    "before": "7.0.5",
+    "after": "7.1.1",
+    "bytesBefore": 19174,
+    "bytesAfter": 22279
+  }
+]

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -136,7 +136,7 @@ The [CLI/analyzer review](../test-specs/webpack-cli-analyzer.md) upgrades the
 build commands to CLI 7.2.3 and analyzer 5.3.2, preserves resource-limit tests
 and adds real command/report regression coverage. Production lock entries and
 application bundles are unchanged; development package bytes increase despite
-six fewer paths. 
+six fewer paths.
 The [Mocha 12 review](../test-specs/mocha12-modernization.md) adopts native Node
 argument parsing, removes two redundant runner overrides and 40 package paths.
 Runner failure/reporting, YAML defaults and retained parser security contracts

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -76,24 +76,24 @@ At the audit baseline, completed foundations were: D3 7.9.0, jsdom-backed test t
 
   Other files: manifests, `.babelrc`, webpack rules and `tests/dependency-{babel,uuid}.test.js`. Review required Babel/preset/loader and UUID releases, engine ranges, CommonJS/ESM loading and API changes before installing them. Babel must preserve supported-browser transforms/build output; UUID must preserve deterministic v5 vectors, persisted identifiers and duplicate upload/update cycles. Native random UUID v4 is not a replacement. Test exact supported runtime floors and full CI. A higher Node floor enables review, not automatic major-version compatibility.
 
-- [ ] **M09 — Review remaining maintained releases and security overrides** (after M07 where runtime requires it; ongoing).
+- [x] **M09 — Review remaining maintained releases and security overrides** (review and compatible updates complete in the final integration tree).
   Files: manifests, each actual consumer and `tests/dependency-*.test.js`. Re-run production/full audits and `npm explain`; track each finding as reachable, build/test-only, mitigated or awaiting upstream work, with evidence. Prioritize reachable issues and unmaintained transitive chains; review Express/Helmet, MongoDB, loaders/lint/build tools and providers independently.
   Acceptance: highest compatible release per consumer, focused exploit/API regression where relevant, full CI and explicit engine/browser/DB compatibility. Remove an override only after every affected parent resolves safely. Do not use forced audit fixes or a bulk latest-version update; keep Dependabot's current target configuration.
-  The [remaining override review](../test-specs/m09-override-review.md) verifies parent ranges, reviews Ajv/flatted fixes and retains shiro-trie. Its child CI and final inventory reconciliation remain pending.
-  The [webpack/HMR refresh](../test-specs/webpack-refresh.md) removes a separate hot-middleware dependency using the maintained development middleware, with repeated update/error recovery coverage and explicit installed/browser size costs. It does not complete the remaining dependency reviews.
+  The [final compatible transitive review](../test-specs/m09-transitive-refresh.md) covers Day.js under launder, webpack's module lexer, APNs error formatting and Mocha serialization. Its final inventory records no further updates within declared consumer ranges and zero known full/production npm advisories. Final child CI and merge verification are required before accepting this completion update.
+  The [remaining override review](../test-specs/m09-override-review.md) verifies parent ranges, reviews Ajv/flatted fixes and retains shiro-trie. The lockfile preserves patched versions without forced resolution. Cache/date/widget migrations retain their separate M25/M27/M28 scope; xml2js remains an explicit compatibility hold.
+  The [webpack/HMR refresh](../test-specs/webpack-refresh.md) removes a separate hot-middleware dependency using the maintained development middleware, with repeated update/error recovery coverage and explicit installed/browser size costs.
   The [ESLint refresh](../test-specs/eslint-modernization.md) replaces the webpack wrapper with a scoped public-API integration, preserves the prior non-blocking development policy, and records the remaining CLI diagnostics for separate cleanup. Production dependencies and bundle bytes are unchanged.
   The [application lint cleanup](../test-specs/lint-cleanup.md) establishes a zero-error baseline and adds lint to one existing CI matrix job; sixteen security warnings remain for targeted review. The API3 alarm credential-log fix merged in #8688; it is no longer pending.
 
 The [MIME and jQuery exposure review](../test-specs/mime-jquery-exposure.md) consolidates
 API lookup on existing mime-types and replaces expose-loader with a browser
-bootstrap. M09 remains open for other dependency and override reviews.
+bootstrap.
 
 The [Helmet review](../test-specs/helmet-modernization.md) merged in #8696
 as `19bd2191`, with all required CI passing and an independently verified merge
 tree. Helmet 8.3 preserves existing CSP/HSTS/embedding policies; only obsolete
 Expect-CT is retired. The [Express 5 review](../test-specs/express5-modernization.md)
 covers request parsing, mutable filters, route syntax and MIME negotiation.
-Remaining dependency and override reviews keep M09 open.
 
 The [SASLprep review](../test-specs/saslprep-modernization.md) removes its redundant
 root declaration because driver 7.6 declares it as required, resolves 1.5.0,
@@ -113,7 +113,6 @@ The [entities consolidation](../test-specs/entities-consolidation.md) upgrades t
 shared decoder to 8.0.0 and consolidates three installed copies into one, without
 an override. HTML decoding/escaping and sanitization remain required; measured
 package files shrink by 776,553 bytes, with no runtime memory-saving claim.
-This scoped review does not complete M09.
 
 The [mime-types maintenance review](../test-specs/mime-types-upgrade.md) aligns
 direct lookup with Express's 3.0.2 release and preserves v1 JavaScript status
@@ -125,25 +124,23 @@ The [APNs provider review](../test-specs/apn-upgrade.md) moves to 8.1.0, removes
 five duplicate dependency paths and the redundant node-forge override. Owned
 TLS/HTTP2 tests cover actual signed Loop requests, retries, failure handling and
 session/timer cleanup. The published package files grow slightly; no RAM-saving
-claim is made. Remaining M09 reviews stay open.
+claim is made.
 
 The [native Pushover transport](../test-specs/pushover-native-transport.md) removes
 pushover-notifications and preserves message/receipt contracts using Node HTTPS.
 Owned TLS tests cover encoding, cancellation, failure classification, deadlines
 and cleanup. Package plus runtime source decreases by 22,575 bytes; no measured
-RAM saving is claimed. This does not complete the remaining M09 reviews.
+RAM saving is claimed.
 
 The [CLI/analyzer review](../test-specs/webpack-cli-analyzer.md) upgrades the
 build commands to CLI 7.2.3 and analyzer 5.3.2, preserves resource-limit tests
 and adds real command/report regression coverage. Production lock entries and
 application bundles are unchanged; development package bytes increase despite
-six fewer paths. Remaining dependency and override reviews keep M09 open.
-
+six fewer paths. 
 The [Mocha 12 review](../test-specs/mocha12-modernization.md) adopts native Node
 argument parsing, removes two redundant runner overrides and 40 package paths.
 Runner failure/reporting, YAML defaults and retained parser security contracts
 have consumer coverage; production dependencies and bundles remain unchanged.
-Other M09 dependency and override reviews remain open.
 
 The [XML parser review](../test-specs/xml-parser-review.md) retains test-only
 xml2js 0.5.0: latest 0.6.2 inserts inherited objects/functions into prototype-named
@@ -154,7 +151,6 @@ The [Swagger review](../test-specs/swagger-modernization.md) upgrades the docs U
 fixes cross-schema initializer state and avoids evaluating browser bundles in
 Node. Isolated middleware retained heap falls about 9.5–9.7 MiB; package and
 documentation-download sizes increase. Installation analytics are disabled.
-Other M09 dependency/override audit work remains open.
 
 ## Phase 3 — reduce production installation and browser cost
 

--- a/docs/test-specs/m09-transitive-refresh.md
+++ b/docs/test-specs/m09-transitive-refresh.md
@@ -1,0 +1,69 @@
+# Final compatible transitive refresh (M09)
+
+Reviewed 2026-09-06 after the override audit. `npm outdated --all` identified four
+remaining updates within their actual parents' declared ranges. Only these four
+lock entries change; no new dependency declaration or override is added.
+
+| Package | Before → after | Actual parent / reason to retain |
+| --- | --- | --- |
+| dayjs | 1.11.20 → 1.11.23 | launder ^1.11.7, via sanitize-html; do not rewrite an upstream dependency locally |
+| es-module-lexer | 2.1.0 → 2.3.2 | webpack ^2.1.0; native Node does not expose an equivalent static import/export lexer |
+| extsprintf | 1.3.0 → 1.4.1 | verror ^1.2.0, via APNs; preserve upstream formatting/error contracts |
+| serialize-javascript | 7.0.5 → 7.1.1 | Mocha ^7.0.2; JSON cannot preserve executable test/hook functions |
+
+## Reviewed changes and regression coverage
+
+[Day.js comparison](https://github.com/iamkun/dayjs/compare/v1.11.20...v1.11.23):
+year-token preservation and timezone-plugin DST/invalid-value fixes. Launder
+loads the core package, not the timezone plugin. Nightscout's sanitizer uses
+launder's static URL predicate; it does not invoke its date helpers. Tests retain
+actual sanitization behavior and smoke-test the parent's local date/time helpers.
+This does not choose Day.js for M27 or migrate Moment, timezone data or therapy
+calculations.
+
+[Lexer comparison](https://github.com/guybedford/es-module-lexer/compare/2.1.0...2.3.2):
+correct template-string dynamic import names, export binding enumeration and
+methods named `import`; grow WASM memory for large sources and improve scanning.
+A consumer-resolved test parses a source larger than 5 MiB with multiple exports,
+a template import and an ordinary import-named method. Real production builds
+and existing development/build-tool tests remain required.
+
+[extsprintf comparison](https://github.com/davepacheco/node-extsprintf/compare/v1.3.0...v1.4.1):
+more informative malformed-format errors. The APNs-resolved VError regression
+preserves valid Unicode/string/integer/percent formatting, cause identity, name
+and metadata. Do not replace the upstream formatter with native util.format:
+the supported formats and invalid-input behavior differ. Existing owned TLS/APNs
+transport tests remain required.
+
+[Serializer comparison](https://github.com/yahoo/serialize-javascript/compare/v7.0.5...v7.1.1):
+reject non-string URL/RegExp representations and escape script-closing prefixes
+split across serialized function bodies. Tests resolve the actual Mocha copy,
+reject these malformed values without coercion, reject HTML end-tag prefixes in
+serialized output, and execute only owned fixture functions to verify preserved
+results and comparison syntax. Existing serial/parallel Mocha hook and failure
+coverage remains required. Upstream documents heuristic parsing limitations;
+this is not a new application HTML templating mechanism or a claim that arbitrary
+untrusted function serialization is safe. Mocha/lexer are build/test-only paths.
+
+## Costs and validation
+
+[Matched package-owned file measurements](../audits/m09-transitive-package-comparison.json):
+Day.js +1,620 bytes, extsprintf +7,540 bytes (production); lexer +74,736 bytes and
+serializer +3,105 bytes (development). No package paths are removed. All six
+application JavaScript bundles are byte-identical to the preceding override
+candidate. There is no claimed runtime-memory or UI improvement.
+
+Node 22 passes 305 dependency and 2,098 backend tests (one existing pending).
+A clean Node 24/npm 12 installation passes 296 dependency cases; optional CLI
+YAML is absent in that mode. Full backend coverage on both Nodes and hosted CI
+are merge gates. The [final inventory](../audits/m09-final-inventory.json) records
+zero known full/production advisories and no remaining updates within consumer
+ranges at the time of review.
+The environment matrix and Node/MongoDB compatibility floors do not change.
+
+After these updates, remaining direct major-version choices are flot/jQuery
+(M28), node-cache (M25), and the documented xml2js 0.5.0 retention decision.
+M27 continues to compare Moment/native Intl/Luxon/Day.js. Do not force transitive
+major upgrades outside their owning consumers' ranges to make an outdated list
+empty. This final child proposes closing M09 after its hosted CI and actual merge are
+verified. Release-wide validation and the draft #8605 merge remain separate.

--- a/docs/test-specs/m09-transitive-refresh.md
+++ b/docs/test-specs/m09-transitive-refresh.md
@@ -54,9 +54,9 @@ application JavaScript bundles are byte-identical to the preceding override
 candidate. There is no claimed runtime-memory or UI improvement.
 
 Node 22 passes 305 dependency and 2,098 backend tests (one existing pending).
-A clean Node 24/npm 12 installation passes 296 dependency cases; optional CLI
-YAML is absent in that mode. Full backend coverage on both Nodes and hosted CI
-are merge gates. The [final inventory](../audits/m09-final-inventory.json) records
+A clean Node 24/npm 12 installation passes 296 dependency and 2,089 backend
+cases (one existing pending); optional CLI YAML is absent in that mode. Hosted
+CI and actual merge verification remain required. The [final inventory](../audits/m09-final-inventory.json) records
 zero known full/production advisories and no remaining updates within consumer
 ranges at the time of review.
 The environment matrix and Node/MongoDB compatibility floors do not change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4824,7 +4824,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -5191,7 +5193,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5540,7 +5544,9 @@
       }
     },
     "node_modules/extsprintf": {
-      "version": "1.3.0",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
       "engines": [
         "node >=0.6.0"
       ],
@@ -8628,7 +8634,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+      "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/tests/dependency-transitive-refresh.test.js
+++ b/tests/dependency-transitive-refresh.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const {createRequire} = require('node:module');
+
+describe('Remaining maintained transitive consumers', function () {
+  const fromMocha = createRequire(require.resolve('mocha'));
+  const serialize = fromMocha('serialize-javascript');
+
+  it('escapes split script end tags while preserving function results', function () {
+    const fixture = {
+      prefix: function () { return '</script '; },
+      suffix: function () { return '><script>fixture</script>'; },
+      compare: function (value) { return value < /script/.test('script'); }
+    };
+    const source = serialize(fixture);
+    assert.equal(/<\/script[\t\n\f\r />]/i.test(source), false);
+    const restored = vm.runInNewContext('(' + source + ')', {}, {timeout: 1000});
+    assert.equal(restored.prefix(), fixture.prefix());
+    assert.equal(restored.suffix(), fixture.suffix());
+    assert.equal(restored.compare(0), fixture.compare(0));
+    assert.equal(restored.compare(2), fixture.compare(2));
+  });
+
+  it('rejects non-string URL and RegExp representations without coercing them', function () {
+    let coerced = false;
+    const nonString = {toString() { coerced = true; return 'fixture'; }};
+    const url = new URL('https://fixture.invalid/path');
+    url.toString = () => nonString;
+    assert.throws(() => serialize(url), /URL.toString\(\) must return a string/);
+    const regexp = /fixture/;
+    Object.defineProperty(regexp, 'source', {value: nonString});
+    assert.throws(() => serialize(regexp), /RegExp.source must be a string/);
+    assert.equal(coerced, false);
+  });
+
+  it('preserves APNs error formatting, cause and structured metadata', function () {
+    const fromApn = createRequire(require.resolve('@parse/node-apn'));
+    const VError = fromApn('verror');
+    const cause = new Error('fixture connection closed');
+    const error = new VError({cause, name: 'FixtureTransportError', info: {status: 503}},
+      'request %s failed after %d attempts (%%)', 'α', 2);
+    assert.equal(error.message, 'request α failed after 2 attempts (%): fixture connection closed');
+    assert.equal(VError.cause(error), cause);
+    assert.deepEqual(VError.info(error), {status: 503});
+    assert.equal(error.name, 'FixtureTransportError');
+  });
+
+  it('retains sanitizer URL filtering through launder and its Day.js dependency', function () {
+    const sanitize = require('sanitize-html');
+    assert.equal(sanitize('<a href="javascript:fixture()">unsafe</a>'), '<a>unsafe</a>');
+    assert.equal(sanitize('<a href="https://example.test/a?x=1&amp;y=2">safe</a>'),
+      '<a href="https://example.test/a?x=1&amp;y=2">safe</a>');
+    const launder = createRequire(require.resolve('sanitize-html'))('launder')();
+    const date = new Date(2024, 1, 29, 13, 5, 9);
+    assert.equal(launder.formatDate(date), '2024-02-29');
+    assert.equal(launder.formatTime(date), '13:05:09');
+  });
+
+  it('lexes webpack module dependencies and every declared export in large sources', async function () {
+    const lexer = createRequire(require.resolve('webpack'))('es-module-lexer');
+    await lexer.init;
+    const source = '/*' + 'x'.repeat(5 * 1024 * 1024) + '*/\n' +
+      'export const first = 1, second = 2;\n' +
+      'export async function load() { return import(`./fixture.mjs`); }\n' +
+      'export const object = { import(a, b) { return a + b; } };';
+    const [imports, exports] = lexer.parse(source, 'fixture-large.mjs');
+    assert.deepEqual(imports.map(entry => entry.n), ['./fixture.mjs']);
+    assert.deepEqual(exports.map(entry => entry.n), ['first', 'second', 'load', 'object']);
+  });
+});


### PR DESCRIPTION
Refresh the final four transitive packages with newer releases inside their owning consumers' ranges: dayjs 1.11.23, es-module-lexer 2.3.2, extsprintf 1.4.1 and serialize-javascript 7.1.1. This PR builds on verified merge #8712 (`94517da0`) and has been refreshed against that base.

New consumer tests protect split script-closing payloads and spoofed URL/RegExp representations, retained function behavior, APNs error formatting/cause metadata, sanitizer behavior and large-module import/export parsing. The serializer regressions fail on 7.0.5 and pass on 7.1.1. Day.js remains a dependency of launder under sanitize-html; this does not select it for M27.

Only four lock entries change. All six application bundles remain byte-identical. Published package files grow by 9,160 bytes in production and 77,841 in development; no RAM saving is claimed. There are no further compatible updates in `npm outdated --all`, and full/production audits report zero known advisories. Major choices remain scoped to M25/M27/M28, with the documented xml2js compatibility hold.

Local validation: Node 22 clean build, 305 dependency cases and 2,098 backend cases (one existing pending); Node 24/npm 12 clean build and 296 dependency cases and 2,089 backend cases (one existing pending). Hosted CI and actual merge verification are required before merging. The plan's M09 completion update describes the intended state after this final child is verified and merged; #8605 remains draft and release-wide validation remains separate.
