### PR TITLE
Fix notification cache snapshots during asynchronous sends

### DIFF
--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -1,6 +1,6 @@
 # Nightscout dependency and runtime modernization
 
-Updated: 2026-09-06. Baseline: `dev` commit `9205ea300b9a6981ad8f16223c69620dd3c1c830` (15.0.9).
+Updated: 2026-09-08. Baseline: `dev` commit `9205ea300b9a6981ad8f16223c69620dd3c1c830` (15.0.9).
 Tracking issue: [#8328](https://github.com/nightscout/cgm-remote-monitor/issues/8328).
 
 This is the execution plan for reducing dependency maintenance, installation size, unnecessary server allocations and browser cost. Deliver each numbered item as a small PR targeting `chore/nightscout-modernization`. After review and green checks against the current integration branch, merge it there and update its status/evidence here. **#8605 is the single integration PR targeting dev** and stays draft until the complete modernization and release gates are satisfied. Do not merge individual implementation PRs into dev. Implementation checkboxes do not waive outstanding release validation.
@@ -323,7 +323,7 @@ The remaining M08, M19, M23 and M26 candidates are assembled into one verificati
 
 ### M25 profile-cache and receipt implementation
 
-A bounded reference cache replaces memory-cache's per-entry timers while preserving the application's five-second get/put/clear contracts. [Workload measurements and limits](../test-specs/profile-cache.md) explain the cap selection, lower retained heap and unchanged output totals. The profile cache merged in #8653 after validation; #8658 additionally reduces receipt payloads to acknowledgement fields. The [notification teardown follow-up](../test-specs/notification-cache-teardown.md) clears owned caches/timers and ignores late provider callbacks after shutdown. Notification-cache bounds and clone policy, and the final retain/replace decision, remain open; M25 is not yet complete.
+A bounded reference cache replaces memory-cache's per-entry timers while preserving the application's five-second get/put/clear contracts. [Workload measurements and limits](../test-specs/profile-cache.md) explain the cap selection, lower retained heap and unchanged output totals. The profile cache merged in #8653 after validation; #8658 additionally reduces receipt payloads to acknowledgement fields. The [notification teardown follow-up](../test-specs/notification-cache-teardown.md) clears owned caches/timers and ignores late provider callbacks after shutdown. The [dispatch snapshot follow-up](../test-specs/notification-dispatch-snapshot.md) captures acknowledgement fields and deduplication keys before asynchronous provider completion, with delayed multi-recipient and reused-payload regressions. Notification-cache bounds and the final retain/replace decision remain open; M25 is not yet complete.
 
 - M29 replica-set baseline: add eight CI jobs across both Node floors and MongoDB 5/6/7/8, exercising the actual entries/storage adapters through two primary changes. Local driver 5.9.2 and proposed 7.6.0 comparisons pass on both Node floors with MongoDB 8.0.29; see [scope and evidence](../test-specs/mongodb-replica-set.md). Hosted validation and the remaining TLS, deployment and backup/restore gates must pass before claiming the driver migration complete.
 

--- a/docs/test-specs/notification-dispatch-snapshot.md
+++ b/docs/test-specs/notification-dispatch-snapshot.md
@@ -1,0 +1,53 @@
+# Notification dispatch snapshots
+
+M25 review found that `pushnotify` constructed its reduced receipt record only
+when Pushover completed. Mutating the notification during the request could
+therefore change the level, group and event used to acknowledge the original
+alarm. Likewise, reusing a notification under another key before Pushover or
+Maker completed could extend the second key's suppression instead of the first.
+
+Capture the three acknowledgement fields before calling Pushover and pass the
+resolved dispatch key to both provider helpers. Each Pushover recipient uses
+the same dispatch snapshot; node-cache still clones each stored receipt and
+read result. The fields are the application's scalar level/group/event values;
+this does not introduce a general deep-clone helper for notification graphs.
+The providers still receive the original payload. TTL lengths, retry policy,
+cancellation, receipt deletion, teardown and persisted data are unchanged.
+
+Three new tests in `tests/pushnotify-cache.test.js` fail on parent
+`bc14aec52bf87de3270fc0418e7448e267aede73`: changed acknowledgement fields,
+Pushover extending the wrong key, and Maker extending the wrong key. The tests
+exercise two recipient receipts and a successful first request completing after
+a failed second request on a reused payload. Existing cancellation, expiry,
+snooze-selection and late-callback teardown cases remain active.
+
+Validation commands (from the child checkout, Node 22.23.2 / npm 10.9.8):
+
+```sh
+npm ci
+node node_modules/mocha/bin/mocha.js tests/pushnotify-cache.test.js tests/pushnotify.test.js tests/notification-state-lifecycle.test.js tests/pushover.test.js tests/maker.test.js --reporter dot
+TZ=America/Los_Angeles npm run test-ci
+TZ=America/Los_Angeles npm run test:core
+npm run test:dependencies
+npm run lint
+```
+
+The focused suite passes 29 cases on both Node 22.23.2 and 24.20.0. The clean
+locked install includes the production build. Full backend validation uses an
+owned MongoDB 8.0.29 container; hosted checks cover the other supported MongoDB
+versions, browser engines, npm 12, CodeQL and both Docker architectures.
+Local backend validation passes 2,101 tests with one existing pending case;
+client-core passes 283 and dependency tests pass 305. Lint reports zero errors
+and sixteen existing security warnings. Current-head hosted CI and verification
+of the merge tree are required before merging.
+
+No package or memory-saving claim is made. M25 remains open: the profile cache
+may evict recomputable values, but evicting live notification markers permits
+duplicates and evicting receipts loses acknowledgement/cancellation mappings.
+A bounded replacement needs an explicit saturation policy and workload evidence;
+a generic oldest-entry eviction or a throwing cache limit is insufficient.
+The current node-cache dependency remains for that separate decision.
+
+Rollback: `git revert f2611a22` (or revert the child PR's
+merge using `git revert -m 1 <merge-commit>`). No configuration/database migration
+is needed; restarting clears process-local notification caches as before.

--- a/lib/server/pushnotify.js
+++ b/lib/server/pushnotify.js
@@ -68,8 +68,8 @@ function init (env, ctx) {
     // Deduplication only needs presence; do not clone and retain the full payload.
     recentlySent.set(key, true, 30);
 
-    sendPushoverNotifications(notify);
-    sendMakerEvent(notify);
+    sendPushoverNotifications(notify, key);
+    sendMakerEvent(notify, key);
 
   };
 
@@ -108,9 +108,13 @@ function init (env, ctx) {
     }
   }
 
-  function sendPushoverNotifications (notify) {
+  function sendPushoverNotifications (notify, key) {
     if (ctx.pushover) {
-      //add the key to the cache before sending, but with a short TTL
+      // Snapshot acknowledgement fields before asynchronous provider responses.
+      // The caller may reuse or mutate the notification while a send is pending.
+      var receiptNotify = {
+        level: notify.level, group: notify.group, eventName: notify.eventName
+      };
       ctx.pushover.send(notify, function pushoverCallback (err, result) {
         if (closed) return;
         if (err) {
@@ -119,16 +123,14 @@ function init (env, ctx) {
           //result comes back as a string here, so fix it
           result = JSON.parse(result);
           //after successfully sent, increase the TTL
-          recentlySent.ttl(notify.key, times.mins(15).secs);
+          recentlySent.ttl(key, times.mins(15).secs);
 
           if (result.receipt) {
             //if this was an emergency alarm, also hold on to the receipt/notify mapping, for later acking
             console.info('storing pushover receipt', result.receipt, notify);
             // Acknowledgement/snooze selection needs only these fields. Avoid
             // cloning and retaining message data and the entire plugin graph.
-            receipts.set(result.receipt, {
-              level: notify.level, group: notify.group, eventName: notify.eventName
-            });
+            receipts.set(result.receipt, receiptNotify);
           }
         }
       });
@@ -148,7 +150,7 @@ function init (env, ctx) {
     }
   }
 
-  function sendMakerEvent (notify) {
+  function sendMakerEvent (notify, key) {
     if (!ctx.maker) {
       return;
     }
@@ -166,7 +168,7 @@ function init (env, ctx) {
         console.error('unable to send maker event', event, err);
       } else {
         console.info('sent maker event: ', event);
-        recentlySent.ttl(notify.key, times.mins(15).secs);
+        recentlySent.ttl(key, times.mins(15).secs);
       }
     });
   }

--- a/tests/pushnotify-cache.test.js
+++ b/tests/pushnotify-cache.test.js
@@ -65,6 +65,49 @@ describe('push notification deduplication cache', function () {
     assert.strictEqual(push.pushoverAck({}), false);
   });
 
+  it('snapshots receipt fields before asynchronous multi-recipient responses', function () {
+    let complete;
+    ctx.pushover.send = (notify, callback) => { complete = callback; };
+    const push = initialize(env, ctx, caches);
+    const payload = notification();
+    push.emitNotification(payload);
+    payload.level = levels.URGENT;
+    payload.group = 'changed-in-flight';
+    payload.eventName = 'changed-in-flight';
+    complete(null, JSON.stringify({receipt: 'first-recipient'}));
+    complete(null, JSON.stringify({receipt: 'second-recipient'}));
+    for (const receipt of ['first-recipient', 'second-recipient']) {
+      assert.strictEqual(push.pushoverAck({receipt}), true);
+      assert.deepStrictEqual(acknowledgements.pop(), [levels.WARN, 'fixture-group', 420000, true]);
+      assert.strictEqual(push.pushoverAck({receipt}), false);
+    }
+  });
+
+  for (const provider of ['pushover', 'maker']) {
+    it('extends the dispatched key when a reused payload changes during ' + provider + ' send', function () {
+      const callbacks = [];
+      delete ctx.pushover;
+      ctx[provider] = provider === 'pushover'
+        ? {send(notify, callback) { sent.push(notify.key); callbacks.push(callback); }}
+        : {sendEvent(event, callback) { sent.push(event); callbacks.push(callback); }};
+      const push = initialize(env, ctx, caches);
+      const payload = notification();
+      push.emitNotification(payload);
+      payload.notifyhash = 'second-key';
+      push.emitNotification(payload);
+      // The first request succeeds after the second request fails. Only the
+      // first key should gain the longer suppression interval.
+      callbacks[1](new Error('second request failed'));
+      now += 1000;
+      callbacks[0](null, '{}');
+      now += 29001;
+      push.emitNotification(notification());
+      assert.strictEqual(sent.length, 2, 'Successful first key remains suppressed');
+      push.emitNotification(Object.assign(notification(), {notifyhash: 'second-key'}));
+      assert.strictEqual(sent.length, 3, 'Failed second key can retry after 30 seconds');
+    });
+  }
+
   it('extends successful sends to 15 minutes and expires repeatedly', function () {
     const push = initialize(env, ctx, caches);
     for (let cycle = 1; cycle <= 2; cycle++) {


### PR DESCRIPTION
When a notification is mutated or reused while a provider request is pending, the completion callback currently reads the new alarm fields/key. Pushover can acknowledge the wrong level/group/event, and Pushover or Maker can extend suppression for the wrong key.

Capture acknowledgement fields before dispatch and keep each provider callback's original deduplication key. Provider payloads, TTL lengths, cancellation and teardown behavior remain unchanged. This is an M25 follow-up for #8605; cache capacity and the final library decision remain open.

Validation:
- All three new regressions fail on the parent `bc14aec5` and pass after the fix, including two recipient receipts and out-of-order completions after payload reuse.
- 29 notification/provider cases pass on Node 22.23.2 and 24.20.0.
- Clean Node 22.23.2/npm 10.9.8 install and production build; MongoDB 8.0.29 backend: 2,101 passing, one existing pending. Client-core: 283; dependency tests: 305.
- Lint: zero errors, sixteen existing warnings. All 19 validation jobs in [CI run 34206846076](https://github.com/nightscout/cgm-remote-monitor/actions/runs/34206846076) passed, as did CodeQL. All four browser artifacts identify the tested tree `113a2e014bd9c5b89cf7202497bc302cd3148720`, which exactly matches the proposed merge with the fresh integration base. Container publishing jobs were intentionally skipped.

No configuration or database migration. Rollback: `git revert f2611a22`. No package-size or RAM-saving claim. Evidence and remaining cache-policy constraints are in `docs/test-specs/notification-dispatch-snapshot.md`.
