### PR TITLE
Record M27 date-time decision with Temporal and cross-browser evidence

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,6 +215,20 @@ jobs:
           path: editor-time-comparison.json
           if-no-files-found: error
           retention-days: 14
+      - name: Install isolated date comparison candidates
+        run: |
+          mkdir -p "$RUNNER_TEMP/nightscout-date-candidates"
+          cp tools/audits/date-candidates/package*.json "$RUNNER_TEMP/nightscout-date-candidates/"
+          npm ci --prefix "$RUNNER_TEMP/nightscout-date-candidates" --ignore-scripts --no-audit --no-fund
+      - name: Compare date candidates with the production browser bundle
+        run: node tools/audits/browser-date-candidate-probe.cjs "$RUNNER_TEMP/nightscout-date-candidates" ${{ matrix.browser }} > date-candidate-comparison.json
+      - name: Save date candidate evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: date-candidates-${{ matrix.node-version }}-${{ matrix.browser }}
+          path: date-candidate-comparison.json
+          if-no-files-found: error
+          retention-days: 14
 
   npm12-build:
     name: Validate npm 12 install and build

--- a/docs/audits/date-candidate-review.json
+++ b/docs/audits/date-candidate-review.json
@@ -1,0 +1,17278 @@
+{
+  "recorded": "2026-09-08",
+  "scope": "Summaries of reproducible candidate probes; representative format mismatches plus every non-format case. Raw browser results are collected in CI artifacts. Memory samples are complete. No application replacement or server memory-saving claim.",
+  "server": [
+    {
+      "baseline": "810b71d0d3f988cac3cacb8a00e5b27be011bab6",
+      "node": "v22.23.2",
+      "icu": "78.2",
+      "tz": "2026a",
+      "nativeTemporal": "undefined",
+      "moment": "2.30.1",
+      "momentTimezone": "0.6.3",
+      "momentTzData": "2026c",
+      "sources": {
+        "date-candidate-probe.cjs": "2bb89c217639e584821e806ed1f28ca19c04d90eeb829895b2a7cde69cbd14e5",
+        "date-candidate-contracts.cjs": "46965f5b9e14e46e1b355fe62a6a90675fd3dfc09b57512e7379258d9a47fa01"
+      },
+      "candidatePackages": {
+        "node_modules/@js-temporal/polyfill": {
+          "version": "0.5.1",
+          "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="
+        },
+        "node_modules/dayjs": {
+          "version": "1.11.23",
+          "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ=="
+        },
+        "node_modules/jsbi": {
+          "version": "4.3.2",
+          "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="
+        },
+        "node_modules/luxon": {
+          "version": "3.7.2",
+          "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
+        }
+      },
+      "scope": "Native candidate operations and explicit formatting adapters; not a production migration or proof of all application contracts. Full server Moment timezone data.",
+      "corpus": {
+        "zones": [
+          "UTC",
+          "America/New_York",
+          "Australia/Lord_Howe",
+          "Asia/Kathmandu",
+          "Asia/Gaza"
+        ],
+        "instants": [
+          -2208988800000,
+          1420070340000,
+          1420070400000,
+          1710053940000,
+          1710054000000,
+          1730611800000,
+          1730615400000,
+          1712414700000,
+          1712416500000,
+          1728142140000,
+          1728142200000,
+          2082758340000,
+          2082758400000
+        ],
+        "locales": [
+          "en",
+          "de",
+          "fr",
+          "ar",
+          "fa"
+        ],
+        "localTimes": [
+          [
+            "2024-03-10T02:30:00",
+            "America/New_York"
+          ],
+          [
+            "2024-11-03T01:30:00",
+            "America/New_York"
+          ],
+          [
+            "2024-10-06T02:15:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-04-07T01:45:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "Asia/Kathmandu"
+          ],
+          [
+            "1900-01-01T00:00:00",
+            "Asia/Gaza"
+          ]
+        ],
+        "calendarDays": [
+          [
+            "2024-03-10T00:00:00",
+            "America/New_York"
+          ],
+          [
+            "2024-11-03T00:00:00",
+            "America/New_York"
+          ],
+          [
+            "2024-10-06T00:00:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-04-07T00:00:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "Asia/Kathmandu"
+          ]
+        ],
+        "offsetTimes": [
+          [
+            "2024-01-01T00:00:00",
+            "+05:30"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "+05:45"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "-03:30"
+          ]
+        ],
+        "dates": [
+          "2024-02-29",
+          "2024-02-30",
+          "2023-02-29",
+          "2024-13-01",
+          "2024-00-01",
+          "2024-01-00",
+          "not-a-date"
+        ],
+        "hours": [
+          -25,
+          -1,
+          0,
+          1,
+          25,
+          10000
+        ]
+      },
+      "timings": [
+        {
+          "round": 0,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 14.729999999999961,
+          "checksum": 75000
+        },
+        {
+          "round": 0,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 13.837666000000013,
+          "checksum": 75000
+        },
+        {
+          "round": 0,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 164.650667,
+          "checksum": 75000
+        },
+        {
+          "round": 0,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 28.367083000000036,
+          "checksum": 75000
+        },
+        {
+          "round": 0,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 61.324333000000024,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 53.92979100000002,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 21.619833000000085,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 164.68445900000006,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 14.889541000000008,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 10.66979200000003,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 6.423667000000023,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 12.694458000000054,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 163.372208,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 23.222499999999968,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 57.07858299999998,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 56.508916,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 20.189124999999876,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 157.40204199999994,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 17.842583000000104,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 6.738791999999876,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 11.258249999999862,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 12.219125000000076,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 158.04662499999995,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 26.905332999999928,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 54.082374999999956,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 52.2096660000002,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 20.84662500000013,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 160.182458,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 12.185458000000153,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 10.895667000000003,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 6.837792000000036,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 12.409417000000076,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 157.20579099999986,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 30.444166000000223,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 54.664124999999785,
+          "checksum": 75000
+        }
+      ],
+      "rawSha256": "4755cc4e1cdb5ca02d03c4aba955e528a68d873f77ab746e5966d3a614a64bc1",
+      "seasons": [
+        {
+          "now": "2024-01-15T00:00:00Z",
+          "cases": 353,
+          "formatCases": 325,
+          "formatMismatchCountsByLocale": {
+            "intl": {
+              "ar": 65
+            },
+            "dayjs": {
+              "ar": 65,
+              "fa": 65
+            },
+            "luxon": {
+              "ar": 65
+            },
+            "temporal": {
+              "ar": 65,
+              "fa": 65
+            }
+          },
+          "formatExamples": [
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            }
+          ],
+          "otherContracts": [
+            {
+              "kind": "local",
+              "args": [
+                "2024-03-10T02:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-11-03T01:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-03T06:30:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-03T06:30:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-10-06T02:15:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-04-07T01:45:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "1900-01-01T00:00:00",
+                "Asia/Gaza"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:45"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "-03:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-03-10T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-11T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-11-03T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-04T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-10-06T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-06T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-04-07T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-07T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": true
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-30"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2023-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-13-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-00-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-01-00"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "not-a-date"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": false
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -25
+              ],
+              "results": {
+                "moment": {
+                  "value": -90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -90000000
+                },
+                "luxon": {
+                  "value": -90000000
+                },
+                "temporal": {
+                  "value": -90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -1
+              ],
+              "results": {
+                "moment": {
+                  "value": -3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -3600000
+                },
+                "luxon": {
+                  "value": -3600000
+                },
+                "temporal": {
+                  "value": -3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                0
+              ],
+              "results": {
+                "moment": {
+                  "value": 0
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 0
+                },
+                "luxon": {
+                  "value": 0
+                },
+                "temporal": {
+                  "value": 0
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                1
+              ],
+              "results": {
+                "moment": {
+                  "value": 3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 3600000
+                },
+                "luxon": {
+                  "value": 3600000
+                },
+                "temporal": {
+                  "value": 3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                25
+              ],
+              "results": {
+                "moment": {
+                  "value": 90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 90000000
+                },
+                "luxon": {
+                  "value": 90000000
+                },
+                "temporal": {
+                  "value": 90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                10000
+              ],
+              "results": {
+                "moment": {
+                  "value": 36000000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 36000000000
+                },
+                "luxon": {
+                  "value": 36000000000
+                },
+                "temporal": {
+                  "value": 36000000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "immutable",
+              "args": [],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            }
+          ]
+        },
+        {
+          "now": "2024-07-15T00:00:00Z",
+          "cases": 353,
+          "formatCases": 325,
+          "formatMismatchCountsByLocale": {
+            "intl": {
+              "ar": 65
+            },
+            "dayjs": {
+              "ar": 65,
+              "fa": 65
+            },
+            "luxon": {
+              "ar": 65
+            },
+            "temporal": {
+              "ar": 65,
+              "fa": 65
+            }
+          },
+          "formatExamples": [
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            }
+          ],
+          "otherContracts": [
+            {
+              "kind": "local",
+              "args": [
+                "2024-03-10T02:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-11-03T01:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-10-06T02:15:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-04-07T01:45:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-06T15:15:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-06T15:15:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "1900-01-01T00:00:00",
+                "Asia/Gaza"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:45"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "-03:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-03-10T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-11T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-11-03T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-04T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-10-06T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-06T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-04-07T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-07T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": true
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-30"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2023-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-13-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-00-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-01-00"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "not-a-date"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": false
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -25
+              ],
+              "results": {
+                "moment": {
+                  "value": -90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -90000000
+                },
+                "luxon": {
+                  "value": -90000000
+                },
+                "temporal": {
+                  "value": -90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -1
+              ],
+              "results": {
+                "moment": {
+                  "value": -3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -3600000
+                },
+                "luxon": {
+                  "value": -3600000
+                },
+                "temporal": {
+                  "value": -3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                0
+              ],
+              "results": {
+                "moment": {
+                  "value": 0
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 0
+                },
+                "luxon": {
+                  "value": 0
+                },
+                "temporal": {
+                  "value": 0
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                1
+              ],
+              "results": {
+                "moment": {
+                  "value": 3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 3600000
+                },
+                "luxon": {
+                  "value": 3600000
+                },
+                "temporal": {
+                  "value": 3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                25
+              ],
+              "results": {
+                "moment": {
+                  "value": 90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 90000000
+                },
+                "luxon": {
+                  "value": 90000000
+                },
+                "temporal": {
+                  "value": 90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                10000
+              ],
+              "results": {
+                "moment": {
+                  "value": 36000000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 36000000000
+                },
+                "luxon": {
+                  "value": 36000000000
+                },
+                "temporal": {
+                  "value": 36000000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "immutable",
+              "args": [],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "baseline": "810b71d0d3f988cac3cacb8a00e5b27be011bab6",
+      "node": "v24.20.0",
+      "icu": "78.3",
+      "tz": "2026c",
+      "nativeTemporal": "undefined",
+      "moment": "2.30.1",
+      "momentTimezone": "0.6.3",
+      "momentTzData": "2026c",
+      "sources": {
+        "date-candidate-probe.cjs": "2bb89c217639e584821e806ed1f28ca19c04d90eeb829895b2a7cde69cbd14e5",
+        "date-candidate-contracts.cjs": "46965f5b9e14e46e1b355fe62a6a90675fd3dfc09b57512e7379258d9a47fa01"
+      },
+      "candidatePackages": {
+        "node_modules/@js-temporal/polyfill": {
+          "version": "0.5.1",
+          "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="
+        },
+        "node_modules/dayjs": {
+          "version": "1.11.23",
+          "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ=="
+        },
+        "node_modules/jsbi": {
+          "version": "4.3.2",
+          "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="
+        },
+        "node_modules/luxon": {
+          "version": "3.7.2",
+          "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
+        }
+      },
+      "scope": "Native candidate operations and explicit formatting adapters; not a production migration or proof of all application contracts. Full server Moment timezone data.",
+      "corpus": {
+        "zones": [
+          "UTC",
+          "America/New_York",
+          "Australia/Lord_Howe",
+          "Asia/Kathmandu",
+          "Asia/Gaza"
+        ],
+        "instants": [
+          -2208988800000,
+          1420070340000,
+          1420070400000,
+          1710053940000,
+          1710054000000,
+          1730611800000,
+          1730615400000,
+          1712414700000,
+          1712416500000,
+          1728142140000,
+          1728142200000,
+          2082758340000,
+          2082758400000
+        ],
+        "locales": [
+          "en",
+          "de",
+          "fr",
+          "ar",
+          "fa"
+        ],
+        "localTimes": [
+          [
+            "2024-03-10T02:30:00",
+            "America/New_York"
+          ],
+          [
+            "2024-11-03T01:30:00",
+            "America/New_York"
+          ],
+          [
+            "2024-10-06T02:15:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-04-07T01:45:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "Asia/Kathmandu"
+          ],
+          [
+            "1900-01-01T00:00:00",
+            "Asia/Gaza"
+          ]
+        ],
+        "calendarDays": [
+          [
+            "2024-03-10T00:00:00",
+            "America/New_York"
+          ],
+          [
+            "2024-11-03T00:00:00",
+            "America/New_York"
+          ],
+          [
+            "2024-10-06T00:00:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-04-07T00:00:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "Asia/Kathmandu"
+          ]
+        ],
+        "offsetTimes": [
+          [
+            "2024-01-01T00:00:00",
+            "+05:30"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "+05:45"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "-03:30"
+          ]
+        ],
+        "dates": [
+          "2024-02-29",
+          "2024-02-30",
+          "2023-02-29",
+          "2024-13-01",
+          "2024-00-01",
+          "2024-01-00",
+          "not-a-date"
+        ],
+        "hours": [
+          -25,
+          -1,
+          0,
+          1,
+          25,
+          10000
+        ]
+      },
+      "timings": [
+        {
+          "round": 0,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 9.230249999999984,
+          "checksum": 75000
+        },
+        {
+          "round": 0,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 10.74354199999999,
+          "checksum": 75000
+        },
+        {
+          "round": 0,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 152.2715,
+          "checksum": 75000
+        },
+        {
+          "round": 0,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 22.07704100000001,
+          "checksum": 75000
+        },
+        {
+          "round": 0,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 55.873625000000004,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 52.007041999999956,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 18.867374999999925,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 154.38675,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 16.637875000000008,
+          "checksum": 75000
+        },
+        {
+          "round": 1,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 7.816625000000045,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 8.41904199999999,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 10.144166999999925,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 152.02929099999994,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 21.975374999999985,
+          "checksum": 75000
+        },
+        {
+          "round": 2,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 53.885666000000015,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 51.86387500000001,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 18.122208999999884,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 148.92333400000007,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 10.507458000000042,
+          "checksum": 75000
+        },
+        {
+          "round": 3,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 11.127292000000125,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 10.64691700000003,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 10.627749999999878,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 151.94166599999994,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 22.47808299999997,
+          "checksum": 75000
+        },
+        {
+          "round": 4,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 52.47458299999994,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 51.52395799999999,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 17.902916000000005,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 142.77329200000008,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 14.861457999999857,
+          "checksum": 75000
+        },
+        {
+          "round": 5,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 11.17104100000006,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "moment",
+          "iterations": 5000,
+          "milliseconds": 6.633166999999958,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "intl",
+          "iterations": 5000,
+          "milliseconds": 10.349749999999858,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "dayjs",
+          "iterations": 5000,
+          "milliseconds": 144.29200000000014,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "luxon",
+          "iterations": 5000,
+          "milliseconds": 24.909416000000192,
+          "checksum": 75000
+        },
+        {
+          "round": 6,
+          "name": "temporal",
+          "iterations": 5000,
+          "milliseconds": 51.05279099999984,
+          "checksum": 75000
+        }
+      ],
+      "rawSha256": "85e952604bb7771cc45bb091537b4d7919455bd4e8c4fbaaab91adedf4165ade",
+      "seasons": [
+        {
+          "now": "2024-01-15T00:00:00Z",
+          "cases": 353,
+          "formatCases": 325,
+          "formatMismatchCountsByLocale": {
+            "intl": {
+              "ar": 65
+            },
+            "dayjs": {
+              "ar": 65,
+              "fa": 65
+            },
+            "luxon": {
+              "ar": 65
+            },
+            "temporal": {
+              "ar": 65,
+              "fa": 65
+            }
+          },
+          "formatExamples": [
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            }
+          ],
+          "otherContracts": [
+            {
+              "kind": "local",
+              "args": [
+                "2024-03-10T02:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-11-03T01:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-03T06:30:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-03T06:30:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-10-06T02:15:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-04-07T01:45:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "1900-01-01T00:00:00",
+                "Asia/Gaza"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:45"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "-03:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-03-10T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-11T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-11-03T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-04T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-10-06T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-06T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-04-07T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-07T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": true
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-30"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2023-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-13-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-00-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-01-00"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "not-a-date"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": false
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -25
+              ],
+              "results": {
+                "moment": {
+                  "value": -90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -90000000
+                },
+                "luxon": {
+                  "value": -90000000
+                },
+                "temporal": {
+                  "value": -90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -1
+              ],
+              "results": {
+                "moment": {
+                  "value": -3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -3600000
+                },
+                "luxon": {
+                  "value": -3600000
+                },
+                "temporal": {
+                  "value": -3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                0
+              ],
+              "results": {
+                "moment": {
+                  "value": 0
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 0
+                },
+                "luxon": {
+                  "value": 0
+                },
+                "temporal": {
+                  "value": 0
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                1
+              ],
+              "results": {
+                "moment": {
+                  "value": 3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 3600000
+                },
+                "luxon": {
+                  "value": 3600000
+                },
+                "temporal": {
+                  "value": 3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                25
+              ],
+              "results": {
+                "moment": {
+                  "value": 90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 90000000
+                },
+                "luxon": {
+                  "value": 90000000
+                },
+                "temporal": {
+                  "value": 90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                10000
+              ],
+              "results": {
+                "moment": {
+                  "value": 36000000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 36000000000
+                },
+                "luxon": {
+                  "value": 36000000000
+                },
+                "temporal": {
+                  "value": 36000000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "immutable",
+              "args": [],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            }
+          ]
+        },
+        {
+          "now": "2024-07-15T00:00:00Z",
+          "cases": 353,
+          "formatCases": 325,
+          "formatMismatchCountsByLocale": {
+            "intl": {
+              "ar": 65
+            },
+            "dayjs": {
+              "ar": 65,
+              "fa": 65
+            },
+            "luxon": {
+              "ar": 65
+            },
+            "temporal": {
+              "ar": 65,
+              "fa": 65
+            }
+          },
+          "formatExamples": [
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            },
+            {
+              "kind": "format",
+              "args": [
+                -2208988800000,
+                "UTC",
+                "ar"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "date": "\u0661\u0669\u0660\u0660-\u0660\u0661-\u0660\u0661",
+                    "time": "\u0660\u0660:\u0660\u0660"
+                  }
+                },
+                "intl": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "dayjs": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "date": "1900-01-01",
+                    "time": "00:00"
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            }
+          ],
+          "otherContracts": [
+            {
+              "kind": "local",
+              "args": [
+                "2024-03-10T02:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-11-03T01:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-10-06T02:15:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-04-07T01:45:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-06T15:15:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-06T15:15:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "1900-01-01T00:00:00",
+                "Asia/Gaza"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:45"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "-03:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-03-10T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-11T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-11-03T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-04T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-10-06T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-06T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-04-07T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-07T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": true
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-30"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2023-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-13-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-00-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-01-00"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "not-a-date"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": false
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -25
+              ],
+              "results": {
+                "moment": {
+                  "value": -90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -90000000
+                },
+                "luxon": {
+                  "value": -90000000
+                },
+                "temporal": {
+                  "value": -90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -1
+              ],
+              "results": {
+                "moment": {
+                  "value": -3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -3600000
+                },
+                "luxon": {
+                  "value": -3600000
+                },
+                "temporal": {
+                  "value": -3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                0
+              ],
+              "results": {
+                "moment": {
+                  "value": 0
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 0
+                },
+                "luxon": {
+                  "value": 0
+                },
+                "temporal": {
+                  "value": 0
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                1
+              ],
+              "results": {
+                "moment": {
+                  "value": 3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 3600000
+                },
+                "luxon": {
+                  "value": 3600000
+                },
+                "temporal": {
+                  "value": 3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                25
+              ],
+              "results": {
+                "moment": {
+                  "value": 90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 90000000
+                },
+                "luxon": {
+                  "value": 90000000
+                },
+                "temporal": {
+                  "value": 90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                10000
+              ],
+              "results": {
+                "moment": {
+                  "value": 36000000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 36000000000
+                },
+                "luxon": {
+                  "value": 36000000000
+                },
+                "temporal": {
+                  "value": 36000000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "immutable",
+              "args": [],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "memory": [
+    {
+      "baseline": "810b71d0d3f988cac3cacb8a00e5b27be011bab6",
+      "probeSha256": "dcb8bc3ffaa8677cf57b56941c4533681ffb4dd90c1660414f00d06be6aae8d8",
+      "scope": "Seven alternating fresh processes per candidate; five cycles of 5000 zoned values. Full server Moment timezone data. No Intl-only date type, application throughput, or server RAM-saving claim.",
+      "results": [
+        {
+          "round": 0,
+          "name": "moment",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45187072,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 57327616,
+            "heapTotal": 11091968,
+            "heapUsed": 5894432,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 5
+          },
+          "loadMilliseconds": 5.541499999999999,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.941665999999998,
+              "populated": {
+                "rss": 68419584,
+                "heapTotal": 17907712,
+                "heapUsed": 8514048,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 68534272,
+                "heapTotal": 15548416,
+                "heapUsed": 6118936,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 8.551749999999998,
+              "populated": {
+                "rss": 73662464,
+                "heapTotal": 26558464,
+                "heapUsed": 8531912,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 73662464,
+                "heapTotal": 24199168,
+                "heapUsed": 6152056,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 7.403666999999999,
+              "populated": {
+                "rss": 78790656,
+                "heapTotal": 26820608,
+                "heapUsed": 8557680,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 78790656,
+                "heapTotal": 24461312,
+                "heapUsed": 6157360,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.5803750000000036,
+              "populated": {
+                "rss": 82477056,
+                "heapTotal": 43597824,
+                "heapUsed": 8562424,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 82608128,
+                "heapTotal": 40714240,
+                "heapUsed": 6168304,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 6.5602910000000065,
+              "populated": {
+                "rss": 84590592,
+                "heapTotal": 43335680,
+                "heapUsed": 8510560,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 84606976,
+                "heapTotal": 41238528,
+                "heapUsed": 6156408,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 0,
+          "name": "dayjs",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45318144,
+            "heapTotal": 7225344,
+            "heapUsed": 4102400,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 58966016,
+            "heapTotal": 7225344,
+            "heapUsed": 4316832,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.8747919999999993,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 153.59754099999998,
+              "populated": {
+                "rss": 91422720,
+                "heapTotal": 15613952,
+                "heapUsed": 6218800,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 91488256,
+                "heapTotal": 13778944,
+                "heapUsed": 4495840,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 147.58716600000002,
+              "populated": {
+                "rss": 120537088,
+                "heapTotal": 15613952,
+                "heapUsed": 6229344,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 120537088,
+                "heapTotal": 14041088,
+                "heapUsed": 4505608,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 148.871583,
+              "populated": {
+                "rss": 171360256,
+                "heapTotal": 24002560,
+                "heapUsed": 6221168,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171360256,
+                "heapTotal": 22429696,
+                "heapUsed": 4497536,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 143.659041,
+              "populated": {
+                "rss": 171655168,
+                "heapTotal": 24002560,
+                "heapUsed": 6223128,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171655168,
+                "heapTotal": 22167552,
+                "heapUsed": 4508600,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 151.05887499999994,
+              "populated": {
+                "rss": 173441024,
+                "heapTotal": 40779776,
+                "heapUsed": 6247448,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 173441024,
+                "heapTotal": 39206912,
+                "heapUsed": 4523120,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 0,
+          "name": "luxon",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 44974080,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 57131008,
+            "heapTotal": 8290304,
+            "heapUsed": 5096704,
+            "external": 1965870,
+            "arrayBuffers": 16619,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.9522499999999994,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 22.74975,
+              "populated": {
+                "rss": 76267520,
+                "heapTotal": 26640384,
+                "heapUsed": 8649872,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 76267520,
+                "heapTotal": 22970368,
+                "heapUsed": 5207304,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 17.659374999999997,
+              "populated": {
+                "rss": 84705280,
+                "heapTotal": 26640384,
+                "heapUsed": 8664360,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 84721664,
+                "heapTotal": 22970368,
+                "heapUsed": 5221312,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 16.94787500000001,
+              "populated": {
+                "rss": 86982656,
+                "heapTotal": 43417600,
+                "heapUsed": 8666312,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86982656,
+                "heapTotal": 39747584,
+                "heapUsed": 5223176,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 16.124666000000005,
+              "populated": {
+                "rss": 91717632,
+                "heapTotal": 43155456,
+                "heapUsed": 8668672,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91734016,
+                "heapTotal": 39747584,
+                "heapUsed": 5225776,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 16.129458,
+              "populated": {
+                "rss": 91897856,
+                "heapTotal": 43155456,
+                "heapUsed": 8670640,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91947008,
+                "heapTotal": 39747584,
+                "heapUsed": 5227696,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 0,
+          "name": "temporal",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45416448,
+            "heapTotal": 7225344,
+            "heapUsed": 4102400,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 61718528,
+            "heapTotal": 8028160,
+            "heapUsed": 5137496,
+            "external": 1965878,
+            "arrayBuffers": 16627,
+            "modules": 3
+          },
+          "loadMilliseconds": 12.419249999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.304208000000003,
+              "populated": {
+                "rss": 71712768,
+                "heapTotal": 16433152,
+                "heapUsed": 7216808,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 71761920,
+                "heapTotal": 15122432,
+                "heapUsed": 5577424,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.721709000000004,
+              "populated": {
+                "rss": 76775424,
+                "heapTotal": 24821760,
+                "heapUsed": 7210192,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 76775424,
+                "heapTotal": 23511040,
+                "heapUsed": 5570384,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.678541999999993,
+              "populated": {
+                "rss": 81264640,
+                "heapTotal": 25083904,
+                "heapUsed": 7215152,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81281024,
+                "heapTotal": 23511040,
+                "heapUsed": 5575288,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 4.758791000000002,
+              "populated": {
+                "rss": 85278720,
+                "heapTotal": 25083904,
+                "heapUsed": 7229408,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85278720,
+                "heapTotal": 23511040,
+                "heapUsed": 5589784,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.649667000000008,
+              "populated": {
+                "rss": 87654400,
+                "heapTotal": 41861120,
+                "heapUsed": 7229400,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 87654400,
+                "heapTotal": 40288256,
+                "heapUsed": 5589728,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 1,
+          "name": "temporal",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45301760,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 61800448,
+            "heapTotal": 8028160,
+            "heapUsed": 5137424,
+            "external": 1965878,
+            "arrayBuffers": 16627,
+            "modules": 3
+          },
+          "loadMilliseconds": 13.286625,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.103833000000002,
+              "populated": {
+                "rss": 71630848,
+                "heapTotal": 16695296,
+                "heapUsed": 7207096,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 71680000,
+                "heapTotal": 15122432,
+                "heapUsed": 5568168,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.951082999999997,
+              "populated": {
+                "rss": 76595200,
+                "heapTotal": 25083904,
+                "heapUsed": 7212168,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 76595200,
+                "heapTotal": 23511040,
+                "heapUsed": 5572360,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 5.036082999999991,
+              "populated": {
+                "rss": 80920576,
+                "heapTotal": 25083904,
+                "heapUsed": 7218424,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 80920576,
+                "heapTotal": 23511040,
+                "heapUsed": 5578560,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.4582500000000067,
+              "populated": {
+                "rss": 85114880,
+                "heapTotal": 25083904,
+                "heapUsed": 7232616,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85114880,
+                "heapTotal": 23511040,
+                "heapUsed": 5592992,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.1471250000000026,
+              "populated": {
+                "rss": 85196800,
+                "heapTotal": 25083904,
+                "heapUsed": 7232560,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85196800,
+                "heapTotal": 23511040,
+                "heapUsed": 5592888,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 1,
+          "name": "luxon",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45694976,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 57458688,
+            "heapTotal": 8290304,
+            "heapUsed": 5096776,
+            "external": 1965870,
+            "arrayBuffers": 16619,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.860208,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 21.594250000000002,
+              "populated": {
+                "rss": 75726848,
+                "heapTotal": 17989632,
+                "heapUsed": 8649712,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 75726848,
+                "heapTotal": 14581760,
+                "heapUsed": 5207144,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 16.770916999999997,
+              "populated": {
+                "rss": 82411520,
+                "heapTotal": 26640384,
+                "heapUsed": 8664200,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 82411520,
+                "heapTotal": 22970368,
+                "heapUsed": 5221152,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 16.479708000000002,
+              "populated": {
+                "rss": 85622784,
+                "heapTotal": 43155456,
+                "heapUsed": 8666152,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 85622784,
+                "heapTotal": 39747584,
+                "heapUsed": 5223016,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 15.524208000000016,
+              "populated": {
+                "rss": 91324416,
+                "heapTotal": 43155456,
+                "heapUsed": 8668472,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91324416,
+                "heapTotal": 39747584,
+                "heapUsed": 5225576,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 15.335916999999995,
+              "populated": {
+                "rss": 91521024,
+                "heapTotal": 43155456,
+                "heapUsed": 8670480,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91553792,
+                "heapTotal": 39747584,
+                "heapUsed": 5227536,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 1,
+          "name": "dayjs",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45121536,
+            "heapTotal": 7225344,
+            "heapUsed": 4102400,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 58818560,
+            "heapTotal": 7225344,
+            "heapUsed": 4316832,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.993583000000001,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 155.40200000000002,
+              "populated": {
+                "rss": 92045312,
+                "heapTotal": 15351808,
+                "heapUsed": 6220640,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 92127232,
+                "heapTotal": 13778944,
+                "heapUsed": 4497680,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 148.01100000000002,
+              "populated": {
+                "rss": 119783424,
+                "heapTotal": 15613952,
+                "heapUsed": 6227736,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 119783424,
+                "heapTotal": 14041088,
+                "heapUsed": 4504000,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 150.26524999999998,
+              "populated": {
+                "rss": 170524672,
+                "heapTotal": 24264704,
+                "heapUsed": 6233056,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170524672,
+                "heapTotal": 22429696,
+                "heapUsed": 4509080,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 146.17662499999994,
+              "populated": {
+                "rss": 171376640,
+                "heapTotal": 24264704,
+                "heapUsed": 6225208,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171376640,
+                "heapTotal": 22429696,
+                "heapUsed": 4510576,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 144.87374999999997,
+              "populated": {
+                "rss": 172916736,
+                "heapTotal": 40779776,
+                "heapUsed": 6252504,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 172916736,
+                "heapTotal": 39206912,
+                "heapUsed": 4528176,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 1,
+          "name": "moment",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45154304,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56786944,
+            "heapTotal": 11091968,
+            "heapUsed": 5894432,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 5
+          },
+          "loadMilliseconds": 5.285457999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.675874999999998,
+              "populated": {
+                "rss": 68075520,
+                "heapTotal": 17645568,
+                "heapUsed": 8494952,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 68206592,
+                "heapTotal": 15286272,
+                "heapUsed": 6088824,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 5.523624999999996,
+              "populated": {
+                "rss": 72990720,
+                "heapTotal": 26034176,
+                "heapUsed": 8513992,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 72990720,
+                "heapTotal": 23674880,
+                "heapUsed": 6120480,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 8.023207999999997,
+              "populated": {
+                "rss": 78708736,
+                "heapTotal": 26820608,
+                "heapUsed": 8554144,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 78708736,
+                "heapTotal": 24199168,
+                "heapUsed": 6161024,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 7.299999999999997,
+              "populated": {
+                "rss": 82395136,
+                "heapTotal": 43597824,
+                "heapUsed": 8554328,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 82395136,
+                "heapTotal": 41238528,
+                "heapUsed": 6165320,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 6.728624999999994,
+              "populated": {
+                "rss": 84033536,
+                "heapTotal": 43335680,
+                "heapUsed": 8530192,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 84033536,
+                "heapTotal": 41238528,
+                "heapUsed": 6131552,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 2,
+          "name": "moment",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45088768,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56770560,
+            "heapTotal": 11091968,
+            "heapUsed": 5894256,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 5
+          },
+          "loadMilliseconds": 5.483540999999999,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.631250000000001,
+              "populated": {
+                "rss": 68091904,
+                "heapTotal": 17645568,
+                "heapUsed": 8499664,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 68091904,
+                "heapTotal": 15286272,
+                "heapUsed": 6096384,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 5.891290999999995,
+              "populated": {
+                "rss": 72712192,
+                "heapTotal": 26034176,
+                "heapUsed": 8521152,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 72728576,
+                "heapTotal": 23674880,
+                "heapUsed": 6112560,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 8.693083000000001,
+              "populated": {
+                "rss": 78512128,
+                "heapTotal": 26820608,
+                "heapUsed": 8514424,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 78512128,
+                "heapTotal": 24199168,
+                "heapUsed": 6133840,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 6.900458999999998,
+              "populated": {
+                "rss": 82116608,
+                "heapTotal": 43597824,
+                "heapUsed": 8542440,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 82116608,
+                "heapTotal": 41238528,
+                "heapUsed": 6159128,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 6.083416999999997,
+              "populated": {
+                "rss": 83656704,
+                "heapTotal": 43335680,
+                "heapUsed": 8536128,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 83656704,
+                "heapTotal": 41238528,
+                "heapUsed": 6161920,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 2,
+          "name": "dayjs",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45301760,
+            "heapTotal": 7225344,
+            "heapUsed": 4102400,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 58703872,
+            "heapTotal": 7225344,
+            "heapUsed": 4316832,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.7985420000000012,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 153.849875,
+              "populated": {
+                "rss": 91029504,
+                "heapTotal": 15613952,
+                "heapUsed": 6216440,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 91095040,
+                "heapTotal": 13778944,
+                "heapUsed": 4493480,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 150.93195899999998,
+              "populated": {
+                "rss": 118702080,
+                "heapTotal": 15876096,
+                "heapUsed": 6230520,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 118702080,
+                "heapTotal": 14041088,
+                "heapUsed": 4506600,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 148.02083399999998,
+              "populated": {
+                "rss": 170180608,
+                "heapTotal": 24002560,
+                "heapUsed": 6228792,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170180608,
+                "heapTotal": 22429696,
+                "heapUsed": 4504816,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 142.38150000000007,
+              "populated": {
+                "rss": 171294720,
+                "heapTotal": 24526848,
+                "heapUsed": 6231064,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171294720,
+                "heapTotal": 22429696,
+                "heapUsed": 4516352,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 146.563583,
+              "populated": {
+                "rss": 173096960,
+                "heapTotal": 41041920,
+                "heapUsed": 6249392,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 173096960,
+                "heapTotal": 39206912,
+                "heapUsed": 4525608,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 2,
+          "name": "luxon",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45023232,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56852480,
+            "heapTotal": 8290304,
+            "heapUsed": 5096704,
+            "external": 1965870,
+            "arrayBuffers": 16619,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.7677499999999995,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 20.829083000000004,
+              "populated": {
+                "rss": 76660736,
+                "heapTotal": 26116096,
+                "heapUsed": 8648936,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 76677120,
+                "heapTotal": 22970368,
+                "heapUsed": 5206368,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 16.727959,
+              "populated": {
+                "rss": 84885504,
+                "heapTotal": 26378240,
+                "heapUsed": 8664432,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 84885504,
+                "heapTotal": 22970368,
+                "heapUsed": 5221384,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 16.184167000000002,
+              "populated": {
+                "rss": 86999040,
+                "heapTotal": 43155456,
+                "heapUsed": 8666384,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86999040,
+                "heapTotal": 39747584,
+                "heapUsed": 5223248,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 16.32670800000001,
+              "populated": {
+                "rss": 91701248,
+                "heapTotal": 43155456,
+                "heapUsed": 8668744,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91750400,
+                "heapTotal": 39747584,
+                "heapUsed": 5225848,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 15.896458000000024,
+              "populated": {
+                "rss": 92012544,
+                "heapTotal": 43155456,
+                "heapUsed": 8670712,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 92012544,
+                "heapTotal": 39747584,
+                "heapUsed": 5227768,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 2,
+          "name": "temporal",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45105152,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 61652992,
+            "heapTotal": 8028160,
+            "heapUsed": 5137424,
+            "external": 1965878,
+            "arrayBuffers": 16627,
+            "modules": 3
+          },
+          "loadMilliseconds": 12.840374999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.441083999999996,
+              "populated": {
+                "rss": 71417856,
+                "heapTotal": 16171008,
+                "heapUsed": 7207112,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 71483392,
+                "heapTotal": 14860288,
+                "heapUsed": 5568184,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.4110840000000024,
+              "populated": {
+                "rss": 76562432,
+                "heapTotal": 24821760,
+                "heapUsed": 7208400,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 76595200,
+                "heapTotal": 23248896,
+                "heapUsed": 5568592,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.394625000000005,
+              "populated": {
+                "rss": 80855040,
+                "heapTotal": 24821760,
+                "heapUsed": 7215432,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 80855040,
+                "heapTotal": 23248896,
+                "heapUsed": 5575568,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.227165999999997,
+              "populated": {
+                "rss": 85196800,
+                "heapTotal": 24821760,
+                "heapUsed": 7229696,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85196800,
+                "heapTotal": 23248896,
+                "heapUsed": 5590072,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.061417000000006,
+              "populated": {
+                "rss": 85262336,
+                "heapTotal": 24821760,
+                "heapUsed": 7229640,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85278720,
+                "heapTotal": 23248896,
+                "heapUsed": 5589968,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 3,
+          "name": "temporal",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45023232,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 61489152,
+            "heapTotal": 8028160,
+            "heapUsed": 5137424,
+            "external": 1965878,
+            "arrayBuffers": 16627,
+            "modules": 3
+          },
+          "loadMilliseconds": 12.397124999999999,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 9.944499999999998,
+              "populated": {
+                "rss": 71352320,
+                "heapTotal": 16433152,
+                "heapUsed": 7208512,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 71401472,
+                "heapTotal": 14860288,
+                "heapUsed": 5565984,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.256166999999998,
+              "populated": {
+                "rss": 76546048,
+                "heapTotal": 24821760,
+                "heapUsed": 7200688,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 76595200,
+                "heapTotal": 23248896,
+                "heapUsed": 5570248,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.960082999999997,
+              "populated": {
+                "rss": 81117184,
+                "heapTotal": 24821760,
+                "heapUsed": 7217544,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81117184,
+                "heapTotal": 23248896,
+                "heapUsed": 5577680,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.447291000000007,
+              "populated": {
+                "rss": 84983808,
+                "heapTotal": 24821760,
+                "heapUsed": 7231656,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 84983808,
+                "heapTotal": 23248896,
+                "heapUsed": 5592032,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.118124999999992,
+              "populated": {
+                "rss": 85164032,
+                "heapTotal": 24821760,
+                "heapUsed": 7231648,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85164032,
+                "heapTotal": 23248896,
+                "heapUsed": 5591976,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 3,
+          "name": "luxon",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45268992,
+            "heapTotal": 7225344,
+            "heapUsed": 4102400,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56901632,
+            "heapTotal": 8290304,
+            "heapUsed": 5096776,
+            "external": 1965870,
+            "arrayBuffers": 16619,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.762540999999999,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 21.5435,
+              "populated": {
+                "rss": 76005376,
+                "heapTotal": 26378240,
+                "heapUsed": 8649016,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 76005376,
+                "heapTotal": 22970368,
+                "heapUsed": 5206448,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 16.935374999999993,
+              "populated": {
+                "rss": 84213760,
+                "heapTotal": 26378240,
+                "heapUsed": 8664512,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 84213760,
+                "heapTotal": 22970368,
+                "heapUsed": 5221464,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 16.180209000000005,
+              "populated": {
+                "rss": 86294528,
+                "heapTotal": 43417600,
+                "heapUsed": 8666464,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86294528,
+                "heapTotal": 39747584,
+                "heapUsed": 5223328,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 15.258209000000008,
+              "populated": {
+                "rss": 91111424,
+                "heapTotal": 43155456,
+                "heapUsed": 8668784,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91144192,
+                "heapTotal": 39747584,
+                "heapUsed": 5225888,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 15.575457999999998,
+              "populated": {
+                "rss": 91357184,
+                "heapTotal": 43155456,
+                "heapUsed": 8670792,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91357184,
+                "heapTotal": 39747584,
+                "heapUsed": 5227848,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 3,
+          "name": "dayjs",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45563904,
+            "heapTotal": 7225344,
+            "heapUsed": 4102400,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 58851328,
+            "heapTotal": 7225344,
+            "heapUsed": 4316904,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.8491250000000008,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 148.672708,
+              "populated": {
+                "rss": 90849280,
+                "heapTotal": 15613952,
+                "heapUsed": 6220616,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 90882048,
+                "heapTotal": 13778944,
+                "heapUsed": 4497736,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 142.82687499999997,
+              "populated": {
+                "rss": 119930880,
+                "heapTotal": 15613952,
+                "heapUsed": 6223456,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 119930880,
+                "heapTotal": 14041088,
+                "heapUsed": 4499840,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 144.92975,
+              "populated": {
+                "rss": 170672128,
+                "heapTotal": 24002560,
+                "heapUsed": 6231072,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170672128,
+                "heapTotal": 22429696,
+                "heapUsed": 4507096,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 141.448417,
+              "populated": {
+                "rss": 171425792,
+                "heapTotal": 24264704,
+                "heapUsed": 6232144,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171425792,
+                "heapTotal": 22429696,
+                "heapUsed": 4517432,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 144.55899999999997,
+              "populated": {
+                "rss": 173293568,
+                "heapTotal": 41041920,
+                "heapUsed": 6249776,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 173293568,
+                "heapTotal": 39206912,
+                "heapUsed": 4525992,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 3,
+          "name": "moment",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45219840,
+            "heapTotal": 7225344,
+            "heapUsed": 4102472,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56737792,
+            "heapTotal": 11091968,
+            "heapUsed": 5894576,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 5
+          },
+          "loadMilliseconds": 4.753250000000001,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.574875000000002,
+              "populated": {
+                "rss": 67633152,
+                "heapTotal": 17907712,
+                "heapUsed": 8490920,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 67731456,
+                "heapTotal": 15548416,
+                "heapUsed": 6105928,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.092666999999999,
+              "populated": {
+                "rss": 72482816,
+                "heapTotal": 26558464,
+                "heapUsed": 8532000,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 72499200,
+                "heapTotal": 24199168,
+                "heapUsed": 6129016,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 8.094791999999998,
+              "populated": {
+                "rss": 78741504,
+                "heapTotal": 26820608,
+                "heapUsed": 8539464,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 78741504,
+                "heapTotal": 24199168,
+                "heapUsed": 6158000,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 6.943208000000013,
+              "populated": {
+                "rss": 82329600,
+                "heapTotal": 43597824,
+                "heapUsed": 8567240,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 82329600,
+                "heapTotal": 41238528,
+                "heapUsed": 6165352,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 6.9007079999999945,
+              "populated": {
+                "rss": 84459520,
+                "heapTotal": 43335680,
+                "heapUsed": 8542096,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 84459520,
+                "heapTotal": 40976384,
+                "heapUsed": 6164256,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 4,
+          "name": "moment",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45170688,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56754176,
+            "heapTotal": 11091968,
+            "heapUsed": 5894432,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 5
+          },
+          "loadMilliseconds": 5.167750000000002,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.656542000000002,
+              "populated": {
+                "rss": 68304896,
+                "heapTotal": 18169856,
+                "heapUsed": 8490784,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 68386816,
+                "heapTotal": 15548416,
+                "heapUsed": 6093360,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 5.330624999999998,
+              "populated": {
+                "rss": 73105408,
+                "heapTotal": 26296320,
+                "heapUsed": 8525968,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 73105408,
+                "heapTotal": 23937024,
+                "heapUsed": 6118136,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 8.136499999999998,
+              "populated": {
+                "rss": 79429632,
+                "heapTotal": 26820608,
+                "heapUsed": 8543112,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 79446016,
+                "heapTotal": 24199168,
+                "heapUsed": 6149168,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 6.921166999999997,
+              "populated": {
+                "rss": 83345408,
+                "heapTotal": 43597824,
+                "heapUsed": 8537504,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 83345408,
+                "heapTotal": 41238528,
+                "heapUsed": 6155096,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 6.441709000000003,
+              "populated": {
+                "rss": 85049344,
+                "heapTotal": 43335680,
+                "heapUsed": 8528912,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 85049344,
+                "heapTotal": 41238528,
+                "heapUsed": 6171112,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 4,
+          "name": "dayjs",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45547520,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 59064320,
+            "heapTotal": 7225344,
+            "heapUsed": 4316760,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.9145409999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 147.155667,
+              "populated": {
+                "rss": 90832896,
+                "heapTotal": 15613952,
+                "heapUsed": 6220400,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 90898432,
+                "heapTotal": 13778944,
+                "heapUsed": 4497440,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 150.25395799999998,
+              "populated": {
+                "rss": 119406592,
+                "heapTotal": 15876096,
+                "heapUsed": 6231328,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 119406592,
+                "heapTotal": 14041088,
+                "heapUsed": 4507408,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 147.87674999999996,
+              "populated": {
+                "rss": 170639360,
+                "heapTotal": 24264704,
+                "heapUsed": 6226168,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170639360,
+                "heapTotal": 22429696,
+                "heapUsed": 4502272,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 142.994375,
+              "populated": {
+                "rss": 171606016,
+                "heapTotal": 24526848,
+                "heapUsed": 6235968,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171606016,
+                "heapTotal": 22429696,
+                "heapUsed": 4521216,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 144.117166,
+              "populated": {
+                "rss": 173080576,
+                "heapTotal": 41304064,
+                "heapUsed": 6249456,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 173080576,
+                "heapTotal": 39206912,
+                "heapUsed": 4525632,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 4,
+          "name": "luxon",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45056000,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56852480,
+            "heapTotal": 8290304,
+            "heapUsed": 5096704,
+            "external": 1965870,
+            "arrayBuffers": 16619,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.788582999999999,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 21.161040999999997,
+              "populated": {
+                "rss": 76283904,
+                "heapTotal": 26378240,
+                "heapUsed": 8644616,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 76300288,
+                "heapTotal": 22970368,
+                "heapUsed": 5202048,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 16.893833,
+              "populated": {
+                "rss": 84574208,
+                "heapTotal": 26378240,
+                "heapUsed": 8663776,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 84574208,
+                "heapTotal": 22970368,
+                "heapUsed": 5220728,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 15.968292000000005,
+              "populated": {
+                "rss": 86540288,
+                "heapTotal": 43417600,
+                "heapUsed": 8666936,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86540288,
+                "heapTotal": 39747584,
+                "heapUsed": 5223800,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 15.837874999999997,
+              "populated": {
+                "rss": 91439104,
+                "heapTotal": 43155456,
+                "heapUsed": 8668240,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91471872,
+                "heapTotal": 39747584,
+                "heapUsed": 5225344,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 15.897874999999999,
+              "populated": {
+                "rss": 91684864,
+                "heapTotal": 43155456,
+                "heapUsed": 8670032,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91684864,
+                "heapTotal": 39747584,
+                "heapUsed": 5227088,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 4,
+          "name": "temporal",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45154304,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 61505536,
+            "heapTotal": 8290304,
+            "heapUsed": 5137424,
+            "external": 1965878,
+            "arrayBuffers": 16627,
+            "modules": 3
+          },
+          "loadMilliseconds": 12.727916999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 9.964125000000003,
+              "populated": {
+                "rss": 72024064,
+                "heapTotal": 16433152,
+                "heapUsed": 7206392,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 72073216,
+                "heapTotal": 15122432,
+                "heapUsed": 5578712,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.772082999999995,
+              "populated": {
+                "rss": 77185024,
+                "heapTotal": 24821760,
+                "heapUsed": 7221432,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 77185024,
+                "heapTotal": 23511040,
+                "heapUsed": 5581624,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.679500000000004,
+              "populated": {
+                "rss": 81461248,
+                "heapTotal": 25083904,
+                "heapUsed": 7226352,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81461248,
+                "heapTotal": 23511040,
+                "heapUsed": 5586488,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 4.3849579999999975,
+              "populated": {
+                "rss": 85426176,
+                "heapTotal": 25083904,
+                "heapUsed": 7240512,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85426176,
+                "heapTotal": 23511040,
+                "heapUsed": 5600888,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.393375000000006,
+              "populated": {
+                "rss": 87392256,
+                "heapTotal": 42123264,
+                "heapUsed": 7240648,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 87408640,
+                "heapTotal": 40288256,
+                "heapUsed": 5600976,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 5,
+          "name": "temporal",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 44892160,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 61505536,
+            "heapTotal": 8028160,
+            "heapUsed": 5137496,
+            "external": 1965878,
+            "arrayBuffers": 16627,
+            "modules": 3
+          },
+          "loadMilliseconds": 11.901541000000002,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.151624999999996,
+              "populated": {
+                "rss": 71352320,
+                "heapTotal": 16171008,
+                "heapUsed": 7217216,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 71434240,
+                "heapTotal": 14860288,
+                "heapUsed": 5577792,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.965875000000004,
+              "populated": {
+                "rss": 76824576,
+                "heapTotal": 24821760,
+                "heapUsed": 7222848,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 76824576,
+                "heapTotal": 23248896,
+                "heapUsed": 5583040,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.482542000000009,
+              "populated": {
+                "rss": 81149952,
+                "heapTotal": 24821760,
+                "heapUsed": 7229160,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81149952,
+                "heapTotal": 23248896,
+                "heapUsed": 5589296,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 4.334709000000004,
+              "populated": {
+                "rss": 85098496,
+                "heapTotal": 24821760,
+                "heapUsed": 7243400,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85114880,
+                "heapTotal": 23248896,
+                "heapUsed": 5603776,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.557083000000006,
+              "populated": {
+                "rss": 86966272,
+                "heapTotal": 41598976,
+                "heapUsed": 7243344,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 86966272,
+                "heapTotal": 40026112,
+                "heapUsed": 5603672,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 5,
+          "name": "luxon",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45449216,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56999936,
+            "heapTotal": 8290304,
+            "heapUsed": 5096704,
+            "external": 1965870,
+            "arrayBuffers": 16619,
+            "modules": 2
+          },
+          "loadMilliseconds": 3.0317919999999994,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 21.945583,
+              "populated": {
+                "rss": 76005376,
+                "heapTotal": 26640384,
+                "heapUsed": 8649640,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 76005376,
+                "heapTotal": 22970368,
+                "heapUsed": 5207072,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 16.575457999999998,
+              "populated": {
+                "rss": 84246528,
+                "heapTotal": 26640384,
+                "heapUsed": 8664128,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 84246528,
+                "heapTotal": 22970368,
+                "heapUsed": 5221080,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 15.972375,
+              "populated": {
+                "rss": 86409216,
+                "heapTotal": 43417600,
+                "heapUsed": 8666080,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86409216,
+                "heapTotal": 39747584,
+                "heapUsed": 5222944,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 15.606291999999982,
+              "populated": {
+                "rss": 91127808,
+                "heapTotal": 43155456,
+                "heapUsed": 8668400,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91127808,
+                "heapTotal": 39747584,
+                "heapUsed": 5225504,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 15.622625,
+              "populated": {
+                "rss": 91389952,
+                "heapTotal": 43155456,
+                "heapUsed": 8670408,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91439104,
+                "heapTotal": 39747584,
+                "heapUsed": 5227464,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 5,
+          "name": "dayjs",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45268992,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 58900480,
+            "heapTotal": 7225344,
+            "heapUsed": 4316760,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.848666999999999,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 159.24325,
+              "populated": {
+                "rss": 90718208,
+                "heapTotal": 15613952,
+                "heapUsed": 6219528,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 90750976,
+                "heapTotal": 13778944,
+                "heapUsed": 4496648,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 150.03441600000002,
+              "populated": {
+                "rss": 120389632,
+                "heapTotal": 15613952,
+                "heapUsed": 6224144,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 120389632,
+                "heapTotal": 14041088,
+                "heapUsed": 4500488,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 147.637292,
+              "populated": {
+                "rss": 171851776,
+                "heapTotal": 24002560,
+                "heapUsed": 6229976,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171851776,
+                "heapTotal": 22429696,
+                "heapUsed": 4506144,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 142.89766700000007,
+              "populated": {
+                "rss": 172752896,
+                "heapTotal": 24002560,
+                "heapUsed": 6228512,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 172752896,
+                "heapTotal": 22167552,
+                "heapUsed": 4513944,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 146.479875,
+              "populated": {
+                "rss": 174522368,
+                "heapTotal": 41041920,
+                "heapUsed": 6244272,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 174522368,
+                "heapTotal": 39206912,
+                "heapUsed": 4520488,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 5,
+          "name": "moment",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45039616,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56705024,
+            "heapTotal": 11091968,
+            "heapUsed": 5894432,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 5
+          },
+          "loadMilliseconds": 5.188500000000001,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.686957999999997,
+              "populated": {
+                "rss": 67420160,
+                "heapTotal": 17907712,
+                "heapUsed": 8481888,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 67518464,
+                "heapTotal": 15548416,
+                "heapUsed": 6106784,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 7.697040999999999,
+              "populated": {
+                "rss": 75268096,
+                "heapTotal": 26820608,
+                "heapUsed": 8539144,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 75431936,
+                "heapTotal": 24199168,
+                "heapUsed": 6144232,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 3.6599159999999955,
+              "populated": {
+                "rss": 80150528,
+                "heapTotal": 26820608,
+                "heapUsed": 8550488,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 80150528,
+                "heapTotal": 24199168,
+                "heapUsed": 6147456,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 7.473292000000001,
+              "populated": {
+                "rss": 83918848,
+                "heapTotal": 43597824,
+                "heapUsed": 8507728,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 83918848,
+                "heapTotal": 40714240,
+                "heapUsed": 6132480,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.396125000000012,
+              "populated": {
+                "rss": 85327872,
+                "heapTotal": 43597824,
+                "heapUsed": 8558280,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 85327872,
+                "heapTotal": 40976384,
+                "heapUsed": 6155296,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 6,
+          "name": "moment",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45596672,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 57606144,
+            "heapTotal": 11091968,
+            "heapUsed": 5894432,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 5
+          },
+          "loadMilliseconds": 5.408290999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 10.732584,
+              "populated": {
+                "rss": 68993024,
+                "heapTotal": 17907712,
+                "heapUsed": 8491664,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 69058560,
+                "heapTotal": 15810560,
+                "heapUsed": 6134432,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 5.031041000000002,
+              "populated": {
+                "rss": 73678848,
+                "heapTotal": 26296320,
+                "heapUsed": 8539688,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 73678848,
+                "heapTotal": 24461312,
+                "heapUsed": 6131984,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 8.68908300000001,
+              "populated": {
+                "rss": 80150528,
+                "heapTotal": 27344896,
+                "heapUsed": 8555032,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 80150528,
+                "heapTotal": 24461312,
+                "heapUsed": 6155144,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.701207999999994,
+              "populated": {
+                "rss": 84017152,
+                "heapTotal": 43597824,
+                "heapUsed": 8561896,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 84017152,
+                "heapTotal": 41238528,
+                "heapUsed": 6169368,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 6.663875000000004,
+              "populated": {
+                "rss": 85639168,
+                "heapTotal": 43597824,
+                "heapUsed": 8522736,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              },
+              "released": {
+                "rss": 85655552,
+                "heapTotal": 41238528,
+                "heapUsed": 6154952,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 6,
+          "name": "dayjs",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45252608,
+            "heapTotal": 7225344,
+            "heapUsed": 4102328,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 58621952,
+            "heapTotal": 7225344,
+            "heapUsed": 4316760,
+            "external": 1915463,
+            "arrayBuffers": 16619,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.8327500000000008,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 145.949625,
+              "populated": {
+                "rss": 90980352,
+                "heapTotal": 15613952,
+                "heapUsed": 6220400,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 91045888,
+                "heapTotal": 13778944,
+                "heapUsed": 4497440,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 144.95937500000002,
+              "populated": {
+                "rss": 119537664,
+                "heapTotal": 15876096,
+                "heapUsed": 6222296,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 119537664,
+                "heapTotal": 14041088,
+                "heapUsed": 4498560,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 147.64270899999997,
+              "populated": {
+                "rss": 170295296,
+                "heapTotal": 24002560,
+                "heapUsed": 6232632,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170295296,
+                "heapTotal": 22429696,
+                "heapUsed": 4508656,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 144.647375,
+              "populated": {
+                "rss": 171245568,
+                "heapTotal": 24264704,
+                "heapUsed": 6225728,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171245568,
+                "heapTotal": 22429696,
+                "heapUsed": 4510976,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 145.1840840000001,
+              "populated": {
+                "rss": 172654592,
+                "heapTotal": 41041920,
+                "heapUsed": 6244184,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              },
+              "released": {
+                "rss": 172654592,
+                "heapTotal": 39206912,
+                "heapUsed": 4520360,
+                "external": 1915463,
+                "arrayBuffers": 16619,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 6,
+          "name": "luxon",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45006848,
+            "heapTotal": 7225344,
+            "heapUsed": 4102472,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 56885248,
+            "heapTotal": 8290304,
+            "heapUsed": 5096848,
+            "external": 1965870,
+            "arrayBuffers": 16619,
+            "modules": 2
+          },
+          "loadMilliseconds": 3.058374999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 21.084458000000005,
+              "populated": {
+                "rss": 76201984,
+                "heapTotal": 26640384,
+                "heapUsed": 8649128,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 76218368,
+                "heapTotal": 22970368,
+                "heapUsed": 5206560,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 16.65054200000001,
+              "populated": {
+                "rss": 84672512,
+                "heapTotal": 26378240,
+                "heapUsed": 8664624,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 84672512,
+                "heapTotal": 22970368,
+                "heapUsed": 5221576,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 15.76745799999999,
+              "populated": {
+                "rss": 86818816,
+                "heapTotal": 43417600,
+                "heapUsed": 8666576,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86818816,
+                "heapTotal": 39747584,
+                "heapUsed": 5223440,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 15.855582999999996,
+              "populated": {
+                "rss": 91619328,
+                "heapTotal": 43155456,
+                "heapUsed": 8668896,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91635712,
+                "heapTotal": 39747584,
+                "heapUsed": 5226000,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 15.099083000000007,
+              "populated": {
+                "rss": 91701248,
+                "heapTotal": 43155456,
+                "heapUsed": 8670944,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              },
+              "released": {
+                "rss": 91701248,
+                "heapTotal": 39747584,
+                "heapUsed": 5228000,
+                "external": 1965870,
+                "arrayBuffers": 16619,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 6,
+          "name": "temporal",
+          "node": "v22.23.2",
+          "icu": "78.2",
+          "tz": "2026a",
+          "before": {
+            "rss": 45203456,
+            "heapTotal": 7225344,
+            "heapUsed": 4102472,
+            "external": 1875212,
+            "arrayBuffers": 16619,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 61652992,
+            "heapTotal": 8028160,
+            "heapUsed": 5137568,
+            "external": 1965878,
+            "arrayBuffers": 16627,
+            "modules": 3
+          },
+          "loadMilliseconds": 12.077708000000001,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 9.901958999999998,
+              "populated": {
+                "rss": 72384512,
+                "heapTotal": 16171008,
+                "heapUsed": 7203104,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 72466432,
+                "heapTotal": 14860288,
+                "heapUsed": 5579560,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.480832999999997,
+              "populated": {
+                "rss": 77398016,
+                "heapTotal": 24821760,
+                "heapUsed": 7222672,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 77398016,
+                "heapTotal": 23248896,
+                "heapUsed": 5582864,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.628458000000009,
+              "populated": {
+                "rss": 81805312,
+                "heapTotal": 24821760,
+                "heapUsed": 7227688,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81805312,
+                "heapTotal": 23248896,
+                "heapUsed": 5587824,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 4.305291999999994,
+              "populated": {
+                "rss": 85803008,
+                "heapTotal": 24821760,
+                "heapUsed": 7241848,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85803008,
+                "heapTotal": 23248896,
+                "heapUsed": 5602224,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.08658299999999,
+              "populated": {
+                "rss": 87523328,
+                "heapTotal": 41598976,
+                "heapUsed": 7241840,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              },
+              "released": {
+                "rss": 87523328,
+                "heapTotal": 40026112,
+                "heapUsed": 5602168,
+                "external": 1965878,
+                "arrayBuffers": 16627,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        }
+      ]
+    },
+    {
+      "baseline": "810b71d0d3f988cac3cacb8a00e5b27be011bab6",
+      "probeSha256": "dcb8bc3ffaa8677cf57b56941c4533681ffb4dd90c1660414f00d06be6aae8d8",
+      "scope": "Seven alternating fresh processes per candidate; five cycles of 5000 zoned values. Full server Moment timezone data. No Intl-only date type, application throughput, or server RAM-saving claim.",
+      "results": [
+        {
+          "round": 0,
+          "name": "moment",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52281344,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 60080128,
+            "heapTotal": 11255808,
+            "heapUsed": 6375008,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 5
+          },
+          "loadMilliseconds": 4.7975829999999995,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 6.070499999999996,
+              "populated": {
+                "rss": 76824576,
+                "heapTotal": 18071552,
+                "heapUsed": 8800168,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 76824576,
+                "heapTotal": 15974400,
+                "heapUsed": 6425424,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 8.265291000000005,
+              "populated": {
+                "rss": 81215488,
+                "heapTotal": 26460160,
+                "heapUsed": 8796024,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 81215488,
+                "heapTotal": 24363008,
+                "heapUsed": 6436208,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 6.930665999999995,
+              "populated": {
+                "rss": 83132416,
+                "heapTotal": 26460160,
+                "heapUsed": 8807688,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 83132416,
+                "heapTotal": 24363008,
+                "heapUsed": 6448048,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 8.443250000000006,
+              "populated": {
+                "rss": 88866816,
+                "heapTotal": 43237376,
+                "heapUsed": 8803648,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 88883200,
+                "heapTotal": 40878080,
+                "heapUsed": 6484088,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.5995829999999955,
+              "populated": {
+                "rss": 91783168,
+                "heapTotal": 43499520,
+                "heapUsed": 8880216,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 91783168,
+                "heapTotal": 41140224,
+                "heapUsed": 6433264,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 0,
+          "name": "dayjs",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52346880,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 65847296,
+            "heapTotal": 7667712,
+            "heapUsed": 4780128,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.7627500000000005,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 137.75958300000002,
+              "populated": {
+                "rss": 98598912,
+                "heapTotal": 16056320,
+                "heapUsed": 6461832,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 98598912,
+                "heapTotal": 14221312,
+                "heapUsed": 4813488,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 141.68562500000002,
+              "populated": {
+                "rss": 118833152,
+                "heapTotal": 15794176,
+                "heapUsed": 6464200,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 118833152,
+                "heapTotal": 13959168,
+                "heapUsed": 4815456,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 143.237167,
+              "populated": {
+                "rss": 170311680,
+                "heapTotal": 24444928,
+                "heapUsed": 6476864,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170311680,
+                "heapTotal": 22347776,
+                "heapUsed": 4816080,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 142.42345900000004,
+              "populated": {
+                "rss": 171229184,
+                "heapTotal": 23920640,
+                "heapUsed": 6469776,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171229184,
+                "heapTotal": 22347776,
+                "heapUsed": 4819640,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 136.72354200000007,
+              "populated": {
+                "rss": 171622400,
+                "heapTotal": 24444928,
+                "heapUsed": 6481288,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171622400,
+                "heapTotal": 22347776,
+                "heapUsed": 4820648,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 0,
+          "name": "luxon",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52199424,
+            "heapTotal": 7405568,
+            "heapUsed": 4553744,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 63946752,
+            "heapTotal": 8454144,
+            "heapUsed": 5530960,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.343207999999997,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 14.949292,
+              "populated": {
+                "rss": 80379904,
+                "heapTotal": 18415616,
+                "heapUsed": 9039368,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 80412672,
+                "heapTotal": 15007744,
+                "heapUsed": 5596864,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 15.672250000000005,
+              "populated": {
+                "rss": 86671360,
+                "heapTotal": 26542080,
+                "heapUsed": 8967232,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86671360,
+                "heapTotal": 23396352,
+                "heapUsed": 5597344,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 15.002667000000002,
+              "populated": {
+                "rss": 92422144,
+                "heapTotal": 43581440,
+                "heapUsed": 9064576,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 92454912,
+                "heapTotal": 40173568,
+                "heapUsed": 5600904,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 14.018583000000007,
+              "populated": {
+                "rss": 99418112,
+                "heapTotal": 43319296,
+                "heapUsed": 8979944,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99434496,
+                "heapTotal": 40173568,
+                "heapUsed": 5623640,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 13.390958999999981,
+              "populated": {
+                "rss": 99450880,
+                "heapTotal": 43319296,
+                "heapUsed": 8970312,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99450880,
+                "heapTotal": 40173568,
+                "heapUsed": 5591440,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 0,
+          "name": "temporal",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 51953664,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64258048,
+            "heapTotal": 8716288,
+            "heapUsed": 5571760,
+            "external": 2298106,
+            "arrayBuffers": 143619,
+            "modules": 3
+          },
+          "loadMilliseconds": 11.521957999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 7.198958000000005,
+              "populated": {
+                "rss": 81362944,
+                "heapTotal": 16596992,
+                "heapUsed": 7612712,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81412096,
+                "heapTotal": 15024128,
+                "heapUsed": 5977240,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.766125000000002,
+              "populated": {
+                "rss": 86048768,
+                "heapTotal": 24985600,
+                "heapUsed": 7629808,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 86048768,
+                "heapTotal": 23150592,
+                "heapUsed": 5989992,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.2846250000000055,
+              "populated": {
+                "rss": 90390528,
+                "heapTotal": 25247744,
+                "heapUsed": 7631032,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 91013120,
+                "heapTotal": 23150592,
+                "heapUsed": 5991168,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.380750000000006,
+              "populated": {
+                "rss": 95207424,
+                "heapTotal": 24985600,
+                "heapUsed": 7656608,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95223808,
+                "heapTotal": 23412736,
+                "heapUsed": 6022160,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.4970830000000035,
+              "populated": {
+                "rss": 95633408,
+                "heapTotal": 24985600,
+                "heapUsed": 7662320,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95633408,
+                "heapTotal": 23412736,
+                "heapUsed": 6003736,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 1,
+          "name": "temporal",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52314112,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64634880,
+            "heapTotal": 8454144,
+            "heapUsed": 5571832,
+            "external": 2298106,
+            "arrayBuffers": 143619,
+            "modules": 3
+          },
+          "loadMilliseconds": 11.939875,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 7.813749999999999,
+              "populated": {
+                "rss": 81854464,
+                "heapTotal": 17121280,
+                "heapUsed": 7612784,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81870848,
+                "heapTotal": 15024128,
+                "heapUsed": 5977312,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 6.632625000000004,
+              "populated": {
+                "rss": 86441984,
+                "heapTotal": 25247744,
+                "heapUsed": 7629880,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 86851584,
+                "heapTotal": 23674880,
+                "heapUsed": 5990064,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.796750000000003,
+              "populated": {
+                "rss": 91160576,
+                "heapTotal": 25509888,
+                "heapUsed": 7631104,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 91209728,
+                "heapTotal": 23674880,
+                "heapUsed": 5991240,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.5597080000000005,
+              "populated": {
+                "rss": 95305728,
+                "heapTotal": 25247744,
+                "heapUsed": 7656680,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95305728,
+                "heapTotal": 23674880,
+                "heapUsed": 6022232,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.3276249999999976,
+              "populated": {
+                "rss": 95453184,
+                "heapTotal": 25509888,
+                "heapUsed": 7662392,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95453184,
+                "heapTotal": 23674880,
+                "heapUsed": 6003808,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 1,
+          "name": "luxon",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52166656,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64110592,
+            "heapTotal": 8454144,
+            "heapUsed": 5530888,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.448125000000001,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 15.180542000000003,
+              "populated": {
+                "rss": 79626240,
+                "heapTotal": 18415616,
+                "heapUsed": 9039296,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 79659008,
+                "heapTotal": 15007744,
+                "heapUsed": 5596792,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 15.770499999999998,
+              "populated": {
+                "rss": 85884928,
+                "heapTotal": 26542080,
+                "heapUsed": 8967160,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 85884928,
+                "heapTotal": 23396352,
+                "heapUsed": 5597272,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 14.555333000000005,
+              "populated": {
+                "rss": 92143616,
+                "heapTotal": 43319296,
+                "heapUsed": 9064776,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 92143616,
+                "heapTotal": 40173568,
+                "heapUsed": 5600832,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 13.950624999999988,
+              "populated": {
+                "rss": 99483648,
+                "heapTotal": 43319296,
+                "heapUsed": 8979872,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99483648,
+                "heapTotal": 40173568,
+                "heapUsed": 5623568,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 13.388334,
+              "populated": {
+                "rss": 99500032,
+                "heapTotal": 43319296,
+                "heapUsed": 8970240,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99500032,
+                "heapTotal": 40173568,
+                "heapUsed": 5591368,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 1,
+          "name": "dayjs",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52297728,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 65699840,
+            "heapTotal": 7667712,
+            "heapUsed": 4780128,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.774874999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 139.935292,
+              "populated": {
+                "rss": 98975744,
+                "heapTotal": 16056320,
+                "heapUsed": 6462192,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 98975744,
+                "heapTotal": 13959168,
+                "heapUsed": 4813848,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 145.55437500000002,
+              "populated": {
+                "rss": 118423552,
+                "heapTotal": 15532032,
+                "heapUsed": 6464560,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 118423552,
+                "heapTotal": 13959168,
+                "heapUsed": 4815816,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 142.44320799999997,
+              "populated": {
+                "rss": 170393600,
+                "heapTotal": 24182784,
+                "heapUsed": 6477224,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170393600,
+                "heapTotal": 22347776,
+                "heapUsed": 4816440,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 144.05512499999998,
+              "populated": {
+                "rss": 171114496,
+                "heapTotal": 24182784,
+                "heapUsed": 6470136,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171114496,
+                "heapTotal": 22347776,
+                "heapUsed": 4820000,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 137.77208399999995,
+              "populated": {
+                "rss": 171327488,
+                "heapTotal": 24182784,
+                "heapUsed": 6481648,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171327488,
+                "heapTotal": 22347776,
+                "heapUsed": 4821008,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 1,
+          "name": "moment",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52232192,
+            "heapTotal": 7405568,
+            "heapUsed": 4553888,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 59998208,
+            "heapTotal": 11255808,
+            "heapUsed": 6375800,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 5
+          },
+          "loadMilliseconds": 4.422916999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 6.126625000000001,
+              "populated": {
+                "rss": 76611584,
+                "heapTotal": 18071552,
+                "heapUsed": 8801000,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 76627968,
+                "heapTotal": 15712256,
+                "heapUsed": 6426256,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 8.440000000000005,
+              "populated": {
+                "rss": 81444864,
+                "heapTotal": 26460160,
+                "heapUsed": 8785816,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 81444864,
+                "heapTotal": 24100864,
+                "heapUsed": 6425816,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 7.191167000000007,
+              "populated": {
+                "rss": 83378176,
+                "heapTotal": 26722304,
+                "heapUsed": 8806640,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 83378176,
+                "heapTotal": 24100864,
+                "heapUsed": 6421104,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 8.345042000000007,
+              "populated": {
+                "rss": 88719360,
+                "heapTotal": 43499520,
+                "heapUsed": 8804000,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 88735744,
+                "heapTotal": 40878080,
+                "heapUsed": 6484440,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.574457999999993,
+              "populated": {
+                "rss": 91160576,
+                "heapTotal": 43499520,
+                "heapUsed": 8880800,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 91160576,
+                "heapTotal": 40878080,
+                "heapUsed": 6433840,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 2,
+          "name": "moment",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52133888,
+            "heapTotal": 7667712,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 60063744,
+            "heapTotal": 11517952,
+            "heapUsed": 6375584,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 5
+          },
+          "loadMilliseconds": 4.4425409999999985,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 6.114083000000004,
+              "populated": {
+                "rss": 76546048,
+                "heapTotal": 18333696,
+                "heapUsed": 8801880,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 76546048,
+                "heapTotal": 15712256,
+                "heapUsed": 6427136,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 8.605333000000002,
+              "populated": {
+                "rss": 81494016,
+                "heapTotal": 26460160,
+                "heapUsed": 8797736,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 81494016,
+                "heapTotal": 24100864,
+                "heapUsed": 6437952,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 7.070458000000002,
+              "populated": {
+                "rss": 83607552,
+                "heapTotal": 26722304,
+                "heapUsed": 8807952,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 83607552,
+                "heapTotal": 24100864,
+                "heapUsed": 6422240,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 8.398916999999997,
+              "populated": {
+                "rss": 89014272,
+                "heapTotal": 43237376,
+                "heapUsed": 8804272,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 89047040,
+                "heapTotal": 40878080,
+                "heapUsed": 6484712,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.531000000000006,
+              "populated": {
+                "rss": 91750400,
+                "heapTotal": 43237376,
+                "heapUsed": 8880920,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 91750400,
+                "heapTotal": 40878080,
+                "heapUsed": 6433960,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 2,
+          "name": "dayjs",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52314112,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 65634304,
+            "heapTotal": 7667712,
+            "heapUsed": 4780128,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.7566249999999997,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 140.511792,
+              "populated": {
+                "rss": 98844672,
+                "heapTotal": 16056320,
+                "heapUsed": 6462192,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 98844672,
+                "heapTotal": 13959168,
+                "heapUsed": 4813848,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 144.99920799999998,
+              "populated": {
+                "rss": 118177792,
+                "heapTotal": 15532032,
+                "heapUsed": 6464560,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 118177792,
+                "heapTotal": 13959168,
+                "heapUsed": 4815816,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 139.61199999999997,
+              "populated": {
+                "rss": 170688512,
+                "heapTotal": 24182784,
+                "heapUsed": 6477224,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170688512,
+                "heapTotal": 22347776,
+                "heapUsed": 4816440,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 139.785167,
+              "populated": {
+                "rss": 171212800,
+                "heapTotal": 23920640,
+                "heapUsed": 6470136,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171212800,
+                "heapTotal": 22347776,
+                "heapUsed": 4820000,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 135.594875,
+              "populated": {
+                "rss": 171819008,
+                "heapTotal": 24444928,
+                "heapUsed": 6481648,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171819008,
+                "heapTotal": 22347776,
+                "heapUsed": 4821008,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 2,
+          "name": "luxon",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52101120,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64159744,
+            "heapTotal": 8454144,
+            "heapUsed": 5530888,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.6400000000000006,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 14.901542,
+              "populated": {
+                "rss": 79888384,
+                "heapTotal": 18415616,
+                "heapUsed": 9039416,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 79921152,
+                "heapTotal": 14745600,
+                "heapUsed": 5596912,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 15.866624999999999,
+              "populated": {
+                "rss": 86212608,
+                "heapTotal": 26542080,
+                "heapUsed": 8967280,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86212608,
+                "heapTotal": 23134208,
+                "heapUsed": 5597392,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 14.676292000000004,
+              "populated": {
+                "rss": 92323840,
+                "heapTotal": 43581440,
+                "heapUsed": 9063776,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 92323840,
+                "heapTotal": 40173568,
+                "heapUsed": 5600952,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 14.219875000000002,
+              "populated": {
+                "rss": 99106816,
+                "heapTotal": 43319296,
+                "heapUsed": 8979992,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99106816,
+                "heapTotal": 40173568,
+                "heapUsed": 5623688,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 13.322124999999986,
+              "populated": {
+                "rss": 99303424,
+                "heapTotal": 43319296,
+                "heapUsed": 8970360,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99303424,
+                "heapTotal": 40173568,
+                "heapUsed": 5591488,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 2,
+          "name": "temporal",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52510720,
+            "heapTotal": 7405568,
+            "heapUsed": 4553744,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64323584,
+            "heapTotal": 8454144,
+            "heapUsed": 5571832,
+            "external": 2298106,
+            "arrayBuffers": 143619,
+            "modules": 3
+          },
+          "loadMilliseconds": 11.432000000000002,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 7.110167000000004,
+              "populated": {
+                "rss": 81412096,
+                "heapTotal": 16859136,
+                "heapUsed": 7612784,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81510400,
+                "heapTotal": 15286272,
+                "heapUsed": 5977312,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.853459000000001,
+              "populated": {
+                "rss": 85983232,
+                "heapTotal": 25247744,
+                "heapUsed": 7642184,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 86016000,
+                "heapTotal": 23674880,
+                "heapUsed": 5990064,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.444709000000003,
+              "populated": {
+                "rss": 90357760,
+                "heapTotal": 25509888,
+                "heapUsed": 7631104,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 90357760,
+                "heapTotal": 23674880,
+                "heapUsed": 5991240,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.590999999999994,
+              "populated": {
+                "rss": 94633984,
+                "heapTotal": 25247744,
+                "heapUsed": 7656680,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 94650368,
+                "heapTotal": 23674880,
+                "heapUsed": 6022232,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.4036250000000052,
+              "populated": {
+                "rss": 95469568,
+                "heapTotal": 25509888,
+                "heapUsed": 7662392,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95469568,
+                "heapTotal": 23674880,
+                "heapUsed": 6003808,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 3,
+          "name": "temporal",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52051968,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64536576,
+            "heapTotal": 8454144,
+            "heapUsed": 6044184,
+            "external": 2298106,
+            "arrayBuffers": 143619,
+            "modules": 3
+          },
+          "loadMilliseconds": 11.474041999999997,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 6.941083000000006,
+              "populated": {
+                "rss": 81330176,
+                "heapTotal": 16859136,
+                "heapUsed": 7612712,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81379328,
+                "heapTotal": 15286272,
+                "heapUsed": 5977240,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.829875000000001,
+              "populated": {
+                "rss": 85999616,
+                "heapTotal": 25247744,
+                "heapUsed": 7629808,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85999616,
+                "heapTotal": 23674880,
+                "heapUsed": 5989992,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.455292,
+              "populated": {
+                "rss": 90243072,
+                "heapTotal": 25509888,
+                "heapUsed": 7631032,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 90243072,
+                "heapTotal": 23674880,
+                "heapUsed": 5991168,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.5983329999999967,
+              "populated": {
+                "rss": 94945280,
+                "heapTotal": 25247744,
+                "heapUsed": 7656608,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 94961664,
+                "heapTotal": 23674880,
+                "heapUsed": 6022160,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.252625000000009,
+              "populated": {
+                "rss": 95109120,
+                "heapTotal": 25247744,
+                "heapUsed": 7662320,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95109120,
+                "heapTotal": 23674880,
+                "heapUsed": 6003736,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 3,
+          "name": "luxon",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52445184,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64077824,
+            "heapTotal": 8454144,
+            "heapUsed": 5530888,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.252958999999997,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 15.21275,
+              "populated": {
+                "rss": 80183296,
+                "heapTotal": 18415616,
+                "heapUsed": 9039296,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 80281600,
+                "heapTotal": 15007744,
+                "heapUsed": 5596792,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 15.704625,
+              "populated": {
+                "rss": 86622208,
+                "heapTotal": 26542080,
+                "heapUsed": 8967160,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86638592,
+                "heapTotal": 23396352,
+                "heapUsed": 5597272,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 15.029832999999996,
+              "populated": {
+                "rss": 92176384,
+                "heapTotal": 43319296,
+                "heapUsed": 9064344,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 92176384,
+                "heapTotal": 40173568,
+                "heapUsed": 5600832,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 14.660833999999994,
+              "populated": {
+                "rss": 99483648,
+                "heapTotal": 43319296,
+                "heapUsed": 8979872,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99483648,
+                "heapTotal": 40173568,
+                "heapUsed": 5623568,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 13.615666999999988,
+              "populated": {
+                "rss": 99500032,
+                "heapTotal": 43319296,
+                "heapUsed": 8970240,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99500032,
+                "heapTotal": 40173568,
+                "heapUsed": 5591368,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 3,
+          "name": "dayjs",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52166656,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 65699840,
+            "heapTotal": 7667712,
+            "heapUsed": 4780128,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.782,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 139.56454200000002,
+              "populated": {
+                "rss": 99254272,
+                "heapTotal": 16056320,
+                "heapUsed": 6461832,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 99254272,
+                "heapTotal": 14221312,
+                "heapUsed": 4813488,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 141.53291700000003,
+              "populated": {
+                "rss": 118243328,
+                "heapTotal": 15532032,
+                "heapUsed": 6464200,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 118243328,
+                "heapTotal": 13959168,
+                "heapUsed": 4815456,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 140.095917,
+              "populated": {
+                "rss": 170016768,
+                "heapTotal": 24444928,
+                "heapUsed": 6476864,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170016768,
+                "heapTotal": 22347776,
+                "heapUsed": 4816080,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 140.00195799999995,
+              "populated": {
+                "rss": 170835968,
+                "heapTotal": 23920640,
+                "heapUsed": 6469776,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170835968,
+                "heapTotal": 22347776,
+                "heapUsed": 4819640,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 139.87408299999993,
+              "populated": {
+                "rss": 171229184,
+                "heapTotal": 24182784,
+                "heapUsed": 6481288,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171229184,
+                "heapTotal": 22347776,
+                "heapUsed": 4820648,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 3,
+          "name": "moment",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52297728,
+            "heapTotal": 7405568,
+            "heapUsed": 4553744,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 59949056,
+            "heapTotal": 11517952,
+            "heapUsed": 6375152,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 5
+          },
+          "loadMilliseconds": 4.5504999999999995,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 6.2157080000000065,
+              "populated": {
+                "rss": 76677120,
+                "heapTotal": 18333696,
+                "heapUsed": 8801312,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 76677120,
+                "heapTotal": 15974400,
+                "heapUsed": 6426568,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 8.359750000000005,
+              "populated": {
+                "rss": 81100800,
+                "heapTotal": 26460160,
+                "heapUsed": 8787128,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 81117184,
+                "heapTotal": 24363008,
+                "heapUsed": 6439504,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 6.4822089999999974,
+              "populated": {
+                "rss": 82935808,
+                "heapTotal": 26722304,
+                "heapUsed": 8790928,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 82935808,
+                "heapTotal": 24363008,
+                "heapUsed": 6422000,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 8.605958999999999,
+              "populated": {
+                "rss": 88195072,
+                "heapTotal": 43499520,
+                "heapUsed": 8804408,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 88211456,
+                "heapTotal": 41140224,
+                "heapUsed": 6483752,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.875500000000002,
+              "populated": {
+                "rss": 91357184,
+                "heapTotal": 43237376,
+                "heapUsed": 8877664,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 91357184,
+                "heapTotal": 41140224,
+                "heapUsed": 6432792,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 4,
+          "name": "moment",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52232192,
+            "heapTotal": 7405568,
+            "heapUsed": 4553744,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 59785216,
+            "heapTotal": 11780096,
+            "heapUsed": 6375752,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 5
+          },
+          "loadMilliseconds": 4.5199169999999995,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 5.946250000000006,
+              "populated": {
+                "rss": 76759040,
+                "heapTotal": 18071552,
+                "heapUsed": 8801952,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 76759040,
+                "heapTotal": 15974400,
+                "heapUsed": 6427208,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 8.830332999999996,
+              "populated": {
+                "rss": 79200256,
+                "heapTotal": 26460160,
+                "heapUsed": 8787768,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 79200256,
+                "heapTotal": 24363008,
+                "heapUsed": 6440144,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 6.763041000000001,
+              "populated": {
+                "rss": 82886656,
+                "heapTotal": 26722304,
+                "heapUsed": 8791576,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 82886656,
+                "heapTotal": 24363008,
+                "heapUsed": 6422648,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 8.572958,
+              "populated": {
+                "rss": 88211456,
+                "heapTotal": 43499520,
+                "heapUsed": 8814808,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 88227840,
+                "heapTotal": 41140224,
+                "heapUsed": 6484400,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.718958000000001,
+              "populated": {
+                "rss": 91209728,
+                "heapTotal": 43499520,
+                "heapUsed": 8878392,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 91209728,
+                "heapTotal": 41140224,
+                "heapUsed": 6433512,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 4,
+          "name": "dayjs",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52330496,
+            "heapTotal": 7405568,
+            "heapUsed": 4553744,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 65650688,
+            "heapTotal": 7667712,
+            "heapUsed": 4780200,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.7286660000000005,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 138.049959,
+              "populated": {
+                "rss": 98729984,
+                "heapTotal": 16056320,
+                "heapUsed": 6462264,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 98779136,
+                "heapTotal": 13959168,
+                "heapUsed": 4813920,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 143.829375,
+              "populated": {
+                "rss": 118390784,
+                "heapTotal": 15794176,
+                "heapUsed": 6464624,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 118390784,
+                "heapTotal": 13959168,
+                "heapUsed": 4815888,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 143.03637499999996,
+              "populated": {
+                "rss": 170229760,
+                "heapTotal": 23920640,
+                "heapUsed": 6477288,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170229760,
+                "heapTotal": 22347776,
+                "heapUsed": 4816512,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 145.91316700000004,
+              "populated": {
+                "rss": 170770432,
+                "heapTotal": 23920640,
+                "heapUsed": 6470208,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170770432,
+                "heapTotal": 22347776,
+                "heapUsed": 4820072,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 138.21550000000002,
+              "populated": {
+                "rss": 171245568,
+                "heapTotal": 23920640,
+                "heapUsed": 6481712,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171245568,
+                "heapTotal": 22347776,
+                "heapUsed": 4821080,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 4,
+          "name": "luxon",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52117504,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64126976,
+            "heapTotal": 8454144,
+            "heapUsed": 5530560,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.250667,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 15.516000000000005,
+              "populated": {
+                "rss": 79708160,
+                "heapTotal": 18939904,
+                "heapUsed": 9047616,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 79822848,
+                "heapTotal": 14745600,
+                "heapUsed": 5597296,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 15.497584000000003,
+              "populated": {
+                "rss": 86065152,
+                "heapTotal": 26279936,
+                "heapUsed": 8967640,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86065152,
+                "heapTotal": 23134208,
+                "heapUsed": 5597752,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 14.952957999999995,
+              "populated": {
+                "rss": 92045312,
+                "heapTotal": 43581440,
+                "heapUsed": 9063688,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 92028928,
+                "heapTotal": 39911424,
+                "heapUsed": 5600928,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 14.363582999999991,
+              "populated": {
+                "rss": 99106816,
+                "heapTotal": 43057152,
+                "heapUsed": 8979896,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99123200,
+                "heapTotal": 39911424,
+                "heapUsed": 5623592,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 13.55920900000001,
+              "populated": {
+                "rss": 99385344,
+                "heapTotal": 43057152,
+                "heapUsed": 8970336,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99401728,
+                "heapTotal": 39911424,
+                "heapUsed": 5591464,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 4,
+          "name": "temporal",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52396032,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64438272,
+            "heapTotal": 8454144,
+            "heapUsed": 5571760,
+            "external": 2298106,
+            "arrayBuffers": 143619,
+            "modules": 3
+          },
+          "loadMilliseconds": 11.504875000000002,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 7.170875000000002,
+              "populated": {
+                "rss": 81444864,
+                "heapTotal": 17121280,
+                "heapUsed": 7612712,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81494016,
+                "heapTotal": 15286272,
+                "heapUsed": 5977240,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.635666999999998,
+              "populated": {
+                "rss": 86310912,
+                "heapTotal": 25247744,
+                "heapUsed": 7629808,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 86310912,
+                "heapTotal": 23674880,
+                "heapUsed": 5989992,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.447333,
+              "populated": {
+                "rss": 90750976,
+                "heapTotal": 25509888,
+                "heapUsed": 7631032,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 90750976,
+                "heapTotal": 23674880,
+                "heapUsed": 5991168,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.4164590000000032,
+              "populated": {
+                "rss": 95109120,
+                "heapTotal": 25247744,
+                "heapUsed": 7653720,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95813632,
+                "heapTotal": 23674880,
+                "heapUsed": 6012280,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.5857500000000044,
+              "populated": {
+                "rss": 95961088,
+                "heapTotal": 25509888,
+                "heapUsed": 7662320,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95961088,
+                "heapTotal": 23674880,
+                "heapUsed": 6003736,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 5,
+          "name": "temporal",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52297728,
+            "heapTotal": 7405568,
+            "heapUsed": 4553744,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64421888,
+            "heapTotal": 8978432,
+            "heapUsed": 5571904,
+            "external": 2298106,
+            "arrayBuffers": 143619,
+            "modules": 3
+          },
+          "loadMilliseconds": 11.568124999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 7.154625000000003,
+              "populated": {
+                "rss": 81477632,
+                "heapTotal": 16596992,
+                "heapUsed": 7612856,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81575936,
+                "heapTotal": 15024128,
+                "heapUsed": 5977384,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 4.893082999999997,
+              "populated": {
+                "rss": 85934080,
+                "heapTotal": 24985600,
+                "heapUsed": 7629952,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85934080,
+                "heapTotal": 23150592,
+                "heapUsed": 5990136,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.635208000000006,
+              "populated": {
+                "rss": 90210304,
+                "heapTotal": 25247744,
+                "heapUsed": 7631176,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 90210304,
+                "heapTotal": 23150592,
+                "heapUsed": 5991312,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.466417000000007,
+              "populated": {
+                "rss": 94666752,
+                "heapTotal": 24985600,
+                "heapUsed": 7656752,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 94666752,
+                "heapTotal": 23412736,
+                "heapUsed": 6022304,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.2693749999999966,
+              "populated": {
+                "rss": 95158272,
+                "heapTotal": 24985600,
+                "heapUsed": 7662464,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95158272,
+                "heapTotal": 23412736,
+                "heapUsed": 6003880,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 5,
+          "name": "luxon",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52133888,
+            "heapTotal": 7667712,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64339968,
+            "heapTotal": 8454144,
+            "heapUsed": 5530888,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.2329170000000005,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 14.556959000000006,
+              "populated": {
+                "rss": 80363520,
+                "heapTotal": 18153472,
+                "heapUsed": 9039296,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 80379904,
+                "heapTotal": 15007744,
+                "heapUsed": 5596792,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 15.434666999999997,
+              "populated": {
+                "rss": 86835200,
+                "heapTotal": 26542080,
+                "heapUsed": 8967160,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86867968,
+                "heapTotal": 23134208,
+                "heapUsed": 5597272,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 14.720917,
+              "populated": {
+                "rss": 92635136,
+                "heapTotal": 43581440,
+                "heapUsed": 9064232,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 92635136,
+                "heapTotal": 40173568,
+                "heapUsed": 5600832,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 14.129916000000009,
+              "populated": {
+                "rss": 99303424,
+                "heapTotal": 43319296,
+                "heapUsed": 8979872,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99303424,
+                "heapTotal": 40173568,
+                "heapUsed": 5623568,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 13.202958999999993,
+              "populated": {
+                "rss": 99336192,
+                "heapTotal": 43319296,
+                "heapUsed": 8970240,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99336192,
+                "heapTotal": 40173568,
+                "heapUsed": 5591368,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 5,
+          "name": "dayjs",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52084736,
+            "heapTotal": 7667712,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 65470464,
+            "heapTotal": 7929856,
+            "heapUsed": 4780128,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.7317909999999976,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 138.448916,
+              "populated": {
+                "rss": 98533376,
+                "heapTotal": 15794176,
+                "heapUsed": 6461832,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 98566144,
+                "heapTotal": 14221312,
+                "heapUsed": 4813488,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 143.215791,
+              "populated": {
+                "rss": 118472704,
+                "heapTotal": 15794176,
+                "heapUsed": 6464200,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 118472704,
+                "heapTotal": 14221312,
+                "heapUsed": 4815456,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 142.18874999999997,
+              "populated": {
+                "rss": 170033152,
+                "heapTotal": 24182784,
+                "heapUsed": 6476864,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170049536,
+                "heapTotal": 22609920,
+                "heapUsed": 4816080,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 142.56008400000002,
+              "populated": {
+                "rss": 170967040,
+                "heapTotal": 23920640,
+                "heapUsed": 6469776,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170967040,
+                "heapTotal": 22609920,
+                "heapUsed": 4819640,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 137.41279199999997,
+              "populated": {
+                "rss": 171016192,
+                "heapTotal": 24182784,
+                "heapUsed": 6481288,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171016192,
+                "heapTotal": 22609920,
+                "heapUsed": 4820648,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 5,
+          "name": "moment",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52232192,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 59703296,
+            "heapTotal": 11517952,
+            "heapUsed": 6375656,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 5
+          },
+          "loadMilliseconds": 4.421540999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 6.026042,
+              "populated": {
+                "rss": 76382208,
+                "heapTotal": 18333696,
+                "heapUsed": 8801952,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 76382208,
+                "heapTotal": 16236544,
+                "heapUsed": 6427208,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 8.594999999999999,
+              "populated": {
+                "rss": 81100800,
+                "heapTotal": 26722304,
+                "heapUsed": 8786768,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 81100800,
+                "heapTotal": 24625152,
+                "heapUsed": 6426768,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 7.096833999999994,
+              "populated": {
+                "rss": 83099648,
+                "heapTotal": 26984448,
+                "heapUsed": 8807784,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 83099648,
+                "heapTotal": 24625152,
+                "heapUsed": 6422072,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 8.20150000000001,
+              "populated": {
+                "rss": 88457216,
+                "heapTotal": 43499520,
+                "heapUsed": 8804104,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 88473600,
+                "heapTotal": 41140224,
+                "heapUsed": 6484544,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.5097920000000045,
+              "populated": {
+                "rss": 91127808,
+                "heapTotal": 43237376,
+                "heapUsed": 8878536,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 91127808,
+                "heapTotal": 41402368,
+                "heapUsed": 6433656,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 6,
+          "name": "moment",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52232192,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 59899904,
+            "heapTotal": 11780096,
+            "heapUsed": 6375584,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 5
+          },
+          "loadMilliseconds": 4.598834,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 6.352249999999998,
+              "populated": {
+                "rss": 76808192,
+                "heapTotal": 17809408,
+                "heapUsed": 8800784,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 76824576,
+                "heapTotal": 15712256,
+                "heapUsed": 6426040,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 8.327833999999996,
+              "populated": {
+                "rss": 81133568,
+                "heapTotal": 26460160,
+                "heapUsed": 8786600,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 81166336,
+                "heapTotal": 24100864,
+                "heapUsed": 6438976,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 6.430667,
+              "populated": {
+                "rss": 82903040,
+                "heapTotal": 26460160,
+                "heapUsed": 8790392,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 82903040,
+                "heapTotal": 24100864,
+                "heapUsed": 6421464,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 8.385083999999992,
+              "populated": {
+                "rss": 88621056,
+                "heapTotal": 42975232,
+                "heapUsed": 8804984,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 88637440,
+                "heapTotal": 40878080,
+                "heapUsed": 6484328,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 4.815999999999988,
+              "populated": {
+                "rss": 91406336,
+                "heapTotal": 43237376,
+                "heapUsed": 8880440,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              },
+              "released": {
+                "rss": 91439104,
+                "heapTotal": 40878080,
+                "heapUsed": 6433480,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 5
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 6,
+          "name": "dayjs",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52133888,
+            "heapTotal": 7405568,
+            "heapUsed": 4553744,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 65601536,
+            "heapTotal": 7667712,
+            "heapUsed": 4780200,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 4
+          },
+          "loadMilliseconds": 0.7440420000000003,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 145.608292,
+              "populated": {
+                "rss": 98926592,
+                "heapTotal": 15532032,
+                "heapUsed": 6461904,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 98942976,
+                "heapTotal": 13959168,
+                "heapUsed": 4813560,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 146.646125,
+              "populated": {
+                "rss": 118472704,
+                "heapTotal": 15794176,
+                "heapUsed": 6464272,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 118472704,
+                "heapTotal": 13959168,
+                "heapUsed": 4815528,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 146.09125,
+              "populated": {
+                "rss": 170508288,
+                "heapTotal": 23920640,
+                "heapUsed": 6476936,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170508288,
+                "heapTotal": 22347776,
+                "heapUsed": 4816152,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 142.67737500000004,
+              "populated": {
+                "rss": 170885120,
+                "heapTotal": 23920640,
+                "heapUsed": 6469848,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 170885120,
+                "heapTotal": 22347776,
+                "heapUsed": 4819712,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 144.43270800000005,
+              "populated": {
+                "rss": 171196416,
+                "heapTotal": 23920640,
+                "heapUsed": 6481360,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              },
+              "released": {
+                "rss": 171196416,
+                "heapTotal": 22347776,
+                "heapUsed": 4820720,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 4
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 6,
+          "name": "luxon",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52215808,
+            "heapTotal": 7405568,
+            "heapUsed": 4553672,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64159744,
+            "heapTotal": 8454144,
+            "heapUsed": 5530888,
+            "external": 2298098,
+            "arrayBuffers": 143611,
+            "modules": 2
+          },
+          "loadMilliseconds": 2.2159590000000016,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 15.461500000000001,
+              "populated": {
+                "rss": 80445440,
+                "heapTotal": 18415616,
+                "heapUsed": 9039296,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 80478208,
+                "heapTotal": 14745600,
+                "heapUsed": 5596792,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 15.75,
+              "populated": {
+                "rss": 86720512,
+                "heapTotal": 26279936,
+                "heapUsed": 8967160,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 86769664,
+                "heapTotal": 23134208,
+                "heapUsed": 5597272,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 15.046582999999998,
+              "populated": {
+                "rss": 92389376,
+                "heapTotal": 43843584,
+                "heapUsed": 9064232,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 92372992,
+                "heapTotal": 39911424,
+                "heapUsed": 5600832,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 14.540291999999994,
+              "populated": {
+                "rss": 99745792,
+                "heapTotal": 43319296,
+                "heapUsed": 8979872,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99762176,
+                "heapTotal": 39911424,
+                "heapUsed": 5623568,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 13.688041999999996,
+              "populated": {
+                "rss": 99893248,
+                "heapTotal": 43057152,
+                "heapUsed": 8970240,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              },
+              "released": {
+                "rss": 99893248,
+                "heapTotal": 39911424,
+                "heapUsed": 5591368,
+                "external": 2298098,
+                "arrayBuffers": 143611,
+                "modules": 2
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        },
+        {
+          "round": 6,
+          "name": "temporal",
+          "node": "v24.20.0",
+          "icu": "78.3",
+          "tz": "2026c",
+          "before": {
+            "rss": 52264960,
+            "heapTotal": 7405568,
+            "heapUsed": 4553744,
+            "external": 2257406,
+            "arrayBuffers": 143611,
+            "modules": 1
+          },
+          "loaded": {
+            "rss": 64307200,
+            "heapTotal": 8978432,
+            "heapUsed": 5571904,
+            "external": 2298106,
+            "arrayBuffers": 143619,
+            "modules": 3
+          },
+          "loadMilliseconds": 11.717416999999998,
+          "cycles": [
+            {
+              "cycle": 0,
+              "milliseconds": 7.5944590000000005,
+              "populated": {
+                "rss": 81608704,
+                "heapTotal": 16596992,
+                "heapUsed": 7612856,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 81657856,
+                "heapTotal": 14761984,
+                "heapUsed": 5977384,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 1,
+              "milliseconds": 5.037999999999997,
+              "populated": {
+                "rss": 85966848,
+                "heapTotal": 24985600,
+                "heapUsed": 7642256,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 85999616,
+                "heapTotal": 23150592,
+                "heapUsed": 5990136,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 2,
+              "milliseconds": 4.483750000000001,
+              "populated": {
+                "rss": 90161152,
+                "heapTotal": 25247744,
+                "heapUsed": 7631176,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 90161152,
+                "heapTotal": 23150592,
+                "heapUsed": 5991312,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 3,
+              "milliseconds": 3.4018749999999898,
+              "populated": {
+                "rss": 94650368,
+                "heapTotal": 24985600,
+                "heapUsed": 7656752,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95256576,
+                "heapTotal": 23412736,
+                "heapUsed": 6022304,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            },
+            {
+              "cycle": 4,
+              "milliseconds": 3.279875000000004,
+              "populated": {
+                "rss": 95436800,
+                "heapTotal": 25247744,
+                "heapUsed": 7662464,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              },
+              "released": {
+                "rss": 95469568,
+                "heapTotal": 23412736,
+                "heapUsed": 6003880,
+                "external": 2298106,
+                "arrayBuffers": 143619,
+                "modules": 3
+              }
+            }
+          ],
+          "resources": [
+            "PipeWrap"
+          ]
+        }
+      ]
+    }
+  ],
+  "localBrowsers": [
+    {
+      "baseline": "810b71d0d3f988cac3cacb8a00e5b27be011bab6",
+      "sources": {
+        "browser-date-candidate-probe.cjs": "7acd5c5adc7109564eb2b940dafc09eda2bb90334b46e6e80a37cfa4cc6849bf",
+        "date-candidate-contracts.cjs": "46965f5b9e14e46e1b355fe62a6a90675fd3dfc09b57512e7379258d9a47fa01",
+        "date-candidate-probe.cjs": "2bb89c217639e584821e806ed1f28ca19c04d90eeb829895b2a7cde69cbd14e5"
+      },
+      "engine": "chromium",
+      "browserVersion": "153.0.8010.12",
+      "node": "v22.23.2",
+      "support": {
+        "Temporal": "object",
+        "Intl": "object",
+        "timeZone": "function",
+        "locales": [
+          "en"
+        ]
+      },
+      "bundleEvidence": {
+        "dayjs": {
+          "bytes": 20801,
+          "gzipBytes": 7627,
+          "sha256": "dca7534821c0380cb7cb29f0fabaa8f6dc7749ee0e7c53efc0b43dfd6f7d7d99"
+        },
+        "luxon": {
+          "bytes": 93295,
+          "gzipBytes": 25819,
+          "sha256": "a820317af939cb7657836778313e4e1c93bcc6facbcf2037847290af13f99ae2"
+        },
+        "temporal": {
+          "bytes": 192076,
+          "gzipBytes": 53165,
+          "sha256": "863845cf91fc1a742e7cea61c624659fa2963570d98f166a0efd4fc0239e9736"
+        }
+      },
+      "withoutIntl": {
+        "moment": {
+          "value": {
+            "date": "2024-01-01",
+            "time": "13:45"
+          }
+        },
+        "dayjs": {
+          "error": "TypeError: Cannot read properties of undefined (reading 'DateTimeFormat')",
+          "initializationErrors": []
+        },
+        "luxon": {
+          "value": {
+            "date": "Invalid DateTime",
+            "time": "Invalid DateTime"
+          },
+          "initializationErrors": []
+        },
+        "temporal": {
+          "error": "TypeError: Cannot read properties of undefined (reading 'Instant')",
+          "initializationErrors": [
+            "Cannot read properties of undefined (reading 'DateTimeFormat')"
+          ]
+        }
+      },
+      "appBundleSha256": "d6f59ba214964e7c34e1b1f6f76729cc294c82ce2e7a7adfe35298a18a42d563",
+      "scope": "Candidate APIs against actual production Moment global; clipped browser timezone data. Standalone candidate bundle bytes are not an app replacement delta. No therapy or UI migration.",
+      "corpus": {
+        "zones": [
+          "UTC",
+          "America/New_York",
+          "Australia/Lord_Howe",
+          "Asia/Kathmandu",
+          "Asia/Gaza"
+        ],
+        "instants": [
+          -2208988800000,
+          1420070340000,
+          1420070400000,
+          1710053940000,
+          1710054000000,
+          1730611800000,
+          1730615400000,
+          1712414700000,
+          1712416500000,
+          1728142140000,
+          1728142200000,
+          2082758340000,
+          2082758400000
+        ],
+        "locales": [
+          "en"
+        ],
+        "localTimes": [
+          [
+            "2024-03-10T02:30:00",
+            "America/New_York"
+          ],
+          [
+            "2024-11-03T01:30:00",
+            "America/New_York"
+          ],
+          [
+            "2024-10-06T02:15:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-04-07T01:45:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "Asia/Kathmandu"
+          ],
+          [
+            "1900-01-01T00:00:00",
+            "Asia/Gaza"
+          ]
+        ],
+        "calendarDays": [
+          [
+            "2024-03-10T00:00:00",
+            "America/New_York"
+          ],
+          [
+            "2024-11-03T00:00:00",
+            "America/New_York"
+          ],
+          [
+            "2024-10-06T00:00:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-04-07T00:00:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "Asia/Kathmandu"
+          ]
+        ],
+        "offsetTimes": [
+          [
+            "2024-01-01T00:00:00",
+            "+05:30"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "+05:45"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "-03:30"
+          ]
+        ],
+        "dates": [
+          "2024-02-29",
+          "2024-02-30",
+          "2023-02-29",
+          "2024-13-01",
+          "2024-00-01",
+          "2024-01-00",
+          "not-a-date"
+        ],
+        "hours": [
+          -25,
+          -1,
+          0,
+          1,
+          25,
+          10000
+        ]
+      },
+      "moment": "2.30.1",
+      "momentTimezone": "0.6.3",
+      "momentTzData": "2026c",
+      "seasons": [
+        {
+          "now": "2024-01-15T00:00:00Z",
+          "cases": 93,
+          "differences": {
+            "moment": {},
+            "intl": {
+              "format": 3,
+              "local": 6,
+              "offsetLocal": 3,
+              "calendarDay": 5,
+              "validDate": 7,
+              "elapsedHours": 6,
+              "immutable": 1
+            },
+            "dayjs": {
+              "format": 3,
+              "local": 2,
+              "calendarDay": 4,
+              "validDate": 5,
+              "immutable": 1
+            },
+            "luxon": {
+              "format": 3,
+              "local": 2,
+              "immutable": 1
+            },
+            "temporal": {
+              "format": 3,
+              "local": 1,
+              "immutable": 1
+            },
+            "nativeTemporal": {
+              "format": 3,
+              "local": 1,
+              "immutable": 1
+            }
+          },
+          "otherContracts": [
+            {
+              "kind": "local",
+              "args": [
+                "2024-03-10T02:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-11-03T01:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-03T06:30:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-03T06:30:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-10-06T02:15:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-04-07T01:45:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "1900-01-01T00:00:00",
+                "Asia/Gaza"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "1899-12-31T22:00:00.000Z",
+                    "offset": 120
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal",
+                "nativeTemporal"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:45"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "-03:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-03-10T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-11T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-11-03T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-04T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-10-06T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-06T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-04-07T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-07T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": true
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                },
+                "nativeTemporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-30"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2023-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-13-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-00-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-01-00"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "not-a-date"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": false
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -25
+              ],
+              "results": {
+                "moment": {
+                  "value": -90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -90000000
+                },
+                "luxon": {
+                  "value": -90000000
+                },
+                "temporal": {
+                  "value": -90000000
+                },
+                "nativeTemporal": {
+                  "value": -90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -1
+              ],
+              "results": {
+                "moment": {
+                  "value": -3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -3600000
+                },
+                "luxon": {
+                  "value": -3600000
+                },
+                "temporal": {
+                  "value": -3600000
+                },
+                "nativeTemporal": {
+                  "value": -3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                0
+              ],
+              "results": {
+                "moment": {
+                  "value": 0
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 0
+                },
+                "luxon": {
+                  "value": 0
+                },
+                "temporal": {
+                  "value": 0
+                },
+                "nativeTemporal": {
+                  "value": 0
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                1
+              ],
+              "results": {
+                "moment": {
+                  "value": 3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 3600000
+                },
+                "luxon": {
+                  "value": 3600000
+                },
+                "temporal": {
+                  "value": 3600000
+                },
+                "nativeTemporal": {
+                  "value": 3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                25
+              ],
+              "results": {
+                "moment": {
+                  "value": 90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 90000000
+                },
+                "luxon": {
+                  "value": 90000000
+                },
+                "temporal": {
+                  "value": 90000000
+                },
+                "nativeTemporal": {
+                  "value": 90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                10000
+              ],
+              "results": {
+                "moment": {
+                  "value": 36000000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 36000000000
+                },
+                "luxon": {
+                  "value": 36000000000
+                },
+                "temporal": {
+                  "value": 36000000000
+                },
+                "nativeTemporal": {
+                  "value": 36000000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "immutable",
+              "args": [],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                },
+                "nativeTemporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal",
+                "nativeTemporal"
+              ]
+            }
+          ]
+        },
+        {
+          "now": "2024-07-15T00:00:00Z",
+          "cases": 93,
+          "differences": {
+            "moment": {},
+            "intl": {
+              "format": 3,
+              "local": 6,
+              "offsetLocal": 3,
+              "calendarDay": 5,
+              "validDate": 7,
+              "elapsedHours": 6,
+              "immutable": 1
+            },
+            "dayjs": {
+              "format": 3,
+              "local": 2,
+              "calendarDay": 4,
+              "validDate": 5,
+              "immutable": 1
+            },
+            "luxon": {
+              "format": 3,
+              "local": 2,
+              "immutable": 1
+            },
+            "temporal": {
+              "format": 3,
+              "local": 1,
+              "immutable": 1
+            },
+            "nativeTemporal": {
+              "format": 3,
+              "local": 1,
+              "immutable": 1
+            }
+          },
+          "otherContracts": [
+            {
+              "kind": "local",
+              "args": [
+                "2024-03-10T02:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-11-03T01:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-10-06T02:15:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-04-07T01:45:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-06T15:15:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-06T15:15:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "1900-01-01T00:00:00",
+                "Asia/Gaza"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "1899-12-31T22:00:00.000Z",
+                    "offset": 120
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal",
+                "nativeTemporal"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:45"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "-03:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-03-10T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-11T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-11-03T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-04T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-10-06T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-06T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-04-07T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-07T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": true
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                },
+                "nativeTemporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-30"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2023-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-13-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-00-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-01-00"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "not-a-date"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": false
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -25
+              ],
+              "results": {
+                "moment": {
+                  "value": -90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -90000000
+                },
+                "luxon": {
+                  "value": -90000000
+                },
+                "temporal": {
+                  "value": -90000000
+                },
+                "nativeTemporal": {
+                  "value": -90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -1
+              ],
+              "results": {
+                "moment": {
+                  "value": -3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -3600000
+                },
+                "luxon": {
+                  "value": -3600000
+                },
+                "temporal": {
+                  "value": -3600000
+                },
+                "nativeTemporal": {
+                  "value": -3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                0
+              ],
+              "results": {
+                "moment": {
+                  "value": 0
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 0
+                },
+                "luxon": {
+                  "value": 0
+                },
+                "temporal": {
+                  "value": 0
+                },
+                "nativeTemporal": {
+                  "value": 0
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                1
+              ],
+              "results": {
+                "moment": {
+                  "value": 3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 3600000
+                },
+                "luxon": {
+                  "value": 3600000
+                },
+                "temporal": {
+                  "value": 3600000
+                },
+                "nativeTemporal": {
+                  "value": 3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                25
+              ],
+              "results": {
+                "moment": {
+                  "value": 90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 90000000
+                },
+                "luxon": {
+                  "value": 90000000
+                },
+                "temporal": {
+                  "value": 90000000
+                },
+                "nativeTemporal": {
+                  "value": 90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                10000
+              ],
+              "results": {
+                "moment": {
+                  "value": 36000000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 36000000000
+                },
+                "luxon": {
+                  "value": 36000000000
+                },
+                "temporal": {
+                  "value": 36000000000
+                },
+                "nativeTemporal": {
+                  "value": 36000000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "immutable",
+              "args": [],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                },
+                "nativeTemporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal",
+                "nativeTemporal"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "baseline": "810b71d0d3f988cac3cacb8a00e5b27be011bab6",
+      "sources": {
+        "browser-date-candidate-probe.cjs": "7acd5c5adc7109564eb2b940dafc09eda2bb90334b46e6e80a37cfa4cc6849bf",
+        "date-candidate-contracts.cjs": "46965f5b9e14e46e1b355fe62a6a90675fd3dfc09b57512e7379258d9a47fa01",
+        "date-candidate-probe.cjs": "2bb89c217639e584821e806ed1f28ca19c04d90eeb829895b2a7cde69cbd14e5"
+      },
+      "engine": "webkit",
+      "browserVersion": "26.6",
+      "node": "v24.20.0",
+      "support": {
+        "Temporal": "object",
+        "Intl": "object",
+        "timeZone": "function",
+        "locales": [
+          "en"
+        ]
+      },
+      "bundleEvidence": {
+        "dayjs": {
+          "bytes": 20801,
+          "gzipBytes": 7627,
+          "sha256": "dca7534821c0380cb7cb29f0fabaa8f6dc7749ee0e7c53efc0b43dfd6f7d7d99"
+        },
+        "luxon": {
+          "bytes": 93295,
+          "gzipBytes": 25819,
+          "sha256": "a820317af939cb7657836778313e4e1c93bcc6facbcf2037847290af13f99ae2"
+        },
+        "temporal": {
+          "bytes": 192076,
+          "gzipBytes": 53165,
+          "sha256": "863845cf91fc1a742e7cea61c624659fa2963570d98f166a0efd4fc0239e9736"
+        }
+      },
+      "withoutIntl": {
+        "moment": {
+          "value": {
+            "date": "2024-01-01",
+            "time": "13:45"
+          }
+        },
+        "dayjs": {
+          "error": "TypeError: undefined is not an object (evaluating 'new Intl.DateTimeFormat')",
+          "initializationErrors": []
+        },
+        "luxon": {
+          "value": {
+            "date": "Invalid DateTime",
+            "time": "Invalid DateTime"
+          },
+          "initializationErrors": []
+        },
+        "temporal": {
+          "error": "TypeError: undefined is not an object (evaluating 'Temporal.Instant')",
+          "initializationErrors": [
+            "undefined is not an object (evaluating 'Intl.DateTimeFormat')"
+          ]
+        }
+      },
+      "appBundleSha256": "d6f59ba214964e7c34e1b1f6f76729cc294c82ce2e7a7adfe35298a18a42d563",
+      "scope": "Candidate APIs against actual production Moment global; clipped browser timezone data. Standalone candidate bundle bytes are not an app replacement delta. No therapy or UI migration.",
+      "corpus": {
+        "zones": [
+          "UTC",
+          "America/New_York",
+          "Australia/Lord_Howe",
+          "Asia/Kathmandu",
+          "Asia/Gaza"
+        ],
+        "instants": [
+          -2208988800000,
+          1420070340000,
+          1420070400000,
+          1710053940000,
+          1710054000000,
+          1730611800000,
+          1730615400000,
+          1712414700000,
+          1712416500000,
+          1728142140000,
+          1728142200000,
+          2082758340000,
+          2082758400000
+        ],
+        "locales": [
+          "en"
+        ],
+        "localTimes": [
+          [
+            "2024-03-10T02:30:00",
+            "America/New_York"
+          ],
+          [
+            "2024-11-03T01:30:00",
+            "America/New_York"
+          ],
+          [
+            "2024-10-06T02:15:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-04-07T01:45:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "Asia/Kathmandu"
+          ],
+          [
+            "1900-01-01T00:00:00",
+            "Asia/Gaza"
+          ]
+        ],
+        "calendarDays": [
+          [
+            "2024-03-10T00:00:00",
+            "America/New_York"
+          ],
+          [
+            "2024-11-03T00:00:00",
+            "America/New_York"
+          ],
+          [
+            "2024-10-06T00:00:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-04-07T00:00:00",
+            "Australia/Lord_Howe"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "Asia/Kathmandu"
+          ]
+        ],
+        "offsetTimes": [
+          [
+            "2024-01-01T00:00:00",
+            "+05:30"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "+05:45"
+          ],
+          [
+            "2024-01-01T00:00:00",
+            "-03:30"
+          ]
+        ],
+        "dates": [
+          "2024-02-29",
+          "2024-02-30",
+          "2023-02-29",
+          "2024-13-01",
+          "2024-00-01",
+          "2024-01-00",
+          "not-a-date"
+        ],
+        "hours": [
+          -25,
+          -1,
+          0,
+          1,
+          25,
+          10000
+        ]
+      },
+      "moment": "2.30.1",
+      "momentTimezone": "0.6.3",
+      "momentTzData": "2026c",
+      "seasons": [
+        {
+          "now": "2024-01-15T00:00:00Z",
+          "cases": 93,
+          "differences": {
+            "moment": {},
+            "intl": {
+              "format": 3,
+              "local": 6,
+              "offsetLocal": 3,
+              "calendarDay": 5,
+              "validDate": 7,
+              "elapsedHours": 6,
+              "immutable": 1
+            },
+            "dayjs": {
+              "format": 3,
+              "local": 2,
+              "calendarDay": 4,
+              "validDate": 5,
+              "immutable": 1
+            },
+            "luxon": {
+              "format": 3,
+              "local": 2,
+              "immutable": 1
+            },
+            "temporal": {
+              "format": 3,
+              "local": 1,
+              "immutable": 1
+            },
+            "nativeTemporal": {
+              "format": 3,
+              "local": 1,
+              "immutable": 1
+            }
+          },
+          "otherContracts": [
+            {
+              "kind": "local",
+              "args": [
+                "2024-03-10T02:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-11-03T01:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-03T06:30:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-03T06:30:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-10-06T02:15:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-04-07T01:45:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "1900-01-01T00:00:00",
+                "Asia/Gaza"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "1899-12-31T22:00:00.000Z",
+                    "offset": 120
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal",
+                "nativeTemporal"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:45"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "-03:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-03-10T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-11T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-11-03T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-04T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-10-06T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-06T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-04-07T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-07T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": true
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                },
+                "nativeTemporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-30"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2023-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-13-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-00-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-01-00"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "not-a-date"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": false
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -25
+              ],
+              "results": {
+                "moment": {
+                  "value": -90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -90000000
+                },
+                "luxon": {
+                  "value": -90000000
+                },
+                "temporal": {
+                  "value": -90000000
+                },
+                "nativeTemporal": {
+                  "value": -90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -1
+              ],
+              "results": {
+                "moment": {
+                  "value": -3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -3600000
+                },
+                "luxon": {
+                  "value": -3600000
+                },
+                "temporal": {
+                  "value": -3600000
+                },
+                "nativeTemporal": {
+                  "value": -3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                0
+              ],
+              "results": {
+                "moment": {
+                  "value": 0
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 0
+                },
+                "luxon": {
+                  "value": 0
+                },
+                "temporal": {
+                  "value": 0
+                },
+                "nativeTemporal": {
+                  "value": 0
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                1
+              ],
+              "results": {
+                "moment": {
+                  "value": 3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 3600000
+                },
+                "luxon": {
+                  "value": 3600000
+                },
+                "temporal": {
+                  "value": 3600000
+                },
+                "nativeTemporal": {
+                  "value": 3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                25
+              ],
+              "results": {
+                "moment": {
+                  "value": 90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 90000000
+                },
+                "luxon": {
+                  "value": 90000000
+                },
+                "temporal": {
+                  "value": 90000000
+                },
+                "nativeTemporal": {
+                  "value": 90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                10000
+              ],
+              "results": {
+                "moment": {
+                  "value": 36000000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 36000000000
+                },
+                "luxon": {
+                  "value": 36000000000
+                },
+                "temporal": {
+                  "value": 36000000000
+                },
+                "nativeTemporal": {
+                  "value": 36000000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "immutable",
+              "args": [],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                },
+                "nativeTemporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal",
+                "nativeTemporal"
+              ]
+            }
+          ]
+        },
+        {
+          "now": "2024-07-15T00:00:00Z",
+          "cases": 93,
+          "differences": {
+            "moment": {},
+            "intl": {
+              "format": 3,
+              "local": 6,
+              "offsetLocal": 3,
+              "calendarDay": 5,
+              "validDate": 7,
+              "elapsedHours": 6,
+              "immutable": 1
+            },
+            "dayjs": {
+              "format": 3,
+              "local": 2,
+              "calendarDay": 4,
+              "validDate": 5,
+              "immutable": 1
+            },
+            "luxon": {
+              "format": 3,
+              "local": 2,
+              "immutable": 1
+            },
+            "temporal": {
+              "format": 3,
+              "local": 1,
+              "immutable": 1
+            },
+            "nativeTemporal": {
+              "format": 3,
+              "local": 1,
+              "immutable": 1
+            }
+          },
+          "otherContracts": [
+            {
+              "kind": "local",
+              "args": [
+                "2024-03-10T02:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-03-10T07:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-11-03T01:30:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-11-03T05:30:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-10-06T02:15:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-10-05T15:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-04-07T01:45:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-06T15:15:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-06T15:15:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-04-06T14:45:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "local",
+              "args": [
+                "1900-01-01T00:00:00",
+                "Asia/Gaza"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "1899-12-31T22:00:00.000Z",
+                    "offset": 120
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "1899-12-31T21:42:08.000Z",
+                    "offset": 137.86666666666667
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal",
+                "nativeTemporal"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:30:00.000Z",
+                    "offset": 330
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "+05:45"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2023-12-31T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "offsetLocal",
+              "args": [
+                "2024-01-01T00:00:00",
+                "-03:30"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-01-01T03:30:00.000Z",
+                    "offset": -210
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-03-10T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-03-11T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-03-11T04:00:00.000Z",
+                    "offset": -240
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-11-03T00:00:00",
+                "America/New_York"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-11-04T04:00:00.000Z",
+                    "offset": -240
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-11-04T05:00:00.000Z",
+                    "offset": -300
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-10-06T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-10-06T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-10-06T13:00:00.000Z",
+                    "offset": 660
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-04-07T00:00:00",
+                "Australia/Lord_Howe"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-04-07T13:00:00.000Z",
+                    "offset": 660
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-04-07T13:30:00.000Z",
+                    "offset": 630
+                  }
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "calendarDay",
+              "args": [
+                "2024-01-01T00:00:00",
+                "Asia/Kathmandu"
+              ],
+              "results": {
+                "moment": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "luxon": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "temporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                },
+                "nativeTemporal": {
+                  "value": {
+                    "iso": "2024-01-01T18:15:00.000Z",
+                    "offset": 345
+                  }
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": true
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                },
+                "nativeTemporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-02-30"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2023-02-29"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-13-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-00-01"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "2024-01-00"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs"
+              ]
+            },
+            {
+              "kind": "validDate",
+              "args": [
+                "not-a-date"
+              ],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": false
+                },
+                "luxon": {
+                  "value": false
+                },
+                "temporal": {
+                  "value": false
+                },
+                "nativeTemporal": {
+                  "value": false
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -25
+              ],
+              "results": {
+                "moment": {
+                  "value": -90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -90000000
+                },
+                "luxon": {
+                  "value": -90000000
+                },
+                "temporal": {
+                  "value": -90000000
+                },
+                "nativeTemporal": {
+                  "value": -90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                -1
+              ],
+              "results": {
+                "moment": {
+                  "value": -3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": -3600000
+                },
+                "luxon": {
+                  "value": -3600000
+                },
+                "temporal": {
+                  "value": -3600000
+                },
+                "nativeTemporal": {
+                  "value": -3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                0
+              ],
+              "results": {
+                "moment": {
+                  "value": 0
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 0
+                },
+                "luxon": {
+                  "value": 0
+                },
+                "temporal": {
+                  "value": 0
+                },
+                "nativeTemporal": {
+                  "value": 0
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                1
+              ],
+              "results": {
+                "moment": {
+                  "value": 3600000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 3600000
+                },
+                "luxon": {
+                  "value": 3600000
+                },
+                "temporal": {
+                  "value": 3600000
+                },
+                "nativeTemporal": {
+                  "value": 3600000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                25
+              ],
+              "results": {
+                "moment": {
+                  "value": 90000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 90000000
+                },
+                "luxon": {
+                  "value": 90000000
+                },
+                "temporal": {
+                  "value": 90000000
+                },
+                "nativeTemporal": {
+                  "value": 90000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "elapsedHours",
+              "args": [
+                10000
+              ],
+              "results": {
+                "moment": {
+                  "value": 36000000000
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": 36000000000
+                },
+                "luxon": {
+                  "value": 36000000000
+                },
+                "temporal": {
+                  "value": 36000000000
+                },
+                "nativeTemporal": {
+                  "value": 36000000000
+                }
+              },
+              "different": [
+                "intl"
+              ]
+            },
+            {
+              "kind": "immutable",
+              "args": [],
+              "results": {
+                "moment": {
+                  "value": false
+                },
+                "intl": {
+                  "unsupported": true
+                },
+                "dayjs": {
+                  "value": true
+                },
+                "luxon": {
+                  "value": true
+                },
+                "temporal": {
+                  "value": true
+                },
+                "nativeTemporal": {
+                  "value": true
+                }
+              },
+              "different": [
+                "intl",
+                "dayjs",
+                "luxon",
+                "temporal",
+                "nativeTemporal"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/audits/date-candidate-runtime-support.json
+++ b/docs/audits/date-candidate-runtime-support.json
@@ -1,0 +1,75 @@
+{
+  "recorded": "2026-09-08",
+  "browserCompatDataCommit": "8d205d1e63a56b31e19265fba92e56840314c188",
+  "support": {
+    "temporal": {
+      "bun": {
+        "version_added": "1.4.0"
+      },
+      "chrome": {
+        "version_added": "144"
+      },
+      "chrome_android": "mirror",
+      "deno": {
+        "version_added": "2.7"
+      },
+      "edge": "mirror",
+      "firefox": {
+        "version_added": "139"
+      },
+      "firefox_android": "mirror",
+      "nodejs": {
+        "version_added": "26.0.0"
+      },
+      "oculus": "mirror",
+      "opera": "mirror",
+      "opera_android": "mirror",
+      "safari": {
+        "version_added": "preview"
+      },
+      "safari_ios": {
+        "version_added": false
+      },
+      "samsunginternet_android": "mirror",
+      "webview_android": "mirror",
+      "webview_ios": "mirror"
+    },
+    "intl": {
+      "bun": {
+        "version_added": "1.0.0"
+      },
+      "chrome": {
+        "version_added": "24"
+      },
+      "chrome_android": "mirror",
+      "deno": {
+        "version_added": "1.8"
+      },
+      "edge": {
+        "version_added": "12"
+      },
+      "firefox": {
+        "version_added": "29"
+      },
+      "firefox_android": {
+        "version_added": "56"
+      },
+      "ie": {
+        "version_added": "11"
+      },
+      "nodejs": {
+        "version_added": "0.12.0"
+      },
+      "oculus": "mirror",
+      "opera": "mirror",
+      "opera_android": "mirror",
+      "safari": {
+        "version_added": "10"
+      },
+      "safari_ios": "mirror",
+      "samsunginternet_android": "mirror",
+      "webview_android": "mirror",
+      "webview_ios": "mirror"
+    }
+  }
+}

--- a/docs/plans/date-time-decision.md
+++ b/docs/plans/date-time-decision.md
@@ -1,0 +1,172 @@
+# M27 decision for Nightscout 15.0.9
+
+Retain Moment 2.30.1 and Moment Timezone 0.6.3 / IANA 2026c, with the existing
+English-only browser Moment locale registry and 2015–2035 browser timezone data
+range. Keep all configured zones and the full server timezone data. Do not add
+another date library to the application or replace individual formatters in this
+release. This is the explicit retain/narrow decision for M27, not a claim that
+Moment is the best choice for new applications or that a replacement is impossible.
+
+The comparison extends the earlier Intl and Luxon work with Day.js and Temporal,
+a shared server/browser corpus, fixed offsets, seasonal overlap selection,
+calendar-day arithmetic, invalid dates, elapsed durations and mutation contracts.
+The candidate manifests are isolated research fixtures; the root manifests,
+production bundles and application implementation are unchanged.
+
+## Why retain the current implementation
+
+1. The supported runtime/browser policy is a requirement. Native Temporal is
+   absent on actual Node 22.23.2 and 24.20.0. The retained iOS 9.3 target lacks
+   Intl, which the tested Day.js timezone plugin, Luxon and Temporal polyfill
+   require. Removing Intl **before loading** each candidate in a fresh browser
+   realm demonstrates the dependency: Day.js throws, Luxon returns an invalid
+   DateTime, and the Temporal polyfill fails initialization. The existing
+   production Moment global still formats the test zone. Removing Intl after
+   loading the polyfill is insufficient because it captures constructors.
+   These probes verify a missing-feature boundary, not full iOS emulation.
+2. The APIs are not interchangeable. Day.js and Luxon choose a different
+   occurrence of an overlapping local time depending on the current season.
+   Day.js also preserves an obsolete offset when adding a calendar day over all
+   four tested DST transitions and normalizes five invalid date inputs.
+   Strict parsing and offset/ambiguity adapters are possible, but must be
+   implemented and validated rather than weakening Nightscout's contracts.
+3. Temporal with explicit `disambiguation: 'compatible'` matches the tested
+   gaps, overlaps, fixed offsets and calendar-day arithmetic. However, immutable
+   objects differ from the existing mutable profile API. Temporal machine fields
+   do not reproduce Moment's locale postformat behavior, and its ISO parsers do
+   not replace Nightscout's RFC 2822, numeric epoch-unit and array-fallback API.
+   Native Intl alone supplies no parsing/calendar arithmetic API.
+4. No complete application migration or whole-server memory reduction is
+   demonstrated. The measured candidate costs below are useful tradeoffs, not
+   proof of a net app saving. Adding a candidate while Moment remains required
+   would add code and another compatibility surface. Further pruning timezone
+   years, zones or locales would change supported input/output contracts.
+
+This decision evaluates candidates against mandatory requirements first. It does
+not build or claim validation of complete IOB/COB/report replacements for candidates
+that fail the retained platform/API boundary. The accepted implementation remains
+the existing application, whose full backend and real-browser suites are the
+regression gate. A future migration must satisfy those application contracts;
+passing a small candidate operation corpus cannot stand in for them.
+
+## Evidence and reproduction
+
+The [recorded server and memory results](../audits/date-candidate-review.json)
+contain candidate versions/integrities, source hashes, runtime/ICU/timezone
+versions, input corpus, all non-format cases, format mismatch counts/examples,
+seven alternating CPU rounds and complete isolated memory samples. Candidate
+versions verified on 2026-09-08: Day.js 1.11.23, Luxon 3.7.2,
+`@js-temporal/polyfill` 0.5.1 and its JSBI 4.3.2 dependency.
+
+Install the root lockfile normally. Copy `tools/audits/date-candidates/package*.json`
+to an **absolute, canonical disposable directory**, then run `npm ci --prefix`
+against that directory with scripts disabled. These packages are not installed
+into the application tree. Example (replace the directory with an owned path):
+
+```sh
+npm ci
+mkdir -p /absolute/disposable/date-candidates
+cp tools/audits/date-candidates/package*.json /absolute/disposable/date-candidates/
+npm ci --prefix /absolute/disposable/date-candidates --ignore-scripts --no-audit --no-fund
+node tools/audits/date-candidate-probe.cjs /absolute/disposable/date-candidates
+node tools/audits/date-candidate-memory.cjs /absolute/disposable/date-candidates
+node tools/audits/browser-date-candidate-probe.cjs /absolute/disposable/date-candidates chromium
+```
+
+Repeat with both exact Node floors and Firefox/WebKit. Existing browser CI jobs
+install the locked candidates separately and publish `date-candidates-*`
+artifacts; no new environment/job is added. The browser probe uses Moment from
+the actual built Nightscout page and compares only its available locales. It
+records the checkout/tree identity, application bundle hash and all comparison
+rows. Missing candidate APIs/load failures fail the research command; output
+differences are recorded, not asserted to be equivalent.
+
+There are 353 server cases per simulated season: 325 formatting cases plus
+28 parsing/calendar/fixed-offset/duration/mutation cases. Both Node floors agree
+on the observations. Of the 325 server formatting cases, Intl and Luxon differ
+on 65 Arabic cases; Day.js and Temporal machine fields differ on 130 Arabic/
+Persian cases. The browser's actual English-only registry has 65 formatting
+cases plus the same 28 other cases. Its clipped historical timezone data can
+differ from Intl-backed candidates; those known range differences are not
+silently treated as correctness improvements.
+
+## Measured costs and limits
+
+Median milliseconds for 5,000 zone conversions plus editor date/time formatting
+pairs, seven alternating rounds after warmup, from pre-parsed instants:
+
+| Candidate | Node 22.23.2 | Node 24.20.0 |
+| --- | ---: | ---: |
+| Moment | 10.67 | 9.23 |
+| Cached Intl adapter | 12.69 | 10.63 |
+| Day.js | 160.18 | 151.94 |
+| Luxon | 23.22 | 21.98 |
+| Temporal polyfill | 54.66 | 52.01 |
+
+This is a bounded formatting workload, not application throughput. Native browser
+Temporal is not the polyfill measured in the Node timing table.
+
+Standalone candidate bundles built with the project's Babel targets, including
+candidate timezone/duration plugins and the five comparison locales where
+applicable: Day.js 20,801 raw / 7,627 gzip bytes; Luxon 93,295 / 25,819;
+Temporal polyfill 192,076 / 53,165. These are **not** replacement deltas for the
+Nightscout app. They exclude a compatibility shim and any Intl fallback needed
+for old supported browsers. No application bundle reduction is claimed.
+
+Seven alternating fresh processes per candidate/runtime measured cold loading,
+post-GC heap/RSS, loaded modules and five populate/release cycles of 5,000 zoned
+values. Node 22 median loaded heap increases were Moment 1,792,104 bytes,
+Day.js 214,432, Luxon 994,376 and Temporal 1,035,096. Median additional heap with
+5,000 retained values was respectively 2,635,760; 1,932,560; 3,573,936; and
+2,095,136 bytes. All raw Node 22/24 samples, including release-cycle residuals
+and RSS, are in the evidence file. These isolated constructors do not measure
+Nightscout servers, therapy workloads or a typical-instance saving; differences
+cannot be added to earlier modernization estimates.
+
+## Application regression coverage and known behavior
+
+`tests/timezone-modernization.test.js` has 51 cases on each Node floor, including
+new 23/25-hour and 23.5/24.5-hour calendar-day boundaries through real profile
+parsing in both glucose unit modes. Invalid date-only and space-separated inputs
+remain rejected through the real API3 parser. Existing cases cover epoch units,
+RFC 2822, first-valid array fallback, mutable timezone conversion, fixed offsets,
+overlap occurrences and timezone-data updates. IOB/COB/profile and browser report
+pipelines remain exercised by the full suites, including both unit modes and
+existing report goldens. No candidate has replaced these code paths.
+
+Local validation: clean Node 22.23.2/npm 10.9.8 install/production build; 2,109
+backend tests pass with one existing pending case, 283 client-core tests and
+305 dependency tests. The focused 51 cases pass on Node 22.23.2 and 24.20.0.
+Current-head hosted checks and all four browser comparison artifacts are required
+before accepting the decision PR.
+
+The existing spring-gap basal schedule discrepancy and browser pre-2015/post-2035
+data limitation stay explicit. This dependency decision does not redefine therapy
+schedule semantics, expand the bundled data range or claim those discrepancies
+are corrected. A behavior fix needs its own application-level contract review.
+
+## Support sources, ownership and revisit trigger
+
+[MDN compatibility data at the recorded commit](https://github.com/mdn/browser-compat-data/tree/8d205d1e63a56b31e19265fba92e56840314c188)
+and [support snapshot](../audits/date-candidate-runtime-support.json) distinguish
+current Chromium/Firefox and WebKit preview support from stable Safari/iOS and
+Node support. Stage 4 standardization does not establish the installed runtime's
+capabilities. The [Temporal polyfill](https://github.com/js-temporal/temporal-polyfill)
+ships ES2020 code and documents transpilation/JSBI requirements;
+[Temporal string documentation](https://tc39.es/proposal-temporal/docs/strings.html)
+explains its parsing boundary. The [Day.js timezone documentation](https://day.js.org/docs/en/timezone/timezone)
+identifies its Intl dependency. [Moment's maintenance policy](https://momentjs.com/docs/)
+is a reason to continue security/timezone maintenance, not a claim of ongoing
+feature development.
+
+Revisit at the next supported-browser/Node policy change, or by 2027-04-30
+(Node 22 retirement review), whichever comes first. Prefer evaluating a direct
+Moment-to-Temporal migration once the required runtimes support it, rather than
+committing now to an intermediate library migration. Any earlier security or
+correctness issue overrides that review date. Re-run the corpus and measure the
+actual app with necessary adapters/fallbacks before choosing a migration.
+
+Per the maintainer's 2026-09-08 instruction, production-host and physical-device
+validation follow the automated work and are performed by the maintainer. This
+record does not claim those manual checks passed. Rollback of this review is a
+revert of its child PR; there is no runtime, configuration or persisted-data change.

--- a/docs/plans/moment-timezone-review.md
+++ b/docs/plans/moment-timezone-review.md
@@ -1,6 +1,6 @@
 # Moment and timezone review (M27)
 
-Status: inventory and initial server characterization complete; replacement decision, browser parity and comparison measurements open.
+Status: the [M27 release decision](date-time-decision.md) retains the current narrowed Moment implementation after the candidate comparison. The sections below preserve the historical experiments and their scope; the final decision supersedes their provisional open statuses.
 The baseline is integration `87340f59`. No runtime code or dependency changes are
 included in this inventory. Do not mark M27 complete from source counts alone.
 

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -27,6 +27,15 @@ At the audit baseline, completed foundations were: D3 7.9.0, jsdom-backed test t
 
 ## Shared merge and release gates
 
+Maintainer direction on 2026-09-08: complete the remaining implementation,
+appropriate automated regression coverage and CI. The maintainer will then run
+the integration branch in production and perform device testing. Live host,
+vendor-account/Atlas IAM and physical iPhone/VoiceOver checks below are therefore
+**maintainer-owned manual validation after the automated work**, not prerequisites
+for finishing that work. Keep them visible and unperformed until results are
+provided; automated tests do not establish manual passes. This handoff does not
+authorize automatic promotion of #8605 into dev before the maintainer's review.
+
 - Record the parent/head commits, runtime/npm versions and exact commands. Use a clean locked install; investigate any retained-version drift rather than accepting an unrelated lockfile refresh.
 - Run applicable focused tests, `npm run test-ci`, **separately** `npm run test:core`, and `npm run test:dependencies`; run production/development builds for dependency or bundler changes. Keep pre-existing quarantines visible until replacement coverage proves their contracts, and investigate new failures against the same parent/environment. The original three pending cases are now one remaining Node case plus two report cases migrated to active browser tests (M08).
 - Require current GitHub CI, CodeQL and Docker validation on each proposed merge with the current modernization branch, then validate the complete #8605 merge against fresh `dev` before promotion. Add regression tests for changed behavior, with a failing-before/passing-after demonstration when fixing a bug; avoid tests that merely repeat manifest contents.
@@ -211,7 +220,7 @@ M18 completed in #8639 (merge `a92d0882`) and #8640 (merge `1fab2a24`). Each pas
 
 ## Phase 5 — larger decisions, not compulsory rewrites
 
-- [ ] **M27 — Moment/timezone decision.** Map `moment`/`moment-timezone` use across profile/IOB/COB, therapy schedules, dates, reports and locale data. Establish golden outputs for DST gaps/overlaps, local midnight, timezone changes, historical data, duration and both glucose units. Compare retaining or narrowing Moment, native Intl plus scoped helpers, Luxon, Day.js and Temporal (including the proposal and discussion in #8348) for API complexity, bundle size, CPU, measured memory use and browser coverage. At the time of the M27 review, reassess Temporal native support across supported Node.js versions and browsers, any polyfill requirement and its cost, and whether a direct Moment-to-Temporal migration would avoid an intermediate library migration. No replacement or migration date is selected; Intl alone is not a complete parsing/arithmetic replacement. Choose retain/narrow/replace with evidence; do not assume a library swap is low effort or promise an old roadmap's 200 KB estimate. Coordinate with the testing proposal's DOM-free report boundary.
+- [x] **M27 — Moment/timezone decision.** The [release decision and comparative evidence](date-time-decision.md) retain the current narrowed Moment implementation under the existing browser/runtime contract, with an explicit revisit trigger; no date-library migration is selected. Map `moment`/`moment-timezone` use across profile/IOB/COB, therapy schedules, dates, reports and locale data. Establish golden outputs for DST gaps/overlaps, local midnight, timezone changes, historical data, duration and both glucose units. Compare retaining or narrowing Moment, native Intl plus scoped helpers, Luxon, Day.js and Temporal (including the proposal and discussion in #8348) for API complexity, bundle size, CPU, measured memory use and browser coverage. At the time of the M27 review, reassess Temporal native support across supported Node.js versions and browsers, any polyfill requirement and its cost, and whether a direct Moment-to-Temporal migration would avoid an intermediate library migration. No replacement or migration date is selected; Intl alone is not a complete parsing/arithmetic replacement. Choose retain/narrow/replace with evidence; do not assume a library swap is low effort or promise an old roadmap's 200 KB estimate. Coordinate with the testing proposal's DOM-free report boundary.
   Inventory baseline and remaining comparison work: [Moment/timezone review](moment-timezone-review.md). The lexical scan identifies 79 files, including 53 application files; it is not a complete call graph or a replacement decision.
 
 - [ ] **M28 — jQuery/UI/Flot and tooltip decision.** See [widget inventory and migration sequence](browser-widget-review.md) for the current consumers and concrete next steps. Inventory actual widgets, global plugin contracts and touch/accessibility behavior. First consider `jquery.tooltips`' two browser-utils initializers with a small delegated, escaped tooltip component; native title alone is not equivalent. After page splitting, compare retaining isolated jQuery UI/Flot against removing one widget/chart at a time. Require hover/focus/touch dismissal, keyboard/screen-reader checks, translated content, repeated initialization and report/chart goldens. Choose a framework only through a separate proposal with measured maintenance/size benefits.
@@ -393,4 +402,4 @@ regressions for changed offsets; see the [timezone review](../test-specs/moment-
 Firefox and WebKit artifacts agree on the same three historical formatting
 differences outside the clipped browser timezone range. These comparisons do
 not replace production Moment or establish complete parsing, therapy, report,
-locale or memory equivalence. M27 remains open for its final decision.
+locale or memory equivalence. The final M27 retain/narrow decision is recorded in [the release review](date-time-decision.md).

--- a/tests/timezone-modernization.test.js
+++ b/tests/timezone-modernization.test.js
@@ -68,6 +68,24 @@ describe('Modernization date/time characterization', function () {
         }
         p.clear();
       });
+      for (const [zone, local, next, hours] of [
+        ['America/New_York', '2024-03-10', '2024-03-11T04:00:00.000Z', 23],
+        ['America/New_York', '2024-11-03', '2024-11-04T05:00:00.000Z', 25],
+        ['Australia/Lord_Howe', '2024-10-06', '2024-10-06T13:00:00.000Z', 23.5],
+        ['Australia/Lord_Howe', '2024-04-07', '2024-04-07T13:30:00.000Z', 24.5]
+      ]) {
+        it('keeps report calendar-day bounds at midnight across ' + zone + ' / ' + local, function () {
+          const p = profile(zone, units);
+          try {
+            const start = p.parseInTimezone(local + 'T00:00:00');
+            const end = start.clone().add(1, 'day');
+            assert.equal(end.toISOString(), next);
+            assert.equal(end.format('HH:mm:ss'), '00:00:00');
+            assert.equal(end.diff(start, 'hours', true), hours);
+            assert.equal(start.format('YYYY-MM-DD HH:mm:ss'), local + ' 00:00:00');
+          } finally {p.clear();}
+        });
+      }
       it('records existing elapsed-time basal selection at the spring gap (open discrepancy)', function () {
         const p = profile('America/New_York', units);
         for (let cycle = 0; cycle < 2; cycle++) {
@@ -90,7 +108,8 @@ describe('Modernization date/time characterization', function () {
     assert.equal(parsed.valueOf(), ms);
     assert.equal(parsed.utcOffset(), 345);
     assert.equal(dateTools.parseToMoment('Mon, 01 Jan 2024 00:00:00 +0000').valueOf(), ms);
-    for (const value of [null, 0, '', '2024-02-30', 'not-a-date', {}]) {
+    for (const value of [null, 0, '', '2024-02-30', '2024-02-30 12:00:00',
+      '2023-02-29', '2024-13-01', 'not-a-date', {}]) {
       assert.equal(dateTools.parseToMoment(value), null);
     }
   });

--- a/tools/audits/browser-date-candidate-probe.cjs
+++ b/tools/audits/browser-date-candidate-probe.cjs
@@ -1,0 +1,132 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const assert = require('node:assert/strict');
+const {createRequire} = require('node:module');
+const {execFileSync} = require('node:child_process');
+const {gzipSync} = require('node:zlib');
+const {createHash} = require('node:crypto');
+const webpack = require('webpack');
+const playwright = require('playwright-core');
+const {createPageFixture, hash} = require('../../tests/fixtures/page-startup/server');
+const {createCandidates, runContracts, runSeasons} = require('./date-candidate-contracts.cjs');
+const {corpus} = require('./date-candidate-probe.cjs');
+
+async function bundles(directory, output) {
+  const external = createRequire(path.resolve(directory, 'package.json'));
+  const specs = {
+    dayjs: [
+      'const dayjs = require(' + JSON.stringify(external.resolve('dayjs')) + ');',
+      ...['utc', 'timezone', 'duration'].map(name => 'dayjs.extend(require(' + JSON.stringify(external.resolve('dayjs/plugin/' + name)) + '));'),
+      ...corpus.locales.slice(1).map(name => 'require(' + JSON.stringify(external.resolve('dayjs/locale/' + name)) + ');'),
+      'globalThis.dateCandidateLibraries.dayjs = dayjs;'
+    ].join('\n'),
+    luxon: 'globalThis.dateCandidateLibraries.luxon = require(' + JSON.stringify(external.resolve('luxon')) + ');',
+    temporal: 'globalThis.dateCandidateLibraries.Temporal = require(' + JSON.stringify(external.resolve('@js-temporal/polyfill')) + ').Temporal;'
+  };
+  const evidence = {};
+  for (const [name, code] of Object.entries(specs)) {
+    const entry = path.join(output, name + '-entry.cjs');
+    fs.writeFileSync(entry, code);
+    const compiler = webpack({mode: 'production', context: process.cwd(), entry,
+      output: {path: output, filename: name + '.js'},
+      module: {rules: [{test: /\.[cm]?js$/, include: [fs.realpathSync(directory)],
+        use: {loader: require.resolve('babel-loader'), options: {babelrc: false, configFile: false,
+          presets: [require.resolve('@babel/preset-env')]}}}]}
+    });
+    await new Promise((resolve, reject) => compiler.run((error, stats) => compiler.close(closeError => {
+      if (error || closeError) return reject(error || closeError);
+      if (stats.hasErrors()) return reject(new Error(stats.toString({all: false, errors: true})));
+      resolve();
+    })));
+    const bytes = fs.readFileSync(path.join(output, name + '.js'));
+    evidence[name] = {bytes: bytes.length, gzipBytes: gzipSync(bytes, {level: 9}).length,
+      sha256: createHash('sha256').update(bytes).digest('hex')};
+  }
+  return evidence;
+}
+
+async function run() {
+  const directory = path.resolve(process.argv[2]);
+  const engine = process.argv[3] || 'chromium';
+  assert.ok(['chromium', 'firefox', 'webkit'].includes(engine));
+  const output = fs.mkdtempSync(path.join(os.tmpdir(), 'nightscout-date-candidates-'));
+  let browser, context, fixture;
+  try {
+    const bundleEvidence = await bundles(directory, output);
+    fixture = await createPageFixture();
+    browser = await playwright[engine].launch();
+    context = await browser.newContext({serviceWorkers: 'block'});
+    const blocked = [], errors = [];
+    await context.route('**/*', route => {
+      if (new URL(route.request().url()).origin !== fixture.origin) {blocked.push(route.request().url()); return route.abort();}
+      return route.continue();
+    });
+    const page = await context.newPage();
+    page.on('pageerror', error => errors.push(error.message));
+    await page.addInitScript(hash => localStorage.setItem('apisecrethash', hash), hash);
+    await page.goto(fixture.origin);
+    await page.waitForFunction(() => window.Nightscout?.client?.latestSGV?.mgdl === 123);
+    const support = await page.evaluate(() => ({Temporal: typeof globalThis.Temporal, Intl: typeof globalThis.Intl,
+      timeZone: typeof Intl.DateTimeFormat, locales: moment.locales()}));
+    await page.evaluate(() => {globalThis.dateCandidateLibraries = {moment: globalThis.moment};});
+    for (const name of ['dayjs', 'luxon', 'temporal']) await page.addScriptTag({path: path.join(output, name + '.js')});
+    await page.evaluate('globalThis.createDateCandidates = ' + createCandidates.toString());
+    await page.evaluate('globalThis.runDateContracts = ' + runContracts.toString());
+    await page.evaluate('globalThis.runDateSeasons = ' + runSeasons.toString());
+    const result = await page.evaluate(corpus => {
+      // Compare only locales actually exposed by Nightscout's production bundle.
+      corpus.locales = moment.locales();
+      const libraries = globalThis.dateCandidateLibraries;
+      const candidates = globalThis.createDateCandidates(libraries);
+      if (globalThis.Temporal) candidates.nativeTemporal = globalThis.createDateCandidates({...libraries, Temporal: globalThis.Temporal}).temporal;
+      const seasons = globalThis.runDateSeasons(candidates, corpus, libraries.luxon, globalThis.runDateContracts);
+      return {corpus, seasons, moment: moment.version, momentTimezone: moment.tz.version, momentTzData: moment.tz.dataVersion};
+    }, corpus);
+    for (const season of result.seasons) for (const row of season.rows) for (const [name, observation] of Object.entries(row.results)) {
+      assert.equal(observation.error, undefined, name + ' could not execute ' + row.kind + ': ' + JSON.stringify(row.args));
+    }
+    // Remove Intl before loading each candidate in a fresh realm: the Temporal
+    // polyfill captures Intl constructors at module initialization.
+    const withoutIntl = {moment: await page.evaluate(() => {
+      const original = globalThis.Intl;
+      try {
+        globalThis.Intl = undefined;
+        const d = moment.tz(1704067200000, 'Pacific/Chatham').locale('en');
+        return {value: {date: d.format('YYYY-MM-DD'), time: d.format('HH:mm')}};
+      } finally {globalThis.Intl = original;}
+    })};
+    for (const name of ['dayjs', 'luxon', 'temporal']) {
+      const isolated = await context.newPage();
+      const initializationErrors = [];
+      isolated.on('pageerror', error => initializationErrors.push(error.message));
+      try {
+        await isolated.evaluate(() => {globalThis.Intl = undefined; globalThis.dateCandidateLibraries = {};});
+        await isolated.addScriptTag({path: path.join(output, name + '.js')});
+        await isolated.evaluate('globalThis.createDateCandidates = ' + createCandidates.toString());
+        const observation = await isolated.evaluate(name => {
+          try {return {value: globalThis.createDateCandidates(globalThis.dateCandidateLibraries)[name].format(1704067200000, 'Pacific/Chatham', 'en')};}
+          catch (error) {return {error: error.name + ': ' + error.message};}
+        }, name);
+        withoutIntl[name] = {...observation, initializationErrors};
+      } finally {await isolated.close();}
+    }
+    await page.evaluate(() => {window.Nightscout.client.socket.disconnect(); window.Nightscout.client.alarmSocket.disconnect();});
+    assert.deepEqual(blocked, []); assert.deepEqual(errors, []);
+    console.log(JSON.stringify({baseline: execFileSync('git', ['rev-parse', 'HEAD'], {encoding: 'utf8'}).trim(),
+      sources: Object.fromEntries(['browser-date-candidate-probe.cjs', 'date-candidate-contracts.cjs', 'date-candidate-probe.cjs'].map(name =>
+        [name, createHash('sha256').update(fs.readFileSync(path.join(__dirname, name))).digest('hex')])),
+      engine, browserVersion: browser.version(), node: process.version, support, bundleEvidence, withoutIntl,
+      appBundleSha256: createHash('sha256').update(fs.readFileSync('node_modules/.cache/_ns_cache/public/js/bundle.app.js')).digest('hex'),
+      scope: 'Candidate APIs against actual production Moment global; clipped browser timezone data. Standalone candidate bundle bytes are not an app replacement delta. No therapy or UI migration.', ...result}, null, 2));
+  } finally {
+    if (context) await context.close();
+    if (browser) await browser.close();
+    if (fixture) await new Promise(resolve => fixture.io.close(resolve));
+    fs.rmSync(output, {recursive: true, force: true});
+  }
+}
+
+run().catch(error => {console.error(error); process.exitCode = 1;});

--- a/tools/audits/date-candidate-contracts.cjs
+++ b/tools/audits/date-candidate-contracts.cjs
@@ -1,0 +1,127 @@
+'use strict';
+
+// Research adapters only: native candidate APIs, never a Moment-compatible shim.
+// This factory is also evaluated in an isolated browser with the same inputs.
+function createCandidates({moment, dayjs, luxon, Temporal}) {
+  const pad = n => String(n).padStart(2, '0');
+  const temporalLocal = (local, zone) => Temporal.PlainDateTime.from(local)
+    .toZonedDateTime(zone, {disambiguation: 'compatible'});
+  const epoch = value => new Date(value).toISOString();
+  const temporalInstant = value => ({iso: epoch(value.epochMilliseconds), offset: value.offsetNanoseconds / 6e10});
+  const momentInstant = value => ({iso: value.toISOString(), offset: value.utcOffset()});
+  const luxonInstant = value => ({iso: epoch(value.toMillis()), offset: value.offset});
+  const formatters = new Map();
+  function intlFormat(instant, zone, locale) {
+    const key = zone + '/' + locale;
+    if (!formatters.has(key)) formatters.set(key, new Intl.DateTimeFormat(locale, {
+      timeZone: zone, calendar: 'gregory', hourCycle: 'h23',
+      year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'
+    }));
+    const parts = Object.fromEntries(formatters.get(key).formatToParts(instant).map(p => [p.type, p.value]));
+    return {date: parts.year + '-' + parts.month + '-' + parts.day, time: parts.hour + ':' + parts.minute};
+  }
+  return {
+    moment: {
+      format: (instant, zone, locale) => {
+        const d = moment.tz(instant, zone).locale(locale);
+        return {date: d.format('YYYY-MM-DD'), time: d.format('HH:mm')};
+      },
+      local: (local, zone) => momentInstant(moment.tz(local, zone)),
+      offsetLocal: (local, offset) => momentInstant(moment.parseZone(local + offset)),
+      calendarDay: (local, zone) => momentInstant(moment.tz(local, zone).add(1, 'day')),
+      validDate: local => moment(local, moment.ISO_8601, true).isValid(),
+      elapsedHours: hours => moment.duration(hours, 'hours').asMilliseconds(),
+      immutable: () => {const d = moment.utc('2024-01-01'); return d.add(1, 'hour') !== d;}
+    },
+    intl: {
+      format: intlFormat,
+      // Intl provides formatting, not local-time parsing or calendar arithmetic.
+      local: null, offsetLocal: null, calendarDay: null, validDate: null, elapsedHours: null, immutable: null
+    },
+    dayjs: {
+      format: (instant, zone, locale) => {
+        const d = dayjs(instant).tz(zone).locale(locale);
+        return {date: d.format('YYYY-MM-DD'), time: d.format('HH:mm')};
+      },
+      local: (local, zone) => momentInstant(dayjs.tz(local, zone)),
+      offsetLocal: (local, offset) => momentInstant(dayjs.utc(local).utcOffset(offset, true)),
+      calendarDay: (local, zone) => momentInstant(dayjs.tz(local, zone).add(1, 'day')),
+      validDate: local => dayjs(local).isValid(),
+      elapsedHours: hours => dayjs.duration(hours, 'hours').asMilliseconds(),
+      immutable: () => {const d = dayjs.utc('2024-01-01'); return d.add(1, 'hour') !== d;}
+    },
+    luxon: {
+      format: (instant, zone, locale) => {
+        const d = luxon.DateTime.fromMillis(instant, {zone, locale});
+        return {date: d.toFormat('yyyy-MM-dd'), time: d.toFormat('HH:mm')};
+      },
+      local: (local, zone) => luxonInstant(luxon.DateTime.fromISO(local, {zone})),
+      offsetLocal: (local, offset) => luxonInstant(luxon.DateTime.fromISO(local + offset, {setZone: true})),
+      calendarDay: (local, zone) => luxonInstant(luxon.DateTime.fromISO(local, {zone}).plus({days: 1})),
+      validDate: local => luxon.DateTime.fromISO(local).isValid,
+      elapsedHours: hours => luxon.Duration.fromObject({hours}).as('milliseconds'),
+      immutable: () => {const d = luxon.DateTime.utc(2024, 1, 1); return d.plus({hours: 1}) !== d;}
+    },
+    temporal: {
+      // Temporal machine-readable fields have no Moment locale postformat hook.
+      // Localized display needs Intl, evaluated separately above.
+      format: (instant, zone) => {
+        const d = Temporal.Instant.fromEpochMilliseconds(instant).toZonedDateTimeISO(zone);
+        return {date: d.toPlainDate().toString(), time: pad(d.hour) + ':' + pad(d.minute)};
+      },
+      local: (local, zone) => temporalInstant(temporalLocal(local, zone)),
+      offsetLocal: (local, offset) => temporalInstant(temporalLocal(local, offset)),
+      calendarDay: (local, zone) => temporalInstant(temporalLocal(local, zone).add({days: 1})),
+      validDate: local => {try {Temporal.PlainDate.from(local); return true;} catch {return false;}},
+      elapsedHours: hours => Temporal.Duration.from({hours}).total({unit: 'milliseconds'}),
+      immutable: () => {const d = Temporal.PlainDateTime.from('2024-01-01'); return d.add({hours: 1}) !== d;}
+    }
+  };
+}
+
+function runContracts(candidates, corpus) {
+  const rows = [];
+  function compare(kind, args) {
+    const results = {};
+    for (const [name, candidate] of Object.entries(candidates)) {
+      if (!candidate[kind]) {results[name] = {unsupported: true}; continue;}
+      try {results[name] = {value: candidate[kind](...args)};}
+      catch (error) {results[name] = {error: error.name + ': ' + error.message};}
+    }
+    const baseline = JSON.stringify(results.moment);
+    rows.push({kind, args, results, different: Object.keys(results).filter(name => JSON.stringify(results[name]) !== baseline)});
+  }
+  for (const zone of corpus.zones) for (const locale of corpus.locales) for (const instant of corpus.instants) compare('format', [instant, zone, locale]);
+  for (const args of corpus.localTimes) compare('local', args);
+  for (const args of corpus.offsetTimes) compare('offsetLocal', args);
+  for (const args of corpus.calendarDays) compare('calendarDay', args);
+  for (const date of corpus.dates) compare('validDate', [date]);
+  for (const hours of corpus.hours) compare('elapsedHours', [hours]);
+  compare('immutable', []);
+  return rows;
+}
+
+function runSeasons(candidates, corpus, luxon, runContracts) {
+  const OriginalDate = globalThis.Date;
+  const originalNow = luxon.Settings.now;
+  const seasons = [];
+  try {
+    for (const now of ['2024-01-15T00:00:00Z', '2024-07-15T00:00:00Z']) {
+      const epoch = OriginalDate.parse(now);
+      globalThis.Date = class extends OriginalDate {
+        constructor(...args) {super(...(args.length ? args : [epoch]));}
+        static now() {return epoch;}
+      };
+      luxon.Settings.now = () => epoch;
+      luxon.Settings.resetCaches();
+      seasons.push({now, rows: runContracts(candidates, corpus)});
+    }
+  } finally {
+    globalThis.Date = OriginalDate;
+    luxon.Settings.now = originalNow;
+    luxon.Settings.resetCaches();
+  }
+  return seasons;
+}
+
+module.exports = {createCandidates, runContracts, runSeasons};

--- a/tools/audits/date-candidate-memory.cjs
+++ b/tools/audits/date-candidate-memory.cjs
@@ -1,0 +1,75 @@
+'use strict';
+
+// Isolated candidate costs only: neither a full Nightscout server nor an estimate
+// of savings from replacing Moment. Each sample loads exactly one candidate.
+const path = require('node:path');
+const {createRequire} = require('node:module');
+const {execFileSync} = require('node:child_process');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const {createHash} = require('node:crypto');
+
+async function sample(name, directory) {
+  assert.equal(typeof global.gc, 'function', 'Run with --expose-gc');
+  const external = createRequire(path.resolve(directory, 'package.json'));
+  async function collect() {
+    for (let n = 0; n < 3; n++) {global.gc(); await new Promise(resolve => setImmediate(resolve));}
+    return {...process.memoryUsage(), modules: Object.keys(require.cache).length};
+  }
+  const before = await collect();
+  const start = performance.now();
+  let make;
+  if (name === 'moment') {
+    const moment = require('moment-timezone');
+    make = instant => moment.tz(instant, 'America/New_York');
+  } else if (name === 'dayjs') {
+    const dayjs = external('dayjs');
+    dayjs.extend(external('dayjs/plugin/utc')); dayjs.extend(external('dayjs/plugin/timezone'));
+    make = instant => dayjs(instant).tz('America/New_York');
+  } else if (name === 'luxon') {
+    const {DateTime} = external('luxon');
+    make = instant => DateTime.fromMillis(instant, {zone: 'America/New_York'});
+  } else if (name === 'temporal') {
+    const {Temporal} = external('@js-temporal/polyfill');
+    make = instant => Temporal.Instant.fromEpochMilliseconds(instant).toZonedDateTimeISO('America/New_York');
+  } else {throw new Error('Unknown candidate');}
+  const loadMilliseconds = performance.now() - start;
+  // Warm the zone formatter/cache before comparing populated and released values.
+  for (let n = 0; n < 100; n++) make(1704067200000 + n * 60000);
+  const loaded = await collect();
+  const cycles = [];
+  for (let cycle = 0; cycle < 5; cycle++) {
+    const started = performance.now();
+    let values = Array.from({length: 5000}, (_, n) => make(1704067200000 + n * 60000));
+    const milliseconds = performance.now() - started;
+    const instant = d => name === 'temporal' ? d.epochMilliseconds : Number(d);
+    assert.equal(instant(values[0]), 1704067200000); assert.equal(instant(values[values.length - 1]), 1704367140000);
+    const populated = await collect();
+    values = null;
+    cycles.push({cycle, milliseconds, populated, released: await collect()});
+  }
+  return {name, node: process.version, icu: process.versions.icu, tz: process.versions.tz,
+    before, loaded, loadMilliseconds, cycles, resources: process.getActiveResourcesInfo()};
+}
+
+async function run() {
+  const directory = path.resolve(process.argv[2]);
+  if (process.argv[3] === '--sample') {
+    console.log(JSON.stringify(await sample(process.argv[4], directory))); return;
+  }
+  const results = [];
+  for (let round = 0; round < 7; round++) {
+    const names = ['moment', 'dayjs', 'luxon', 'temporal']; if (round % 2) names.reverse();
+    for (const name of names) {
+      results.push({round, ...JSON.parse(execFileSync(process.execPath,
+        ['--expose-gc', __filename, directory, '--sample', name], {encoding: 'utf8'}))});
+    }
+  }
+  console.log(JSON.stringify({
+    baseline: execFileSync('git', ['rev-parse', 'HEAD'], {encoding: 'utf8'}).trim(),
+    probeSha256: createHash('sha256').update(fs.readFileSync(__filename)).digest('hex'),
+    scope: 'Seven alternating fresh processes per candidate; five cycles of 5000 zoned values. Full server Moment timezone data. No Intl-only date type, application throughput, or server RAM-saving claim.',
+    results
+  }, null, 2));
+}
+run().catch(error => {console.error(error); process.exitCode = 1;});

--- a/tools/audits/date-candidate-probe.cjs
+++ b/tools/audits/date-candidate-probe.cjs
@@ -1,0 +1,77 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {createRequire} = require('node:module');
+const {execFileSync} = require('node:child_process');
+const {createHash} = require('node:crypto');
+const assert = require('node:assert/strict');
+const {createCandidates, runContracts, runSeasons} = require('./date-candidate-contracts.cjs');
+const {zones, instants} = require('./intl-editor-format-probe.cjs');
+
+const corpus = {
+  zones, instants, locales: ['en', 'de', 'fr', 'ar', 'fa'],
+  localTimes: [
+    ['2024-03-10T02:30:00', 'America/New_York'], ['2024-11-03T01:30:00', 'America/New_York'],
+    ['2024-10-06T02:15:00', 'Australia/Lord_Howe'], ['2024-04-07T01:45:00', 'Australia/Lord_Howe'],
+    ['2024-01-01T00:00:00', 'Asia/Kathmandu'], ['1900-01-01T00:00:00', 'Asia/Gaza']
+  ],
+  calendarDays: [
+    ['2024-03-10T00:00:00', 'America/New_York'], ['2024-11-03T00:00:00', 'America/New_York'],
+    ['2024-10-06T00:00:00', 'Australia/Lord_Howe'], ['2024-04-07T00:00:00', 'Australia/Lord_Howe'],
+    ['2024-01-01T00:00:00', 'Asia/Kathmandu']
+  ],
+  offsetTimes: ['+05:30', '+05:45', '-03:30'].map(offset => ['2024-01-01T00:00:00', offset]),
+  dates: ['2024-02-29', '2024-02-30', '2023-02-29', '2024-13-01', '2024-00-01', '2024-01-00', 'not-a-date'],
+  hours: [-25, -1, 0, 1, 25, 10000]
+};
+
+function load(candidateDirectory) {
+  const external = createRequire(path.resolve(candidateDirectory, 'package.json'));
+  const dayjs = external('dayjs');
+  for (const plugin of ['utc', 'timezone', 'duration']) dayjs.extend(external('dayjs/plugin/' + plugin));
+  for (const locale of corpus.locales.slice(1)) external('dayjs/locale/' + locale);
+  return {moment: require('moment-timezone'), dayjs, luxon: external('luxon'), Temporal: external('@js-temporal/polyfill').Temporal};
+}
+
+async function run() {
+  const directory = path.resolve(process.argv[2]);
+  const libraries = load(directory);
+  const lock = JSON.parse(fs.readFileSync(path.join(directory, 'package-lock.json')));
+  for (const [name, version] of Object.entries({'@js-temporal/polyfill': '0.5.1', luxon: '3.7.2', dayjs: '1.11.23'})) {
+    assert.equal(lock.packages['node_modules/' + name].version, version, 'Review changed candidate versions');
+  }
+  const candidates = createCandidates(libraries);
+  const seasons = runSeasons(candidates, corpus, libraries.luxon, runContracts);
+  for (const season of seasons) for (const row of season.rows) for (const [name, observation] of Object.entries(row.results)) {
+    assert.equal(observation.error, undefined, name + ' could not execute ' + row.kind + ': ' + JSON.stringify(row.args));
+  }
+  const timings = [];
+  for (const c of Object.values(candidates)) for (let n = 0; n < 200; n++) c.format(instants[n % instants.length], 'America/New_York', 'en');
+  for (let round = 0; round < 7; round++) {
+    const names = Object.keys(candidates); if (round % 2) names.reverse();
+    for (const name of names) {
+      let checksum = 0;
+      const start = performance.now();
+      for (let n = 0; n < 5000; n++) {
+        const result = candidates[name].format(instants[n % instants.length], 'America/New_York', 'en');
+        checksum += result.date.length + result.time.length;
+      }
+      timings.push({round, name, iterations: 5000, milliseconds: performance.now() - start, checksum});
+    }
+  }
+  const sourceHash = name => createHash('sha256').update(fs.readFileSync(path.join(__dirname, name))).digest('hex');
+  console.log(JSON.stringify({
+    baseline: execFileSync('git', ['rev-parse', 'HEAD'], {encoding: 'utf8'}).trim(),
+    node: process.version, icu: process.versions.icu, tz: process.versions.tz,
+    nativeTemporal: typeof globalThis.Temporal, moment: libraries.moment.version,
+    momentTimezone: libraries.moment.tz.version, momentTzData: libraries.moment.tz.dataVersion,
+    sources: Object.fromEntries(['date-candidate-probe.cjs', 'date-candidate-contracts.cjs'].map(name => [name, sourceHash(name)])),
+    candidatePackages: Object.fromEntries(Object.entries(lock.packages).filter(([key]) => key).map(([key, value]) => [key, {version: value.version, integrity: value.integrity}])),
+    scope: 'Native candidate operations and explicit formatting adapters; not a production migration or proof of all application contracts. Full server Moment timezone data.',
+    corpus, seasons, timings
+  }, null, 2));
+}
+
+module.exports = {corpus, load};
+if (require.main === module) run().catch(error => {console.error(error); process.exitCode = 1;});

--- a/tools/audits/date-candidates/package-lock.json
+++ b/tools/audits/date-candidates/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "nightscout-m27-candidates",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@js-temporal/polyfill": "0.5.1",
+        "dayjs": "1.11.23",
+        "luxon": "3.7.2"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/tools/audits/date-candidates/package.json
+++ b/tools/audits/date-candidates/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "nightscout-m27-candidates",
+  "private": true,
+  "dependencies": {
+    "@js-temporal/polyfill": "0.5.1",
+    "dayjs": "1.11.23",
+    "luxon": "3.7.2"
+  }
+}


### PR DESCRIPTION
Record M27's explicit decision to retain the existing narrowed Moment implementation for 15.0.9. The shared comparison now includes Day.js, Luxon, Intl and Temporal, with runtime/browser support, calendar-day/DST behavior, fixed offsets, invalid dates, duration/mutation contracts, and measured standalone costs. No candidate is installed into Nightscout's runtime or root dependency tree.

The retained iOS 9.3 target lacks Intl, and both supported Node floors lack native Temporal. Fresh-realm feature-removal probes expose the candidates' Intl dependency. Temporal's explicit compatible disambiguation matches the tested calendar/zone contracts; the decision preserves the current platform/API contract and records when to reassess a direct migration.

- Added eight real-profile calendar-day regressions across 23/25-hour and half-hour DST days in both unit modes, plus additional actual API invalid-date cases. All 51 date/time cases pass on Node 22.23.2 and 24.20.0.
- Clean Node 22 install/build; backend 2,109 passing with one existing pending case; client-core 283; dependencies 305; lint zero errors with sixteen existing warnings.
- Seven alternating candidate CPU rounds and seven fresh-process memory samples per candidate per Node floor. Source hashes and raw memory samples are recorded; no whole-server or app bundle saving is claimed.
- Local Chromium and WebKit comparisons use the actual production Moment bundle. Existing browser CI jobs collect all four current-head artifacts with separately locked research dependencies; no new job/environment is added. Hosted Firefox 155.0 and the other three browser jobs passed; all eight editor/candidate artifacts were downloaded and verified against the tested merge tree.

Also records the maintainer's 2026-09-08 direction: complete code/regression/CI work first; production-host, real-account/Atlas and physical-device testing are maintainer-owned afterward. Those manual checks are not marked passed, and #8605 is not promoted to dev.

Hosted CI run [34209734494](https://github.com/nightscout/cgm-remote-monitor/actions/runs/34209734494), CodeQL and both Docker architectures passed. All artifacts identify virtual merge fa5e9ec270cfd4b388913447d481a045fffdef93, whose tree fb101a3409b487d626505772a219980fd886bace exactly matches the proposed merge into the freshly fetched integration branch; audit source hashes match. Rollback: revert this child PR; no configuration, runtime or persisted-data migration occurs. The complete rationale, limitations and review trigger are in `docs/plans/date-time-decision.md`.
