### PR TITLE
Resolve modernization CodeQL credential and Location warnings

### DIFF
--- a/docs/test-specs/modernization-completion.md
+++ b/docs/test-specs/modernization-completion.md
@@ -92,8 +92,11 @@ fall from 1,651,030 to 1,359,001 and non-polling requests from 203 to 178.
 [journey](../audits/final-modernization/browser-journey.json) evidence includes
 raw timing, DOM, heap, transfer and build identities. Timings vary by page;
 the dashboard median is slightly higher within the matched variation limit.
-The measurement fixture optionally accepts the historical status-query test
-credential so the unchanged baseline can authenticate; production auth is untouched.
+These historical measurements used the then-current fixture query-credential
+option. The security follow-up removes that option: measurement browser contexts
+now send the fixed fixture credential in a header, so the unchanged baseline can
+still authenticate. Production authentication is untouched; the original raw
+measurements/source hashes remain a record of their original implementation.
 
 ## Validation and handoff
 

--- a/docs/test-specs/modernization-security-warnings.md
+++ b/docs/test-specs/modernization-security-warnings.md
@@ -1,0 +1,45 @@
+# Modernization CodeQL warnings
+
+Review of #8605 found two active alerts on its merge ref: #114
+(`js/sensitive-get-query`, test fixture) and #64
+(`js/server-side-unvalidated-url-redirection`, API3). Earlier fixture alert #103
+was already fixed. A green CodeQL check did not mean the branch had zero open
+warnings: query severity and findings inherited from the base matter.
+
+The browser measurement fixture now requires the `api-secret` header and never
+reads a query credential. Both measurement tools supply the fixed, synthetic
+credential through Playwright context headers. The unchanged historical client
+can therefore authenticate without a query fallback in the fixture. Normal
+fixture authentication tests stay private; no alert suppression or dismissal is
+used. Historical raw measurements retain their original source hashes.
+
+API3 create and deduplicating replacement now construct Location from the
+registered `/api/v3` prefix, configured collection name and separately encoded
+identifier. Request paths and proxy/Host metadata are not inputs. Both handlers
+share the construction, including the equivalent replacement path not identified
+by the original alert. UUID/ObjectId response identifiers, status codes, stored
+documents and ordinary URLs are unchanged. Case-insensitive/trailing-slash POSTs
+return the canonical resource URL. The adversarial unit request demonstrates why
+request-derived URLs are an unsafe construction pattern; it is not a claim that
+an external redirect was reproduced through the deployed Express route chain.
+
+Five new regressions fail before the fixes: four create/deduplication cases using
+UUID/ObjectId identifiers with adversarial request paths, and one fixture case
+where an outdated caller requests query authentication. Afterward they pass on
+Node 22.23.2 and 24.20.0. The existing real API persisted-UUID lifecycle additionally
+covers mixed-case/trailing-slash create and deduplication URLs, readable canonical
+Location, storage/cache output and deletion over repeated cycles.
+
+Run the focused cases with:
+
+```sh
+node node_modules/mocha/bin/mocha.js --timeout 10000 --exit \
+  tests/api3-location.test.js tests/page-fixture-traffic.test.js
+```
+
+Full backend/client-core/dependency/installed-connector tests, browser startup and
+service-worker journeys, and current-head hosted CI/CodeQL remain merge gates.
+Inspect open alerts specifically on `refs/pull/8605/merge` after integration;
+alerts can remain open on master/dev until the integration PR is merged there.
+Rollback reverts the child commit; it restores the warned URL constructions.
+There is no dependency, schema, identifier-format or production auth migration.

--- a/lib/api3/generic/create/insert.js
+++ b/lib/api3/generic/create/insert.js
@@ -3,7 +3,7 @@
 const apiConst = require('../../const.json')
   , security = require('../../security')
   , validate = require('./validate.js')
-  , path = require('path')
+  , documentLocation = require('../../shared/documentLocation')
   , opTools = require('../../shared/operationTools')
   ;
 
@@ -14,7 +14,7 @@ const apiConst = require('../../const.json')
  */
 async function insert (opCtx, doc) {
 
-  const { ctx, auth, col, req, res } = opCtx;
+  const { ctx, auth, col, res } = opCtx;
 
   await security.demandPermission(opCtx, `api:${col.colName}:create`);
 
@@ -35,7 +35,7 @@ async function insert (opCtx, doc) {
     throw new Error('empty identifier');
 
   res.setHeader('Last-Modified', now.toUTCString());
-  res.setHeader('Location', path.posix.join(req.baseUrl, req.path, identifier));
+  res.setHeader('Location', documentLocation(col.colName, identifier));
 
 
   const fields = {

--- a/lib/api3/generic/update/replace.js
+++ b/lib/api3/generic/update/replace.js
@@ -3,7 +3,7 @@
 const apiConst = require('../../const.json')
   , security = require('../../security')
   , validate = require('./validate.js')
-  , path = require('path')
+  , documentLocation = require('../../shared/documentLocation')
   , opTools = require('../../shared/operationTools')
   , treatmentDuration = require('../../../treatmentDuration')
   ;
@@ -17,7 +17,7 @@ const apiConst = require('../../const.json')
  */
 async function replace (opCtx, doc, storageDoc, options) {
 
-  const { ctx, auth, col, req, res } = opCtx;
+  const { ctx, auth, col, res } = opCtx;
   const { isDeduplication } = options || {};
 
   await security.demandPermission(opCtx, `api:${col.colName}:update`);
@@ -46,7 +46,7 @@ async function replace (opCtx, doc, storageDoc, options) {
   }
 
   if (storageDoc.identifier !== doc.identifier || isDeduplication) {
-    res.setHeader('Location', path.posix.join(req.baseUrl, req.path, doc.identifier));
+    res.setHeader('Location', documentLocation(col.colName, doc.identifier));
     fields.identifier = doc.identifier;
     fields.isDeduplication = true;
     if (storageDoc.identifier !== doc.identifier) {

--- a/lib/api3/shared/documentLocation.js
+++ b/lib/api3/shared/documentLocation.js
@@ -1,0 +1,7 @@
+'use strict';
+
+// API3 is mounted at /api/v3. Collection names come from generic/setup, not
+// request paths or proxy headers. Encode each dynamic segment independently.
+module.exports = function documentLocation (collection, identifier) {
+  return '/api/v3/' + encodeURIComponent(collection) + '/' + encodeURIComponent(identifier);
+};

--- a/tests/api3-location.test.js
+++ b/tests/api3-location.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {EventEmitter} = require('node:events');
+const insert = require('../lib/api3/generic/create/insert');
+const replace = require('../lib/api3/generic/update/replace');
+
+describe('API3 document Location headers', function () {
+  for (const identifier of ['8c59e104-14cf-5bac-90e2-a47e502baaac', '65b000000000000000000001']) {
+    for (const deduplicate of [false, true]) {
+      it('uses the collection resource for ' + (deduplicate ? 'deduplicated ' : 'created ') + identifier, async function () {
+        const doc = {identifier, date: 1704067200000, utcOffset: 0, app: 'location-fixture', device: 'fixture'};
+        const res = {headers: {}, setHeader(name, value) {this.headers[name] = value;},
+          status(code) {this.statusCode = code; return this;}, json(body) {this.body = body; return this;}};
+        const ctx = {bus: new EventEmitter()};
+        const opCtx = {ctx, auth: {shiros: [{check: () => true}]}, res,
+          // Location must not depend on arbitrary request URL/proxy metadata.
+          req: {baseUrl: '/\\external.example', path: '/elsewhere', headers: {host: 'external.example'}},
+          col: {colName: 'treatments', autoPrune() {}, storage: {
+            insertOne: async () => identifier, replaceOne: async () => 1
+          }}};
+        if (deduplicate) await replace(opCtx, {...doc}, {...doc}, {isDeduplication: true});
+        else await insert(opCtx, {...doc});
+        assert.equal(res.statusCode, deduplicate ? 200 : 201);
+        assert.equal(res.headers.Location, '/api/v3/treatments/' + identifier);
+        assert.equal(new URL(res.headers.Location, 'https://nightscout.example').origin, 'https://nightscout.example');
+        assert.equal(res.body.identifier, identifier);
+      });
+    }
+  }
+});

--- a/tests/api3.create.test.js
+++ b/tests/api3.create.test.js
@@ -594,14 +594,18 @@ describe('API3 CREATE', function() {
       eventType: 'Correction Bolus', insulin: 0.3, app: testConst.TEST_APP
     };
     for (let cycle = 0; cycle < 2; cycle++) {
-      let res = await self.instance.post(self.url, self.jwt.create).send(doc).expect(201);
+      // Express accepts case-insensitive routes and a trailing slash; Location
+      // must still identify the canonical, readable resource.
+      const requestUrl = cycle ? self.url.toUpperCase() + '/' : self.url;
+      let res = await self.instance.post(requestUrl, self.jwt.create).send(doc).expect(201);
       res.body.identifier.should.equal(identifier);
       res.headers.location.should.equal(`${self.url}/${identifier}`);
       self.cache.nextShouldEql(self.col, {...doc, identifier});
 
-      res = await self.instance.post(self.url, self.jwt.update).send(doc).expect(200);
+      res = await self.instance.post(requestUrl, self.jwt.update).send(doc).expect(200);
       res.body.identifier.should.equal(identifier);
       res.body.isDeduplication.should.equal(true);
+      res.headers.location.should.equal(`${self.url}/${identifier}`);
       self.cache.nextShouldEql(self.col, {...doc, identifier});
 
       const stored = await self.get(identifier);

--- a/tests/fixtures/page-startup/server.js
+++ b/tests/fixtures/page-startup/server.js
@@ -51,7 +51,7 @@ async function createPageFixture(options = {}) {
   const worker = fs.readFileSync(path.join(root, 'views/service-worker.js'), 'utf8');
   app.get('/sw.js', (request, response) => response.type('js').set('Cache-Control', 'no-store').send(ejs.render(worker, {locals: {cachebuster: state.workerVersion}})));
   app.get('/api/v1/status.json', (request, response) => {
-    if (request.headers['api-secret'] !== hash && !(options.legacyStatusQuery && request.query.secret === hash)) {state.challenges++; return response.status(401).json({message: 'Authentication required'});}
+    if (request.headers['api-secret'] !== hash) {state.challenges++; return response.status(401).json({message: 'Authentication required'});}
     if (state.loadingResponses > 0) {state.loadingResponses--; return response.json({...settings, runtimeState: 'loading'});}
     response.json(settings);
   });

--- a/tests/page-fixture-traffic.test.js
+++ b/tests/page-fixture-traffic.test.js
@@ -3,7 +3,7 @@
 const assert = require('node:assert/strict');
 const http = require('node:http');
 const {gunzipSync} = require('node:zlib');
-const {createPageFixture} = require('./fixtures/page-startup/server');
+const {createPageFixture, hash} = require('./fixtures/page-startup/server');
 
 describe('Page benchmark HTTP body accounting', function () {
   it('counts actual compressed and identity bytes once at the final response write', async function () {
@@ -27,6 +27,20 @@ describe('Page benchmark HTTP body accounting', function () {
         assert.equal(result.headers['content-encoding'] || 'identity', encoding);
         if (encoding === 'gzip') assert.ok(gunzipSync(result.bytes).length > result.bytes.length, 'Measure compressed bytes, not source bytes');
       }
+    } finally {await new Promise(resolve => fixture.io.close(resolve));}
+  });
+});
+
+
+describe('Page fixture authentication', function () {
+  it('requires a credential header even when an older caller requests query authentication', async function () {
+    const fixture = await createPageFixture({legacyStatusQuery: true});
+    try {
+      const url = fixture.origin + '/api/v1/status.json';
+      assert.equal((await fetch(url + '?secret=' + hash)).status, 401);
+      assert.equal((await fetch(url + '?secret=' + hash, {headers: {'api-secret': 'wrong'}})).status, 401);
+      assert.equal((await fetch(url, {headers: {'api-secret': hash}})).status, 200);
+      assert.equal((await fetch(url + '?secret=wrong', {headers: {'api-secret': hash}})).status, 200);
     } finally {await new Promise(resolve => fixture.io.close(resolve));}
   });
 });

--- a/tools/measure-page-journey.js
+++ b/tools/measure-page-journey.js
@@ -10,7 +10,7 @@ const {createPageFixture, pages, hash} = require('../tests/fixtures/page-startup
 async function journey(fixture, data) {
   const browser = await chromium.launch();
   try {
-    const context = await browser.newContext({serviceWorkers: 'allow', viewport: {width: 1280, height: 900}, timezoneId: 'America/Los_Angeles'});
+    const context = await browser.newContext({extraHTTPHeaders: {'api-secret': hash}, serviceWorkers: 'allow', viewport: {width: 1280, height: 900}, timezoneId: 'America/Los_Angeles'});
     const errors = [], external = [], steps = [];
     context.on('request', request => {if (new URL(request.url()).origin !== fixture.origin) external.push(request.url());});
     const page = await context.newPage();
@@ -59,7 +59,7 @@ async function main() {
   const data = workload(), fixtures = new Map(), rows = [];
   let complete = false, assessment;
   try {
-    for (const [label, root] of Object.entries(roots)) fixtures.set(label, await createPageFixture({root, ...data, legacyStatusQuery: true, compress: true, measureTraffic: true}));
+    for (const [label, root] of Object.entries(roots)) fixtures.set(label, await createPageFixture({root, ...data, compress: true, measureTraffic: true}));
     for (let run = 0; run < samples; run++) for (const label of run % 2 ? ['candidate', 'parent'] : ['parent', 'candidate']) {
       process.stderr.write('Journey ' + run + ' ' + label + '\n');
       rows.push({run, label, ...await journey(fixtures.get(label), data)});

--- a/tools/measure-page-startup.js
+++ b/tools/measure-page-startup.js
@@ -52,7 +52,7 @@ function ready(entry) {
 async function sample(fixture, data, entry, url, snapshotPath) {
   const browser = await chromium.launch();
   try {
-    const context = await browser.newContext({serviceWorkers: 'block', viewport: {width: 1280, height: 900}, timezoneId: 'America/Los_Angeles'});
+    const context = await browser.newContext({extraHTTPHeaders: {'api-secret': hash}, serviceWorkers: 'block', viewport: {width: 1280, height: 900}, timezoneId: 'America/Los_Angeles'});
     const errors = [], external = [], responses = new Map(), completed = [];
     let websocketPayloadBytes = 0;
     context.on('request', request => {if (new URL(request.url()).origin !== fixture.origin) external.push(request.url());});
@@ -126,7 +126,7 @@ async function main() {
   const fixtures = new Map(), rows = [];
   let complete = false, assessment;
   try {
-    for (const [label, root] of Object.entries(roots)) fixtures.set(label, await createPageFixture({root, ...data, legacyStatusQuery: true, compress: true}));
+    for (const [label, root] of Object.entries(roots)) fixtures.set(label, await createPageFixture({root, ...data, compress: true}));
     for (let run = 0; run < samples; run++) {
       for (const [url, , , entry] of selectedPages) {
         for (const label of run % 2 ? ['candidate', 'parent'] : ['parent', 'candidate']) {


### PR DESCRIPTION
Resolve both active CodeQL alerts on #8605: [#114](https://github.com/nightscout/cgm-remote-monitor/security/code-scanning/114) (query credentials in the browser fixture) and inherited [#64](https://github.com/nightscout/cgm-remote-monitor/security/code-scanning/64) (request-derived API3 Location). Earlier fixture alert #103 is already fixed.

Require the fixture credential header and supply it through measurement browser contexts, preserving access for the unchanged historical client without a server-side query fallback. Build create/deduplication Location headers from the fixed API3 route, configured collection and encoded identifier, covering the equivalent replacement path too. Ordinary UUID/ObjectId URLs and response/storage formats remain unchanged; mixed-case/trailing-slash POSTs return a canonical resource URL.

Five new regression cases fail before these changes and pass on both Node 22.23.2 and 24.20.0. The existing persisted-UUID real API lifecycle additionally verifies canonical Location across mixed-case create/deduplication requests, readback and repeated deletion. The adversarial handler fixture establishes unsafe URL construction, not an end-to-end deployed redirect exploit. No finding is suppressed or dismissed.

Local validation passes 2,125 backend tests (one existing pending), 283 core, 305 dependency and 87 installed connector cases; 36 focused/API cases pass on Node 24. Lint has zero errors and 16 existing warnings. Seven startup runs per page and seven navigation journeys pass existing acceptance limits with the unchanged historical client and updated fixture. These are compatibility reruns, not replacement performance claims. CodeQL analysis of virtual merge `57440f17` completed with zero results and zero open alerts; all 22 hosted checks passed (two additional jobs skipped). The initial Node 24/MongoDB 6 watcher restart assertion passed on one unchanged rerun, along with the three cancelled matrix jobs; no root cause is claimed. All 13 browser/recovery artifact directories match the tested merge and source hashes, and owned database cleanup was verified. Merged as `855669c9ab190878370214996b70aa713eca866d`, whose tree matches the independently checked `605156c98944b250d681741cc1432aee2e2f5664`. Final [#8605 CI 34218346539](https://github.com/nightscout/cgm-remote-monitor/actions/runs/34218346539) and CodeQL passed: 21 checks succeeded and two jobs skipped. All 13 final artifact directories match virtual merge `80e047a5cb771273a332c12c7c173d26f6801d10`, including source hashes, bundle identity and owned database cleanup. GitHub reports zero open alerts on that merge ref, both #114 and #64 are fixed, and both Advanced Security review threads are resolved; findings on master/dev remain until this integration reaches those branches. Historical measurements retain their original source hashes. Rollback reverts this child and restores the warned constructions; no schema, dependency, identifier or production-auth migration is involved.
