### PR TITLE
Restore proxy compatibility for existing ingress deployments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,13 +319,16 @@ jobs:
         run: |
           docker run --rm "$IMAGE" node -e "require('./lib/server/runtime-policy')(); console.log(process.version)"
           docker run --rm "$IMAGE" node -e 'const load = require("node:module").createRequire(require.resolve("mongodb")); require("node:assert/strict").equal(load("@mongodb-js/saslprep").saslprep("I\u00ADX"), "IX")'
-          docker run --detach --name nightscout-smoke -e INSECURE_USE_HTTP=true -p 127.0.0.1:1337:1337 "$IMAGE"
+          docker run --detach --name nightscout-smoke -p 127.0.0.1:1337:1337 "$IMAGE"
           trap 'docker logs nightscout-smoke; docker rm -f nightscout-smoke' EXIT
           # With no database credentials the application must serve its setup/error page.
           for attempt in {1..60}; do
-            status=$(curl --silent --output /tmp/nightscout-smoke.html --write-out '%{http_code}' http://127.0.0.1:1337/ || true)
+            status=$(curl --silent --header 'X-Forwarded-Proto: https' --output /tmp/nightscout-smoke.html --write-out '%{http_code}' http://127.0.0.1:1337/ || true)
             if [[ "$status" == "200" || "$status" == "500" || "$status" == "503" ]]; then
               grep -qi nightscout /tmp/nightscout-smoke.html
+              # Default proxy compatibility must avoid HTTPS redirect loops,
+              # while unforwarded HTTP still receives a redirect.
+              test "$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:1337/)" = 307
               exit 0
             fi
             sleep 1

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ $ npm install
 
 ## Installation notes for users with nginx or Apache reverse proxy for SSL/TLS offloading:
 
-- Your site redirects insecure connections to `https` by default. Starting in 15.0.9, reverse-proxy installations must set `TRUST_PROXY` to their trusted proxy IP addresses/CIDRs and configure forwarded headers correctly. Otherwise TLS termination can cause redirect loops. See the [trusted-proxy migration guide](docs/proposals/trusted-proxy-migration.md) before upgrading.
+- Your site redirects insecure connections to `https` by default. Reverse-proxy compatibility remains enabled by default. The proxy must sanitize forwarded headers and control access to the backend. Optional `TRUST_PROXY` settings provide direct-only or explicit IP/CIDR trust; see the [proxy configuration guide](docs/proposals/trusted-proxy-migration.md).
 - In case you use a proxy. Do not use an external network interfaces for hosting Nightscout. Make sure the unsecure port is not available from a remote network connection
 - HTTP Strict Transport Security (HSTS) headers are enabled by default, use settings `SECURE_HSTS_HEADER` and `SECURE_HSTS_HEADER_*`
 - See [Predefined values for your server settings](#predefined-values-for-your-server-settings-optional) for more details
@@ -323,7 +323,7 @@ autonomy for your data:
   * `EDIT_MODE` (`on`) - possible values `on` or `off`. Enables the icon allowing for editing of treatments in the main view.
 
 ### Predefined values for your server settings (optional)
-  * `TRUST_PROXY` (empty) - Comma-separated trusted proxy IP addresses or CIDRs. Empty trusts no proxy. Required behind a reverse proxy for forwarded client IP, HTTPS and hostname metadata. See the [15.0.9 migration guide](docs/proposals/trusted-proxy-migration.md).
+  * `TRUST_PROXY` (empty) - Empty preserves reverse-proxy compatibility without listing proxy addresses. Set `false` to ignore all forwarded metadata, or supply comma-separated trusted proxy IP addresses/CIDRs for restricted trust. See the [proxy configuration guide](docs/proposals/trusted-proxy-migration.md) for the security boundary and client-header rules.
   * `INSECURE_USE_HTTP` (`false`) - Redirect unsafe http traffic to https. Possible values `false`, or `true`. Your site redirects to `https` by default. If you don't want that from Nightscout, but want to implement that with a Nginx or Apache proxy, set `INSECURE_USE_HTTP` to `true`. Note: This will allow (unsafe) http traffic to your Nightscout instance and is not recommended.
   * `SECURE_HSTS_HEADER` (`true`) - Add HTTP Strict Transport Security (HSTS) header. Possible values `false`, or `true`.
   * `SECURE_HSTS_HEADER_INCLUDESUBDOMAINS` (`false`) - includeSubdomains options for HSTS. Possible values `false`, or `true`.

--- a/docs/plans/nightscout-modernization.md
+++ b/docs/plans/nightscout-modernization.md
@@ -379,16 +379,21 @@ Child CI, the published Connect shutdown pin (#8720 / upstream #66), and
 owned database upgrade/backup recovery (#8718) complete the automated M29 work.
 Live vendor/hosting migration validation remains maintainer-owned afterward.
 
-### M22 explicit trusted-proxy policy
+### M22 proxy compatibility and optional explicit trust
 
-The maintainer approved requiring explicit trusted-proxy configuration for
-15.0.9. #8680 merged as `d080c1c8` after required CI and replaces all six `forwarded-for` consumers with a shared
-`proxy-addr` helper and applies the same policy to Express HTTPS/hostname
-handling, including removal of the direct `X-Forwarded-Proto` redirect bypass.
-Direct connections are the default. See the [deployment migration guide](../proposals/trusted-proxy-migration.md).
-M22 implementation and automated proxy/header/transport regression coverage are
-complete. Hosting-specific validation is maintainer-owned after automated
-completion; no generic Heroku/Azure proxy CIDR is assumed.
+The production Kubernetes trial superseded the mandatory explicit-IP migration:
+rotating ingress pods must not require updating Nightscout configuration to avoid
+HTTPS redirect loops. Unset/empty `TRUST_PROXY` preserves edge-managed proxy
+compatibility; `false` ignores forwarded metadata; explicit IP/CIDR lists retain
+restricted trust. Compatibility mode also restores distinct forwarded client IPs
+for authentication throttling and raw Socket.IO consumers. It relies on the edge
+to sanitize headers and restrict backend access, rather than claiming the same
+spoofing protection as explicit trust. The maintained helper and dependency
+removal remain. Legacy client-header precedence is deterministic instead of
+request-history dependent. See the [configuration guide](../proposals/trusted-proxy-migration.md).
+Automated tests cover both compatibility and strict modes, changing proxy peers,
+HTTP/API3 authentication, Socket.IO and the default image HTTPS redirect path.
+Actual deployment and device validation remains maintainer-owned.
 
 ### Tracker reconciliation
 

--- a/docs/plans/tracking-8328-reconciliation.md
+++ b/docs/plans/tracking-8328-reconciliation.md
@@ -19,7 +19,7 @@ policy supersedes that target. A framework/TypeScript rewrite, further MongoDB
 5/6 retirement, and replacement of every retained library are not implicit
 requirements of this dependency plan.
 
-M10 build/runtime separation, M22 explicit proxy trust, M25 maintained cache,
+M10 build/runtime separation, M22 proxy compatibility with optional explicit trust, M25 maintained cache,
 M27 date/time and M28 widget retain/migrate decisions are explicit. M29 includes
 legacy Dexcom/MiniMed migration mappings, the reviewed Connect pin (upstream
 #66, stacked on #64 which includes merged #65), and owned database upgrade and

--- a/docs/proposals/trusted-proxy-migration.md
+++ b/docs/proposals/trusted-proxy-migration.md
@@ -1,80 +1,76 @@
-# Trusted proxies in Nightscout 15.0.9
+# Proxy configuration in Nightscout 15.0.9
 
-M22 policy approved: reverse proxies must be explicitly trusted. With
-`TRUST_PROXY` unset, Nightscout uses the connected peer's address and ignores
-forwarded client-IP, protocol and hostname metadata. This is an intentional
-change from the permissive behavior in 15.0.8.
+The production Kubernetes trial exposed redirect loops from the initially
+mandatory proxy-IP configuration. That migration is superseded: existing
+TLS-terminating proxy installations retain compatibility without enumerating
+changing ingress pod addresses. No additional environment variable is required.
 
-## Configure before upgrading
+## Modes
 
-Set `TRUST_PROXY` to a comma-separated list of the IP addresses or CIDRs of the
-proxies between the client and Nightscout. For example, a proxy on the same host
-connecting over loopback can use `TRUST_PROXY=127.0.0.1,::1`. Only use that example
-when the connected peer actually is the trusted local proxy. Booleans, hop
-counts and named subnet aliases are rejected; a malformed setting prevents
-startup. An empty setting trusts no proxy.
+| `TRUST_PROXY` | Behavior |
+| --- | --- |
+| Unset or empty | Compatibility: honor forwarded protocol/hostname and legacy client-IP headers from the connecting peer. |
+| `false` | Direct-only: ignore forwarded metadata; use the socket peer and actual TLS connection. |
+| Comma-separated IP addresses/CIDRs | Restricted trust: only configured proxy peers supply forwarded metadata; walk `X-Forwarded-For` from right to left, stopping at the first untrusted address. |
 
-The edge must overwrite untrusted `X-Forwarded-For`, `X-Forwarded-Proto` and
-`X-Forwarded-Host` values. Additional trusted proxies append their observed peer
-to the IP chain. Nightscout walks `X-Forwarded-For` from right to left, starting
-at the connected peer, and stops at the first untrusted address. Do not trust
-client networks or every address: that would restore spoofable client metadata.
-Restrict direct access to the backend where the deployment requires a proxy.
+`true`, hop counts, subnet aliases and malformed settings are rejected at startup.
+The existing `CUSTOMCONNSTR_TRUST_PROXY` environment convention also works.
+An explicitly configured list never falls back to compatibility for unknown peers.
 
-Use bare IPv4 or IPv6 addresses in `X-Forwarded-For`, including IPv4-mapped IPv6
-where applicable. Port-bearing values (such as `192.0.2.1:1234` or
-`[2001:db8::1]:1234`), quoted addresses and invalid values are unsupported;
-Nightscout falls back to the socket peer for authentication throttling if the
-selected address is invalid. Configure the edge to remove ports. `Fastly-Client-IP`,
-`X-Real-IP`, `Z-Forwarded-For` and RFC `Forwarded` are no longer alternate inputs.
-If a provider uses those headers, normalize its verified client address into
-`X-Forwarded-For` at the trusted edge. Never copy arbitrary client-supplied values.
+## Compatibility boundary
 
-## Deployment examples and checks
+The default restores the previous edge-managed trust model, not the spoofing
+protections of the earlier default-direct modernization candidate. The proxy
+must overwrite untrusted forwarded headers and control access to the backend.
+Publicly reachable clients must not be able to bypass that boundary and supply
+trusted metadata. Direct-facing installations should use `TRUST_PROXY=false`.
 
-- **Local nginx/Apache:** when the proxy connects from loopback, use
-  `TRUST_PROXY=127.0.0.1,::1`. Configure the proxy to set the forwarded protocol
-  from its actual TLS connection and emit a bare client IP. Verify HTTPS requests
-  do not redirect repeatedly and direct HTTP still redirects.
-- **Docker:** use the actual address of the proxy container, or a dedicated
-  proxy-only network CIDR. For example, if the controlled proxy is assigned
-  `172.30.0.2`, use `TRUST_PROXY=172.30.0.2`. This address is illustrative, not a
-  Nightscout default. Do not copy an arbitrary Docker subnet or trust every
-  container sharing an application network. Do not publish the backend port
-  publicly if access is intended exclusively through the proxy.
-- **Heroku:** set the `TRUST_PROXY` config var to verified router peer addresses
-  or ranges for the deployment. Do not guess a private range or substitute
-  `true` or a hop count. If the platform cannot provide a stable, enforceable
-  trust boundary, validate an ingress arrangement with explicit trusted peers
-  before upgrading. A generic safe router CIDR is not supplied by this change.
-- **Azure:** set `TRUST_PROXY` in application settings (the existing
-  `CUSTOMCONNSTR_TRUST_PROXY` environment convention also works). Use verified
-  ingress peer addresses/ranges, including every trusted intermediate hop.
-  Confirm whether the ingress emits ports and normalize them before Nightscout.
-  As with Heroku, no platform-wide CIDR is assumed.
+HTTPS detection uses Express's forwarded protocol handling. With
+`INSECURE_USE_HTTP=false` (the default), proxied HTTPS requests proceed, while
+plain HTTP without an HTTPS indication still redirects. Disabling Nightscout's
+HTTPS enforcement is not necessary to solve the ingress redirect loop.
 
-On each hosting target, check login/token authentication, failed-login backoff,
-status requests, API v3 and Socket.IO polling plus WebSocket reconnection. Verify
-that altering forwarded headers on an untrusted direct request cannot change its
-client identity or mark plain HTTP as HTTPS. A missing trust setting on a TLS
-terminating proxy can cause redirect loops and group users under the proxy's
-throttle key. Configure trust correctly instead of disabling HTTPS enforcement
-to conceal that problem.
+Client identity retains the legacy header families in fixed priority order:
+`Fastly-Client-IP`, `X-Forwarded-For`, `Z-Forwarded-For`, `Forwarded`, `X-Real-IP`.
+The selected comma-separated chain must contain valid IP addresses throughout;
+its first address is the client. Bare IPv4/IPv6 and IPv4 with a numeric port are
+accepted. Invalid chains fall back to the socket peer. Here `Forwarded` means the
+legacy bare-IP header, not RFC `for=...` syntax. Bracketed IPv6 with a port is
+unsupported. Fixed precedence deliberately removes the old package's
+request-history-dependent header ordering. Edges using a lower-priority header
+must also strip or overwrite higher-priority client-supplied headers.
 
-## Implementation and validation
+## Deployment guidance
 
-All six former `forwarded-for` consumers use one helper built on `proxy-addr`,
-already required by Express and now explicitly declared. The old dependency is
-removed. The main Express application and both API sub-applications use the same
-configuration; raw Socket.IO requests use it without relying on Express getters.
-The HTTPS redirect now uses `req.secure`, with the same trust boundary.
+- **Kubernetes / ingress-nginx:** existing sanitized HTTP forwarding behind TLS
+  termination works with the default, including ingress pod replacement. Keep
+  backend access controlled, for example with enforced network policy selecting
+  the ingress namespace/pods. Do not infer a trusted cluster CIDR from a pod list.
+- **Docker, nginx/Apache, Heroku and Azure:** existing edge-managed proxy setups
+  can use the compatibility default without guessing provider address ranges.
+- **Restricted trust:** use verified proxy source addresses/CIDRs as seen by
+  Nightscout. Account for intermediate proxies, source NAT and address rotation.
+  A stable dedicated proxy network may be appropriate; arbitrary shared pod or
+  client networks are not equivalent to a proxy-only trust boundary.
 
-`tests/client-ip.test.js` covers spoofing, multi-hop trust, IPv4/IPv6, invalid and
-port-bearing values, repeated requests, independent policies, actual HTTP and
-Socket.IO transports, authentication delay keys and the Nightscout HTTPS
-redirect. Existing security-header tests explicitly trust their local test edge.
-Full CI and actual hosting validation remain separate from these owned fixtures.
-There is no UI redesign; deployment configuration and authentication behavior
-are affected. No runtime memory saving is claimed.
+Restricted mode accepts only `X-Forwarded-For` for client identity. Alternate
+headers, malformed addresses and port-bearing values do not bypass its policy.
+Express HTTPS/hostname metadata and raw HTTP/API3/Socket.IO client resolution use
+one configured trust policy. In compatibility mode the legacy client headers
+can differ from Express's `req.ip`, which uses `X-Forwarded-For`.
+
+## Validation
+
+`tests/client-ip.test.js` covers compatibility, explicit direct mode, CIDR trust,
+changing ingress peers, header precedence, malformed chains, IPv4/IPv6/ports,
+HTTPS redirects, independent authentication-delay keys and HTTP/API3/Socket.IO
+consumers. Environment tests cover unset, empty, false, lists and Azure aliases.
+The native amd64/arm64 Docker CI smoke uses default HTTPS enforcement and a
+forwarded HTTPS request, then checks unforwarded HTTP still redirects.
+
+Check real deployment login, status/API3, client identity and Socket.IO after
+rollout. Automated fixtures do not establish a deployment's actual trust boundary.
+Rollback of this compatibility correction restores the mandatory explicit-IP
+candidate behavior, including redirect loops on unconfigured TLS proxies.
 
 Reference: [Express behind proxies](https://expressjs.com/en/guide/behind-proxies/).

--- a/docs/test-specs/modernization-completion.md
+++ b/docs/test-specs/modernization-completion.md
@@ -113,7 +113,7 @@ restores of original and final backups through authenticated Nightscout APIs.
 Current-head hosted results and exact merge-tree/artifact verification must pass
 before the final child merges. #8605's final merge is checked against fresh dev.
 
-M22's default-direct and explicit proxy policy remains deliberate; see the
+M22 now preserves proxy compatibility by default after the Kubernetes production trial; direct-only and explicit proxy trust remain opt-in. See the
 [configuration guide](../proposals/trusted-proxy-migration.md). M25 retains the
 bounded profile reference cache and uses maintained notification caching with
 explicit clone/expiry semantics. Notification keys remain TTL-bound rather than
@@ -121,7 +121,7 @@ silently evicting live acknowledgements. M27 retains narrowed Moment; M28 retain
 selected jQuery UI/jQuery and upgrades Flot after characterization. These are
 completed decisions with review triggers, not unfinished compulsory rewrites.
 
-Maintainer handoff: configure the actual proxy trust/runtimes; run the branch in
+Maintainer handoff: verify the edge-managed proxy boundary or configure optional explicit trust, and verify runtimes; run the branch in
 the intended production environment; validate vendor accounts/Atlas IAM where
 used, upgrade/rollback with a known-good artifact and backup, and physical devices
 including Safari/VoiceOver. No extra MongoDB retirement or automatic dev merge is

--- a/lib/server/client-ip.js
+++ b/lib/server/client-ip.js
@@ -3,12 +3,19 @@
 const proxyaddr = require('proxy-addr');
 const { isIP } = require('node:net');
 
+// Compatibility mode retains the pre-15.0.9 edge-managed trust boundary.
+// The marker also reaches raw API3/Socket.IO consumers through Express's trust fn.
+const compatibilityTrust = Object.freeze(Object.assign(() => true, { legacyForwardedHeaders: true }));
+const legacyHeaders = ['fastly-client-ip', 'x-forwarded-for', 'z-forwarded-for', 'forwarded', 'x-real-ip'];
+
 function compileTrust (value) {
-  if (value === undefined || value === null || value === '') return () => false;
-  if (typeof value !== 'string') throw new Error('TRUST_PROXY must be a comma-separated list of proxy IP addresses or CIDRs');
+  if (typeof value === 'string') value = value.trim();
+  if (value === undefined || value === null || value === '') return compatibilityTrust;
+  if (value === false || value === 'false') return () => false;
+  if (typeof value !== 'string') throw new Error('TRUST_PROXY must be false or a comma-separated list of proxy IP addresses or CIDRs');
   const addresses = value.split(',').map(value => value.trim());
   if (addresses.some(value => !isIP(value.split('/')[0]))) {
-    throw new Error('TRUST_PROXY must contain explicit proxy IP addresses or CIDRs; booleans, hop counts and subnet aliases are unsupported');
+    throw new Error('TRUST_PROXY must contain explicit proxy IP addresses or CIDRs; true, hop counts and subnet aliases are unsupported');
   }
   return proxyaddr.compile(addresses);
 }
@@ -18,7 +25,24 @@ function getClientIP (req, trust) {
   const socket = req.socket || req.connection || {};
   const peer = socket.remoteAddress;
   if (!peer) return undefined;
-  const address = proxyaddr({ socket, headers: req.headers || {} }, trust);
+  const headers = req.headers || {};
+  if (trust.legacyForwardedHeaders) {
+    // Fixed precedence avoids the old forwarded-for package's request-history
+    // dependent ordering. Validate the entire selected chain before using it.
+    for (const name of legacyHeaders) {
+      if (!(name in headers)) continue;
+      if (typeof headers[name] !== 'string') return peer;
+      const addresses = headers[name].split(',').map(value => {
+        const address = value.trim();
+        if (isIP(address)) return address;
+        const withPort = /^(\d+\.\d+\.\d+\.\d+):\d+$/.exec(address);
+        return withPort ? withPort[1] : address;
+      });
+      return addresses.every(address => isIP(address)) ? addresses[0] : peer;
+    }
+    return peer;
+  }
+  const address = proxyaddr({ socket, headers }, trust);
   // Ports and malformed forwarding values are deliberately not accepted. The
   // trusted edge must emit bare IPs; fall back to the peer for throttling.
   return isIP(address) ? address : peer;

--- a/tests/client-ip.test.js
+++ b/tests/client-ip.test.js
@@ -21,7 +21,7 @@ function appFor (trustProxy) {
 
 describe('explicit trusted proxies', function () {
   it('ignores every forwarding header for direct peers, independently of request history', function () {
-    const resolve = createClientIP();
+    const resolve = createClientIP('false');
     for (let cycle = 0; cycle < 2; cycle++) {
       for (const headers of [
         { 'fastly-client-ip': '192.0.2.1', 'x-real-ip': '192.0.2.2' },
@@ -55,14 +55,14 @@ describe('explicit trusted proxies', function () {
   });
 
   it('rejects permissive shortcuts and invalid configuration', function () {
-    for (const value of [true, false, 1, 'true', 'false', '1', 'loopback', '*', '10.0.0.1,', '10.0.0.0/33', '::1/129']) {
+    for (const value of [true, 1, 'true', '1', 'loopback', '*', '10.0.0.1,', '10.0.0.0/33', '::1/129']) {
       assert.throws(() => compileTrust(value));
     }
   });
 
   it('keeps policies isolated between application instances', function () {
     const trusted = createClientIP('10.1.0.2');
-    const direct = createClientIP();
+    const direct = createClientIP('false');
     const req = raw('10.1.0.2', { 'x-forwarded-for': '198.51.100.4' });
     assert.equal(trusted(req), '198.51.100.4');
     assert.equal(direct(req), '10.1.0.2');
@@ -71,7 +71,7 @@ describe('explicit trusted proxies', function () {
 
   it('uses the same explicit trust for HTTP IP, hostname and TLS metadata', async function () {
     for (const trusted of [false, true]) {
-      const res = await request(appFor(trusted ? '127.0.0.1,::1' : undefined)).get('/')
+      const res = await request(appFor(trusted ? '127.0.0.1,::1' : 'false')).get('/')
         .set('Host', 'direct.example').set('X-Forwarded-For', '198.51.100.4')
         .set('X-Forwarded-Host', 'edge.example').set('X-Forwarded-Proto', 'https').expect(200);
       assert.equal(res.body.ip, res.body.expressIP);
@@ -82,7 +82,7 @@ describe('explicit trusted proxies', function () {
   });
 
   it('prevents spoofed IPs from escaping the authentication delay list', function () {
-    const resolve = createClientIP();
+    const resolve = createClientIP('false');
     const delay = require('../lib/authorization/delaylist')({settings: {authFailDelay: 10000}});
     delay.addFailedRequest(resolve(raw('203.0.113.10', { 'x-forwarded-for': '192.0.2.1' })));
     assert.ok(delay.shouldDelayRequest(resolve(raw('203.0.113.10', { 'x-forwarded-for': '192.0.2.2' }))) > 0);
@@ -96,7 +96,7 @@ describe('explicit trusted proxies', function () {
       for (const trusted of [false, true]) {
         const server = http.createServer();
         const io = new Server(server);
-        const resolve = createClientIP(trusted ? '127.0.0.1,::1' : undefined);
+        const resolve = createClientIP(trusted ? '127.0.0.1,::1' : 'false');
         io.on('connection', socket => socket.emit('client-address', resolve(socket.request)));
         await new Promise(done => server.listen(0, '127.0.0.1', done));
         try {
@@ -121,7 +121,7 @@ describe('explicit trusted proxies', function () {
   it('passes the configured client IP to API v3 authentication', async function () {
     const security = require('../lib/api3/security');
     for (const trusted of [false, true]) {
-      const app = appFor(trusted ? '10.1.0.2' : undefined);
+      const app = appFor(trusted ? '10.1.0.2' : 'false');
       app.set('API3_SECURITY_ENABLE', true);
       const req = raw('10.1.0.2', { 'x-forwarded-for': '198.51.100.4' });
       req.header = name => name === 'Authorization' ? 'Bearer owned-test-token' : undefined;
@@ -136,7 +136,7 @@ describe('explicit trusted proxies', function () {
   it('passes the configured client IP to HTTP authorization', function () {
     const init = require('../lib/authorization');
     for (const trusted of [false, true]) {
-      const env = { trustProxy: trusted ? '10.1.0.2' : '', settings: {} };
+      const env = { trustProxy: trusted ? '10.1.0.2' : 'false', settings: {} };
       const ctx = { store: {collection() { return {}; }}, language: {translate: text => text} };
       const authorization = init(env, ctx);
       let observed;
@@ -152,11 +152,111 @@ describe('explicit trusted proxies', function () {
   it('enforces the actual Nightscout HTTPS redirect against untrusted headers', async function () {
     const createApp = require('../lib/server/app');
     for (const trusted of [false, true]) {
-      const env = { name: 'proxy-test', version: '1', trustProxy: trusted ? '127.0.0.1,::1' : '',
+      const env = { name: 'proxy-test', version: '1', trustProxy: trusted ? '127.0.0.1,::1' : 'false',
         insecureUseHttp: false, secureHstsHeader: false, static_files: '/static', settings: require('../lib/settings')() };
       const app = createApp(env, { bootErrors: [{ desc: 'test', err: 'test' }] });
       await request(app).get('/robots.txt').set('X-Forwarded-Proto', 'https').expect(trusted ? 200 : 307);
       await request(app).get('/robots.txt').expect(307);
     }
+  });
+});
+
+describe('proxy compatibility default', function () {
+  it('retains validated legacy client headers with deterministic precedence', function () {
+    for (const setting of [undefined, null, '', '   ']) {
+      const resolve = createClientIP(setting);
+      for (let cycle = 0; cycle < 2; cycle++) {
+        assert.equal(resolve(raw('10.1.0.2', {'x-real-ip': '198.51.100.4'})), '198.51.100.4');
+        assert.equal(resolve(raw('10.1.0.3', {'x-real-ip': '198.51.100.4', 'x-forwarded-for': '198.51.100.5, 10.1.0.2'})), '198.51.100.5');
+        assert.equal(resolve(raw('10.1.0.3', {'fastly-client-ip': '198.51.100.6', 'x-forwarded-for': '198.51.100.5'})), '198.51.100.6');
+        for (const header of ['z-forwarded-for', 'forwarded']) {
+          assert.equal(resolve(raw('10.1.0.2', {[header]: '198.51.100.7'})), '198.51.100.7');
+        }
+        assert.equal(resolve(raw('10.1.0.2', {'x-forwarded-for': '198.51.100.4:443, 10.1.0.3:1234'})), '198.51.100.4');
+        assert.equal(resolve(raw('::1', {'x-forwarded-for': '2001:db8::4, ::1'})), '2001:db8::4');
+        for (const value of ['unknown', '198.51.100.4, unknown', 'for=198.51.100.4', '']) {
+          assert.equal(resolve(raw('10.1.0.2', {'x-forwarded-for': value, 'x-real-ip': '198.51.100.9'})), '10.1.0.2');
+        }
+        assert.equal(resolve(raw('10.1.0.2')), '10.1.0.2');
+      }
+    }
+  });
+
+  for (const setting of [undefined, '', 'false', '127.0.0.1,::1']) {
+    const enabled = setting !== 'false';
+    it('handles HTTPS, client identity and changing ingress peers with setting ' + JSON.stringify(setting), async function () {
+      const createApp = require('../lib/server/app');
+      const env = {name: 'proxy-compatibility-test', version: '1', trustProxy: setting,
+        insecureUseHttp: false, secureHstsHeader: false, static_files: '/static', settings: require('../lib/settings')()};
+      const app = createApp(env, {bootErrors: [{desc: 'test', err: 'test'}]});
+      await request(app).get('/robots.txt').set('X-Forwarded-Proto', 'https').expect(enabled ? 200 : 307);
+      await request(app).get('/robots.txt').expect(307);
+      const metadata = await request(appFor(setting)).get('/').set('X-Forwarded-Proto', 'https')
+        .set('X-Forwarded-Host', 'edge.example').set('X-Forwarded-For', '198.51.100.4, 127.0.0.1').expect(200);
+      assert.equal(metadata.body.secure, enabled);
+      assert.equal(metadata.body.ip === '198.51.100.4', enabled);
+      assert.equal(metadata.body.hostname === 'edge.example', enabled);
+      if (setting === undefined || setting === '') {
+        const resolve = createClientIP(setting);
+        for (const peer of ['10.1.0.2', '10.1.0.3', '10.1.0.4']) {
+          assert.equal(resolve(raw(peer, {'x-forwarded-for': '198.51.100.4, 10.1.0.5'})), '198.51.100.4');
+        }
+      }
+    });
+  }
+
+  it('keeps different clients on independent authentication delay keys by default', function () {
+    const resolve = createClientIP();
+    const delay = require('../lib/authorization/delaylist')({settings: {authFailDelay: 10000}});
+    const first = resolve(raw('10.1.0.2', {'x-forwarded-for': '198.51.100.4'}));
+    const second = resolve(raw('10.1.0.2', {'x-forwarded-for': '198.51.100.5'}));
+    delay.addFailedRequest(first);
+    assert.ok(delay.shouldDelayRequest(first) > 0);
+    assert.equal(delay.shouldDelayRequest(second), false);
+    delay.requestSucceeded(first);
+  });
+
+  for (const transport of ['polling', 'websocket']) {
+    it('retains the original client on default raw Socket.IO ' + transport + ' connections', async function () {
+      const server = http.createServer();
+      const io = new Server(server);
+      const resolve = createClientIP();
+      io.on('connection', socket => socket.emit('client-address', resolve(socket.request)));
+      await new Promise(done => server.listen(0, '127.0.0.1', done));
+      try {
+        for (let cycle = 0; cycle < 2; cycle++) {
+          const client = connect('http://127.0.0.1:' + server.address().port, {
+            transports: [transport], reconnection: false, forceNew: true,
+            extraHeaders: {'X-Forwarded-For': '198.51.100.4, 10.1.0.2'}
+          });
+          try {
+            const address = await new Promise((resolve, reject) => {
+              client.once('client-address', resolve);
+              client.once('connect_error', reject);
+            });
+            assert.equal(address, '198.51.100.4');
+          } finally {client.disconnect();}
+        }
+      } finally {await new Promise(done => io.close(done));}
+    });
+  }
+
+  it('passes default client identity through HTTP and API3 authorization', async function () {
+    const req = raw('10.1.0.2', {'x-forwarded-for': '198.51.100.4'});
+    req.header = () => undefined;
+    req.query = {};
+    const authorization = require('../lib/authorization')({settings: {}}, {
+      store: {collection() {return {};}}, language: {translate: text => text}
+    });
+    let observed;
+    authorization.resolve = data => {observed = data;};
+    authorization.resolveWithRequest(req, () => {});
+    assert.equal(observed.ip, '198.51.100.4');
+    const app = appFor();
+    app.set('API3_SECURITY_ENABLE', true);
+    req.header = name => name === 'Authorization' ? 'Bearer owned-test-token' : undefined;
+    const ctx = {authorization: {resolve(data, callback) {observed = data; callback(null, {shiros: []});}}};
+    await require('../lib/api3/security').authenticate({app, ctx, req, res: {}});
+    assert.equal(observed.ip, '198.51.100.4');
   });
 });

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -25,6 +25,27 @@ describe('env', function () {
     }
   });
 
+  it('preserves unset, direct and explicit proxy configuration modes', function () {
+    const original = process.env.TRUST_PROXY;
+    const azure = process.env.CUSTOMCONNSTR_TRUST_PROXY;
+    try {
+      delete process.env.CUSTOMCONNSTR_TRUST_PROXY;
+      for (const value of [undefined, '', 'false', '127.0.0.1,::1']) {
+        if (value === undefined) delete process.env.TRUST_PROXY;
+        else process.env.TRUST_PROXY = value;
+        require('../lib/server/env')().trustProxy.should.equal(value || '');
+      }
+      delete process.env.TRUST_PROXY;
+      process.env.CUSTOMCONNSTR_TRUST_PROXY = 'false';
+      require('../lib/server/env')().trustProxy.should.equal('false');
+    } finally {
+      if (original === undefined) delete process.env.TRUST_PROXY;
+      else process.env.TRUST_PROXY = original;
+      if (azure === undefined) delete process.env.CUSTOMCONNSTR_TRUST_PROXY;
+      else process.env.CUSTOMCONNSTR_TRUST_PROXY = azure;
+    }
+  });
+
   it('should not set the API key without API_SECRET or API_SECRET_FILE', function () {
     delete process.env.API_SECRET;
     delete process.env.API_SECRET_FILE;


### PR DESCRIPTION
TLS-terminating ingress deployments with no new configuration currently loop through HTTPS redirects because the modernization branch ignores forwarded metadata by default. Restore the previous edge-managed proxy model for unset/empty `TRUST_PROXY`, so rotating ingress peers continue working and distinct clients retain separate authentication-delay keys.

Keep the maintained helper and optional restricted IP/CIDR policy, and add `TRUST_PROXY=false` for direct connections. Compatibility mode restores the legacy client-header families with validated chains and fixed precedence, removing the old dependency's request-history-dependent ordering. This mode relies on ingress header sanitization and controlled backend access; it does not claim the spoofing protections of explicit trust. Documentation and M22 completion records now reflect that tradeoff.

Regression coverage exercises default HTTPS handling, changing proxy peers, IPv4/IPv6/ports, legacy header precedence and malformed chains, authentication throttling, HTTP/API3 authorization and both Socket.IO transports. Existing strict-mode spoofing tests remain. The Docker CI smoke now tests forwarded HTTPS with default enforcement, followed by an unforwarded HTTP redirect.

Validation so far: eight new cases fail against the previous implementation; 81 focused proxy/environment/security-header tests pass on Node 22.23.2 and 24.20.0. Lint has zero errors and 16 existing warnings. The full local Node 22 suite passes 2,135 backend tests (one existing pending) and 283 client-core tests. All 22 hosted checks passed, including both native Docker redirect checks and CodeQL with zero findings. All 13 browser/recovery artifact directories match tested virtual merge `eddac870152be976d332b8245cc9aae96da0b086`, including source hashes, per-job bundle identity and owned database cleanup. Merged as `ee2a0b9ee83b26f811da8a096d6ebdb31e85780a`; the integrated tree matches the independently computed and tested `54d3ab849491551f984451b79573c1d6d2d680ea`.
