### PR TITLE
Reduce routine log volume and add opt-in debugging (#8714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to cgm-remote-monitor are documented in this file.
 
 ### Fixed
 
+- **Log volume:** Disable routine heartbeat, data-reload and Nightscout Connect
+  diagnostics by default. Add `DEBUG_LOGGING=true` for server troubleshooting
+  and `CONNECT_DEBUG=true` for connector-only diagnostics. Keep warnings and
+  failures visible, and replace connector payload dumps with concise summaries.
+  Fixes #8714.
 - **MongoDB proxy dependency:** Update ip-address to 10.7.0. Add regression
   coverage for IPv4/IPv6 conversion, malformed addresses and SOCKS5 connections
   through MongoDB's installed proxy client. No MongoDB configuration or UI

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ autonomy for your data:
   * `SSL_CA` - Path to your ssl ca file, so that ssl(https) can be enabled directly in node.js. If using Let's Encrypt, make this variable the path to chain.pem file (chain).
   * `HEARTBEAT` (`60`)  - Number of seconds to wait in between database checks
   * `DEBUG_MINIFY` (`true`)  - Debug option, setting to `false` will disable bundle minification to help tracking down error and speed up development
+  * `DEBUG_LOGGING` (`false`) - Set to `true` to log routine server heartbeats, data reload summaries and Nightscout Connect diagnostics. Warnings, errors and startup messages remain visible with debugging off. This is a server environment setting; restart Nightscout after changing it. On Heroku, add or edit it under **Settings → Config Vars**. Set it back to `false` or remove it when troubleshooting is complete. It does not control Heroku router/access logs or every plugin's logging.
   * `DE_NORMALIZE_DATES`(`true`) - The Nightscout REST API normalizes all entered dates to UTC zone. Some Nightscout clients have broken date deserialization logic and expect to received back dates in zoned formats. Setting this variable to `true` causes the REST API to serialize dates sent to Nightscout in zoned format back to zoned format when served to clients over REST.
 
 ### Predefined values for your browser settings (optional)
@@ -495,6 +496,7 @@ Connect common diabetes cloud resources to Nightscout.
 Include the keyword `connect` in the `ENABLE` list.
 Nightscout connection uses extended settings using the environment variable prefix `CONNECT_`.
   * `CONNECT_SOURCE` - The name for the source of one of the supported inputs.  one of `nightscout`, `dexcomshare`, etc...
+  * `CONNECT_DEBUG` (inherits `DEBUG_LOGGING`, which defaults to `false`) - Set to `true` for connector-only debugging, or `false` to keep the connector quiet while server debugging is enabled. Diagnostic output uses operation summaries, without dumping credentials, sessions or patient records. Warnings and failures remain visible. Restart Nightscout after changing this setting.
   * `CONNECT_SOURCE_COLLECTIONS` - For Nightscout source sync, a comma-separated list of collections. Default: `entries,treatments,devicestatus,profiles`.
   * `CONNECT_SOURCE_MAX_COUNT` - For Nightscout source sync, maximum records per collection request. Default: `1000`.
 ###### Nightscout

--- a/app.json
+++ b/app.json
@@ -2,6 +2,11 @@
   "name": "CGM Remote Monitor",
   "repository": "https://github.com/nightscout/cgm-remote-monitor",
   "env": {
+    "DEBUG_LOGGING": {
+      "description": "Log routine server and Nightscout Connect diagnostics for troubleshooting. Warnings and errors remain visible when false. Disable after troubleshooting.",
+      "value": "false",
+      "required": false
+    },
     "MONGODB_URI": {
       "description": "The MongoDB Connection String to connect to your MongoDB cluster. If you don't have this from MongoDB Atlas, please re-read installation instructions at http://nightscout.github.io/nightscout/new_user/ before continuing",
       "value": "",

--- a/lib/data/dataloader.js
+++ b/lib/data/dataloader.js
@@ -113,14 +113,15 @@ function init(env, ctx) {
             }
             ddata.processTreatments(true);
 
-            var counts = [];
-            Object.entries(ddata).forEach(([key, value]) => {
-                if (Array.isArray(value) && value.length > 0) {
-                    counts.push(key + ':' + value.length);
-                }
-            });
-
-            console.info('Load Complete:\n\t', counts.join(', '));
+            if (env.debug && env.debug.logging) {
+                var counts = [];
+                Object.entries(ddata).forEach(([key, value]) => {
+                    if (Array.isArray(value) && value.length > 0) {
+                        counts.push(key + ':' + value.length);
+                    }
+                });
+                console.debug('Load Complete:', counts.join(', '));
+            }
             done(err, result);
         }
 

--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -75,7 +75,7 @@ function boot (env, language) {
     return ctx.bootErrors && ctx.bootErrors.length > 0;
   }
 
-  function migrateBridgeToConnect (ctx) {
+  function migrateBridgeToConnect () {
     var result = bridgeConnectCompat.applyBridgeToConnectCompatibility(env);
     if (result.legacy) {
       console.log("DEPRECATION WARNING", "Using legacy share2nightscout-bridge because DEXCOM_BRIDGE_USE_LEGACY is enabled.");
@@ -320,17 +320,17 @@ function boot (env, language) {
     var updateData = debounce(runDataLoad, UPDATE_DEBOUNCE_WAIT, { leading: true, trailing: true, maxWait: UPDATE_MAX_WAIT });
 
     ctx.bus.on('tick', function timedReloadData (tick) {
-      console.info('tick', tick.now);
+      if (env.debug && env.debug.logging) console.debug('tick', tick.now);
       updateData();
     });
 
     ctx.bus.on('data-received', function forceReloadData ( ) {
-      console.info('got data-received event, requesting reload');
+      if (env.debug && env.debug.logging) console.debug('got data-received event, requesting reload');
       updateData();
     });
 
     ctx.bus.on('data-loaded', function updatePlugins ( ) {
-      console.info('data loaded: reloading sandbox data and updating plugins');
+      if (env.debug && env.debug.logging) console.debug('data loaded: reloading sandbox data and updating plugins');
       var sbx = require('../sandbox')().serverInit(env, ctx);
       ctx.plugins.setProperties(sbx);
       ctx.notifications.initRequests();
@@ -351,7 +351,7 @@ function boot (env, language) {
 
   function setupConnect (ctx, next) {
     console.log('Executing setupConnect');
-    migrateBridgeToConnect(ctx);
+    migrateBridgeToConnect();
     ctx.nightscoutConnect = require('nightscout-connect')(env, ctx)
     // ctx.nightscoutConnect.
     return next( );

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -44,7 +44,8 @@ function config () {
   env.IMPORT_CONFIG = readENV('IMPORT_CONFIG', null);
   env.static_files = readENV('NIGHTSCOUT_STATIC_FILES', '/static');
   env.debug = {
-    minify: readENVTruthy('DEBUG_MINIFY', true)
+    minify: readENVTruthy('DEBUG_MINIFY', true),
+    logging: readENVTruthy('DEBUG_LOGGING', false)
   };
 
   env.err = [];
@@ -56,6 +57,13 @@ function config () {
   setAPISecret();
   setVersion();
   updateSettings();
+
+  // BRIDGE_* compatibility can enable Connect after extended settings parsing.
+  // Honor its debug override even when ENABLE only contains "bridge".
+  if (readENVRaw('CONNECT_DEBUG') !== undefined) {
+    env.extendedSettings.connect = env.extendedSettings.connect || {};
+    env.extendedSettings.connect.debug = readENVTruthy('CONNECT_DEBUG', false);
+  }
 
   return env;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "mongo-url-parser": "^1.0.2",
         "mongodb": "^5.9.2",
         "mongomock": "^0.1.2",
-        "nightscout-connect": "https://github.com/nightscout/nightscout-connect/archive/refs/tags/v0.0.13.tar.gz",
+        "nightscout-connect": "https://github.com/nightscout/nightscout-connect/archive/234d47c85510a77f07b3be0d2c026dd0272715d6.tar.gz",
         "node-cache": "^4.2.1",
         "process": "^0.11.10",
         "pushover-notifications": "^1.2.2",
@@ -7891,8 +7891,8 @@
     },
     "node_modules/nightscout-connect": {
       "version": "0.0.13",
-      "resolved": "https://github.com/nightscout/nightscout-connect/archive/refs/tags/v0.0.13.tar.gz",
-      "integrity": "sha512-ye91VY0JqPHTDfwbNIdiDa19LSfbKzurN6lkfX/Q+J3r3dofg51rMtIi1CeZteWGVrVfTIysTK8fYBFPjZYIcA==",
+      "resolved": "https://github.com/nightscout/nightscout-connect/archive/234d47c85510a77f07b3be0d2c026dd0272715d6.tar.gz",
+      "integrity": "sha512-gJCEEHXVDriBcYvDWPMCernrC5YPxB9zko4oeiYwUYYlWKN12G5CsgvFl7XH0Rxmfrtu2yLdpdqi/vmA3A9gwQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "axios": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "mongo-url-parser": "^1.0.2",
     "mongodb": "^5.9.2",
     "mongomock": "^0.1.2",
-    "nightscout-connect": "https://github.com/nightscout/nightscout-connect/archive/refs/tags/v0.0.13.tar.gz",
+    "nightscout-connect": "https://github.com/nightscout/nightscout-connect/archive/234d47c85510a77f07b3be0d2c026dd0272715d6.tar.gz",
     "node-cache": "^4.2.1",
     "process": "^0.11.10",
     "pushover-notifications": "^1.2.2",

--- a/tests/dataloader.test.js
+++ b/tests/dataloader.test.js
@@ -1,68 +1,80 @@
 'use strict';
 
-require('should');
+const should = require('should');
 
 const dataloaderInit = require('../lib/data/dataloader');
 const createDData = require('../lib/data/ddata');
 
 describe('dataloader', function () {
-  it('completes update when db.stats is promise-based', function (done) {
-    const ddata = createDData();
-    ddata.processTreatments = function () {};
-    const ctx = {
-      settings: {},
-      language: {
-        translate: function (value) { return value; }
-      },
-      cache: {
-        isEmpty: function () { return true; },
-        insertData: function (key, results) { return results; },
-        getRemovalGeneration: function () { return 0; }
-      },
-      ddata: ddata,
-      entries: {
-        list: function (query, callback) { callback(null, []); }
-      },
-      treatments: {
-        list: function (query, callback) { callback(null, []); }
-      },
-      profile: {
-        last: function (callback) { callback(null, []); }
-      },
-      food: {
-        list: function (callback) { callback(null, []); }
-      },
-      devicestatus: {
-        list: function (query, callback) { callback(null, []); }
-      },
-      activity: {
-        list: function (query, callback) { callback(null, []); }
-      },
-      store: {
-        db: {
-          stats: function () {
-            return Promise.resolve({ dataSize: 123, indexSize: 456 });
+  [false, true].forEach(function (logging) {
+    it('completes update with logging=' + logging + ' when db.stats is promise-based', function (done) {
+      const ddata = createDData();
+      ddata.processTreatments = function () {};
+      const ctx = {
+        settings: {},
+        language: {
+          translate: function (value) { return value; }
+        },
+        cache: {
+          isEmpty: function () { return true; },
+          insertData: function (key, results) { return results; },
+          getRemovalGeneration: function () { return 0; }
+        },
+        ddata: ddata,
+        entries: {
+          list: function (query, callback) { callback(null, []); }
+        },
+        treatments: {
+          list: function (query, callback) { callback(null, []); }
+        },
+        profile: {
+          last: function (callback) { callback(null, []); }
+        },
+        food: {
+          list: function (callback) { callback(null, []); }
+        },
+        devicestatus: {
+          list: function (query, callback) { callback(null, []); }
+        },
+        activity: {
+          list: function (query, callback) { callback(null, []); }
+        },
+        store: {
+          db: {
+            stats: function () {
+              return Promise.resolve({ dataSize: 123, indexSize: 456 });
+            }
           }
         }
-      }
-    };
-    const env = {
-      settings: {
-        isEnabled: function () { return false; },
-        units: 'mg/dl'
-      },
-      extendedSettings: {}
-    };
-    const loader = dataloaderInit(env, ctx);
+      };
+      const env = {
+        debug: { logging: logging },
+        settings: {
+          isEnabled: function () { return false; },
+          units: 'mg/dl'
+        },
+        extendedSettings: {}
+      };
+      const loader = dataloaderInit(env, ctx);
+      const originalInfo = console.info;
+      const originalDebug = console.debug;
+      const logs = [];
+      console.info = console.debug = function (...args) { logs.push(args); };
 
-    loader.update(ddata, function (err) {
-      should.not.exist(err);
-      ddata.dbstats.should.eql({
-        dataSize: 123,
-        indexSize: 456
+      loader.update(ddata, function (err) {
+        console.info = originalInfo;
+        console.debug = originalDebug;
+        logs.length.should.equal(logging ? 1 : 0);
+        if (logging) logs[0][0].should.equal('Load Complete:');
+        should.not.exist(err);
+        ddata.dbstats.should.eql({
+          dataSize: 123,
+          indexSize: 456
+        });
+        done();
       });
-      done();
     });
+
   });
 
   it('does not resurrect treatments deleted while a load is in flight', function (done) {

--- a/tests/debug-logging.test.js
+++ b/tests/debug-logging.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const assert = require('assert');
+const EventEmitter = require('events');
+const configure = require('../lib/server/env');
+const boot = require('../lib/server/bootevent');
+const compat = require('../lib/server/bridge-connect-compat');
+
+describe('debug logging configuration', function () {
+  let saved;
+  const names = ['DEBUG_LOGGING', 'debug_logging', 'CUSTOMCONNSTR_DEBUG_LOGGING', 'CUSTOMCONNSTR_debug_logging',
+    'CONNECT_DEBUG', 'connect_debug', 'CUSTOMCONNSTR_CONNECT_DEBUG', 'CUSTOMCONNSTR_connect_debug',
+    'ENABLE', 'BRIDGE_USER_NAME', 'BRIDGE_PASSWORD', 'CONNECT_SOURCE', 'CONNECT_SHARE_ACCOUNT_NAME', 'CONNECT_SHARE_PASSWORD'];
+  beforeEach(function () {
+    saved = {};
+    names.forEach(name => { saved[name] = process.env[name]; delete process.env[name]; });
+  });
+  afterEach(function () {
+    names.forEach(name => {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    });
+  });
+
+  it('defaults to quiet logging without changing minification', function () {
+    const env = configure();
+    assert.equal(env.debug.logging, false);
+    assert.equal(env.debug.minify, true);
+  });
+  ['DEBUG_LOGGING', 'debug_logging', 'CUSTOMCONNSTR_DEBUG_LOGGING', 'CUSTOMCONNSTR_debug_logging'].forEach(name => {
+    it('accepts a trimmed true/on value through ' + name, function () {
+      process.env[name] = ' ON ';
+      assert.equal(configure().debug.logging, true);
+    });
+  });
+  ['false', 'OFF', '', 'invalid', '1'].forEach(value => {
+    it('keeps diagnostics disabled for ' + JSON.stringify(value), function () {
+      process.env.DEBUG_LOGGING = value;
+      assert.equal(configure().debug.logging, false);
+    });
+  });
+  [undefined, 'true', 'false', 'invalid'].forEach(value => {
+    it('preserves connector debug override through legacy bridge migration: ' + value, function () {
+      process.env.ENABLE = 'bridge';
+      process.env.BRIDGE_USER_NAME = 'fixture-user';
+      process.env.BRIDGE_PASSWORD = 'fixture-password';
+      if (value !== undefined) process.env.CONNECT_DEBUG = value;
+      const env = configure();
+      compat.applyBridgeToConnectCompatibility(env);
+      assert.equal(env.extendedSettings.connect.source, 'dexcomshare');
+      assert.equal(env.extendedSettings.connect.debug, value === undefined ? undefined : value === 'true');
+    });
+  });
+
+  [
+    [undefined, undefined, false], ['true', undefined, true],
+    ['false', 'true', true], ['true', 'false', false], ['true', 'invalid', false]
+  ].forEach(function ([globalDebug, connectorDebug, expected]) {
+    it(`installed connector honors DEBUG_LOGGING=${globalDebug}, CONNECT_DEBUG=${connectorDebug}`, async function () {
+      process.env.ENABLE = 'connect';
+      process.env.CONNECT_SOURCE = 'dexcomshare';
+      process.env.CONNECT_SHARE_ACCOUNT_NAME = 'fixture-user';
+      process.env.CONNECT_SHARE_PASSWORD = 'fixture-password';
+      if (globalDebug !== undefined) process.env.DEBUG_LOGGING = globalDebug;
+      if (connectorDebug !== undefined) process.env.CONNECT_DEBUG = connectorDebug;
+      const env = configure();
+      const ctx = { bus: new EventEmitter(), bootErrors: [] };
+      const original = {};
+      const logs = [];
+      let handle;
+      try {
+        ['log', 'info', 'debug', 'warn', 'error'].forEach(method => {
+          original[method] = console[method];
+          console[method] = (...args) => logs.push(args);
+        });
+        handle = require('nightscout-connect')(env, ctx);
+        // Exercise the real internal output without starting vendor requests.
+        ctx.bus.removeListener('data-processed', handle.run);
+        const sg = { mills: Date.now(), sgv: 123 };
+        const sbx = { data: { sgvs: [sg], treatments: [], devicestatus: [], profile: [] }, lastEntry: items => items[items.length - 1] };
+        logs.length = 0;
+        ctx.bus.emit('tick', { now: sg.mills });
+        ctx.bus.emit('data-processed', sbx);
+        assert.equal(logs.length, expected ? 1 : 0);
+        if (expected) assert.equal(logs[0][0], 'DEBUG nightscout-connect: data-loaded');
+      } finally {
+        if (handle) await handle.stop();
+        ctx.bus.removeAllListeners();
+        Object.assign(console, original);
+      }
+    });
+  });
+
+});
+
+describe('boot event diagnostics', function () {
+  [false, true].forEach(logging => {
+    ['tick', 'data-received'].forEach(event => {
+      it(`processes ${event} and notifications with logging=${logging}`, function () {
+        const steps = [];
+        const bootId = require.resolve('bootevent');
+        const sandboxId = require.resolve('../lib/sandbox');
+        require(bootId);
+        require(sandboxId);
+        const originalBoot = require.cache[bootId].exports;
+        const originalSandbox = require.cache[sandboxId].exports;
+        const savedConsole = { log: console.log, info: console.info, debug: console.debug };
+        const logs = [];
+        const bus = new EventEmitter();
+        let loads = 0;
+        let notifications = 0;
+        let processed = 0;
+        const sbx = {};
+        try {
+          require.cache[bootId].exports = () => ({ acquire(fn) { steps.push(fn); return this; } });
+          require.cache[sandboxId].exports = () => ({ serverInit: () => sbx });
+          for (const method of Object.keys(savedConsole)) console[method] = (...args) => logs.push(args);
+          boot({ debug: { logging } }, {});
+          const ctx = {
+            bus, ddata: {}, bootErrors: [],
+            dataloader: { update(data, done) { loads++; done(); } },
+            plugins: { setProperties() {}, checkNotifications() {} },
+            notifications: { initRequests() {}, process() { notifications++; } },
+            pushnotify: { emitNotification() {} }
+          };
+          steps.find(fn => fn.name === 'setupListeners')(ctx, () => {});
+          logs.length = 0;
+          bus.on('data-processed', () => processed++);
+          bus.emit(event, { now: 1234 });
+          assert.equal(loads, 1);
+          assert.equal(notifications, 1);
+          assert.equal(processed, 1);
+          assert.equal(ctx.runtimeState, 'loaded');
+          assert.equal(logs.length, logging ? 2 : 0);
+        } finally {
+          require.cache[bootId].exports = originalBoot;
+          require.cache[sandboxId].exports = originalSandbox;
+          Object.assign(console, savedConsole);
+          bus.removeAllListeners();
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #8714.

Nightscout Connect hardcodes heartbeat/data-loaded logging, dumps whole data and session objects, and logs successful polling transitions. Nightscout also logs each heartbeat and data reload. These routine messages can consume a Heroku log allowance while the application is functioning normally.

Default these diagnostics to off. Add `DEBUG_LOGGING=true` for server heartbeat/reload summaries and connector diagnostics, with `CONNECT_DEBUG=true` for connector-only troubleshooting and `CONNECT_DEBUG=false` to override server debugging. Keep startup messages, warnings and failures visible. Document the Heroku Config Vars setting and ship `DEBUG_LOGGING=false` in `app.json`. The connector override also works with legacy `BRIDGE_*` migration.

Pin [nightscout-connect#67](https://github.com/nightscout/nightscout-connect/pull/67) at `234d47c85510a77f07b3be0d2c026dd0272715d6`. That source change passes a logger through the providers/internal output/polling machines, replaces payload dumps with operation summaries, retains numeric HTTP status on failures, and prevents repeated missing-action warnings when optional capture is disabled. The lockfile changes only the connector URL and integrity.

A controlled reproduction with ten heartbeat/data-processed pairs dropped from **80 lines / 2,629 bytes** on v0.0.13 to **zero by default**, or **10 lines / 379 bytes** with debugging enabled. Heroku router/access logs and other plugins' logging are outside this setting; production quota usage was not measured.

Validation:
- Clean Node 22 `npm ci`, including production webpack build, passes (existing asset-size warnings).
- 54 focused tests pass: configuration/defaults/overrides, the installed connector, bridge compatibility, real boot listeners, data loading and notification processing.
- All 76 connector tests pass on Node 20, 22 and 24; all 76 also pass from Nightscout's installed dependency with its Axios override.
- Changed-file ESLint has no errors (four existing filesystem warnings); `git diff --check` passes.

GitHub CI will verify the full Nightscout matrix, client-core coverage, npm 12 build, CodeQL and Docker image. No live vendor credentials or Heroku deployment were used for local validation.
